### PR TITLE
1575 строк, выученных прокси в игре — которых нет в батчах

### DIFF
--- a/discovered/discovered_2026-08-05.csv
+++ b/discovered/discovered_2026-08-05.csv
@@ -1,0 +1,4066 @@
+english,translate
+"Vote for Champion's Dusk today in PvP's Unranked Arena and help test the new Stronghold PvP mode.
+
+Learn more here.","Сегодня проголосуйте за карту «Чемпионский закат» в нерейтинговом режиме PvP и помогите протестировать новый режим игры на арене «Крепость».
+
+Узнайте больше здесь."
+"Hammer and mace skills deal increased damage when striking a disabled or defiant foe. Gain adrenaline when you disable a foe.<br><c=@reminder>Disables include stun, taunt, daze, knockback, pull, knockdown, sink, float, fear, and launch.</c>","Навыки молота и булавы наносят увеличенный урон при ударе по обездвиженному или находящемуся в состоянии защиты противнику. Получайте адреналин, когда обездвиживаете противника.<br><c=@reminder>Обездвиживание включает оглушение, насмешку, ошеломление, отбрасывание, подтягивание, сбивание с ног, погружение, поднятие в воздух, испуг и отброс.</c>"
+"Unable to find server address. A Domain Name Server (DNS) request failed. 
+
+Please try again, and if the problem persists, visit our support website.","Не удалось найти адрес сервера. Запрос к серверу доменных имен (DNS) завершился неудачно.
+
+Пожалуйста, попробуйте ещё раз, и если проблема не исчезнет, посетите наш сайт поддержки."
+Increases Critical-Hit Chance,Увеличивает шанс критического удара.
+"Find others to help you explore Inner Nayos.
+The Guild Wars 2: Secrets of the Obscure expansion is required to access this map.","Найдите других игроков, чтобы вместе исследовать Внутренний Найос.
+Для доступа к этой карте необходимо установить дополнение Guild Wars 2: Secrets of the Obscure."
+"The Vigil was created to fight the dragons. To destroy them, before they destroy us.","«Стражи» были созданы для борьбы с драконами. Чтобы уничтожить их, прежде чем они уничтожат нас."
+"We're proud that you've chosen to serve alongside us. Your mentor will be Forgal, one of our finest soldiers, and the most stalwart norn I know.","Мы рады, что ты решил служить вместе с нами. Твой наставник — Форгал, один из лучших наших солдат и самый стойкий норн, которого я знаю."
+"Collect %num2% Kryptis essences in Convergences. 
+(Gain less progress when collecting essence as a wisp with the Wisp Pockets Mastery.)","Соберите %num2% эссенций Криптиса в Конвергенциях.
+Получайте меньше прогресса при сборе эссенции в виде духа, используя умение «Карманы духа»."
+"Earn a gold medal in the Amnytas Supply Run adventure.
+
+(Progress will update when you claim the rewards from this adventure.)","Завоюйте золотую медаль в приключении «Поставка в Амните».
+
+(Прогресс будет обновлен после получения наград за это приключение.)"
+"Striking a stealthed foe triggers Invisible Analysis.<br>Disabling a foe triggers Controlled Analysis.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Атака невидимого противника активирует «Невидимый анализ».<br>Выведение противника из строя активирует «Контролируемый анализ».<br><c=@reminder>К способам выведения из строя относятся оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подброс, насмешка и запугивание.</c>"
+"Missile hits launch a rocket at your target. After enough rockets have been fired, an orbital strike is called instead.<br><c=@reminder>This trait has an internal cooldown.</c>",При попадании ракеты запускается ракета в цель. После достаточного количества выпущенных ракет вместо этого вызывается орбитальный удар.<br><c=@reminder>У этой черты есть внутренний перезаряд.</c>
+"<c=@abilitytype>Manipulation.</c> The next utility skill you use has significantly reduced recharge, and Mimic's recharge is increased by the original recharge of the affected skill.<br><c=@reminder>Mimic's recharge cannot be reset by other mesmer skills.</c>","<c=@abilitytype>Манипуляция.</c> Время перезарядки следующего используемого умения значительно сокращается, а время перезарядки «Мимикрии» увеличивается на величину исходного времени перезарядки затронутого умения.<br><c=@reminder>Время перезарядки «Мимикрии» не может быть сброшено другими умениями иллюзиониста.</c>"
+Striking a chilled foe grants might and life force.<br><c=@reminder>Single attacks can activate this trait more than once before recharging.</c>,Нанесение удара по замороженному противнику дарует мощь и жизненную силу.<br><c=@reminder>Одиночные атаки могут активировать эту способность несколько раз до перезарядки.</c>
+Heal allies when you grant them boons. Grant boons to allies when your upkeep cost is equal to or higher than the threshold.<br><c=@reminder>An ally can only be affected by this skill once per interval.</c>,"Восстанавливайте здоровье союзникам, когда вы накладываете на них благословения. Накладывайте благословения на союзников, когда стоимость поддержания навыка равна или превышает установленное значение.<br><c=@reminder>На одного и того же союзника этим навыком можно воздействовать только один раз за интервал.</c>"
+Your first attack after entering shroud transfers conditions.<br><c=@reminder>Only activates if you have conditions.</c>,Ваша первая атака после вступления в Саван передаёт эффекты состояний.<br><c=@reminder>Активируется только при наличии эффектов состояний.</c>
+"Find others to help you explore the Sandswept Isles!
+The Guild Wars 2: Path of Fire expansion and the Living World episode ""A Bug in the System"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Песчаные острова!
+Для доступа к этой карте необходимо установить дополнение Guild Wars 2: Path of Fire и пройти эпизод «Ошибка в системе» из серии Living World."
+"Weaken your foe with a fierce blow, dealing increased damage when striking a controlled or defiant foe.<br><c=@reminder>Controls include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Ослабьте врага мощным ударом, нанося увеличенный урон при атаке под контролем или в состоянии вызова.<br><c=@reminder>Контроль включает оглушение, дезориентацию, отбрасывание, притягивание, сбивание с ног, погружение, поднятие в воздух, насмешку и страх.</c>"
+<c=@abilitytype>Signet Passive:</c> Faster endurance regeneration.<br><c=@abilitytype>Signet Active:</c> Cure all conditions and gain endurance. Gain additional endurance for each condition cured.,"<c=@abilitytype>Пассивный навык ""Знамя"":</c> Ускоренная регенерация выносливости.<br><c=@abilitytype>Активный навык ""Знамя"":</c> Снимает все негативные эффекты и восстанавливает выносливость. Восстанавливает дополнительную выносливость за каждый снятый эффект."
+Knock down your foe. Weakened foes stay knocked down longer. Recharges Fierce Blow if you control a foe with this ability.<br><c=reminder>Recharges Fierce Blow if striking a target with a defiance bar.</c>,"Сбивайте врагов с ног. Ослабленные враги дольше остаются в этом состоянии. Если вы используете эту способность, чтобы контролировать врага, то перезаряжается умение «Яростный удар».<br><c=reminder>Перезаряжает умение «Яростный удар» при нанесении удара по цели с полоской сопротивления.</c>"
+"Crush your opponent's armor, leaving them vulnerable and gaining might. Vulnerability and might stacks doubled if you hit a disabled foe.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Сокрушайте броню противника, делая его уязвимым и получая эффект «Мощь». Эффекты «Уязвимость» и «Мощь» суммируются вдвое, если вы атакуете обездвиженного врага.<br><c=@reminder>Обездвиживание включает оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем в воздух, отталкивание, насмешку и страх.</c>"
+"Find others to help you explore Grothmar Valley!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""Bound by Blood"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Гротмарскую долину!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «Bound by Blood» из серии Living World."
+"Complete 10 events for the Order of the Crystal Bloom in the Burning Forest.
+Required to gain access to the Crystal Bloom quartermaster.","Выполните 10 заданий для Ордена Хрустального Цветения в Пылающем Лесу.
+Необходимо для получения доступа к торговцу в Кристальном саду."
+"Complete 10 events for the Mist Wardens in Melandru's Lost Domain.
+Required to gain access to the Mist Warden quartermaster.","Выполните 10 заданий для Стражей Туманов в Затерянном Домене Меландру.
+Необходимо для получения доступа к торговцу ""Страж Туманов""."
+"Sandswept Isles, where the shortsighted seek immediate power and knowledge.
+
+Note: Completion of this achievement requires completion of the Riding Skyscales achievements.","Песчаные острова, где недальновидные ищут мгновенную власть и знания.
+
+Примечание: для получения этого достижения необходимо выполнить достижения «Укрощение небесных ящеров»."
+"<c=@flavor>""Magic belongs to the people, and for the people it will be kept.""
+—Fiona</c>","<c=@flavor>«Магия принадлежит народу и будет сохранена для него.»  
+—Фиона</c>"
+"<c=@flavor>""If I can pull this off, my career is set!""
+—Shana</c>","<c=@flavor>«Если у меня получится, моя карьера будет обеспечена!»
+— Шана</c>"
+Defeat the champion djinn in a cavern beneath the Ruined Paths.,Победите джинна-чемпиона в пещере под Руинами.
+"<c=@flavor>""I can retire after this!""
+—Flinzz</c>","<c=@flavor>""После этого я смогу уйти на покой!""
+—Флинзз</c>"
+"<c=@flavor>""Such things we could learn!""
+—Keadin</c>","<c=@flavor>«Мы могли бы многому научиться!»
+— Кеадин</c>"
+"<c=@flavor>""Magic is a dangerous thing, especially in the wrong hands.""
+—Garen","<c=@flavor>Магия — опасная вещь, особенно в чужих руках.
+— Гарен"
+"<c=@flavor>""Quaggan do work, quaggan get paid. Quaggan is told this is how the world works.""
+—Loonaloo</c>","<c=@flavor>Квагган работает, квагган получает плату. Кваггану говорят, что так устроен мир.  
+—Луналу</c>"
+"Open %num2% astral fluctuating masses.
+
+(These can be purchased from Gharr Leadclaw in the Wizard's Tower. Requires Wayfinder Mastery.)","Открой %num2% астральных пульсирующих масс.
+
+(Их можно приобрести у Гарра Клыка в Башне магов. Требуется навык «Мастер Путеводителя».)"
+"Earn a silver medal in the Amnytas Supply Run.
+
+(Progress will update when you claim the rewards from this adventure.)","Завоюйте серебряную медаль в соревновании ""Поставки Амнит"".
+
+(Прогресс будет обновлен после получения наград за это приключение.)"
+"Eternal life, either blessing or curse, squandered by greed and the thirst for power.
+
+Note: Completion of this achievement requires completion of the Riding Skyscales achievement.","Вечная жизнь – благословение или проклятие? – растрачена из-за жадности и неутолимой жажды власти.
+
+Примечание: для получения этого достижения необходимо выполнить достижение «Укрощение небесных ящеров»."
+"Vision and visions, ended together in time...
+
+Note: Completion of this achievement requires completion of the Riding Skyscales achievement.","Видения и прозрения, объединенные временем…
+
+Примечание: для получения этого достижения необходимо выполнить достижение «Укрощение небесных ящеров»."
+"Crashing to the earth, cleaving the Mists...
+
+Note: Completion of this achievement requires completion of the Riding Skyscales achievement.","Стремительно падая с небес, он рассекает Туманы…
+
+Примечание: для получения этого достижения необходимо выполнить достижение «Верховая езда на небесных ящерах»."
+"Can you see past the void?
+
+Note: Only Mastery Insights in Living World Season 4 are required for this achievement.","Сможешь увидеть сквозь пустоту?
+
+Примечание: для получения этого достижения требуются только знания из четвертого сезона «Живой истории»."
+"What is time to one who transcends it?
+
+Note: Completion of this achievement requires completion of the Riding Skyscales achievement.","Что значит время для того, кто превзошёл его?
+
+Примечание: для получения этого достижения необходимо выполнить достижение «Укрощение небесных ящеров»."
+"Requires Guild Wars 2: End of Dragons.
+
+Jump on a skiff and hit the water! Maybe you'll catch a fish or two along the way.","Требуется дополнение Guild Wars 2: End of Dragons.
+
+Запрыгивайте на скольз и отправляйтесь в плавание! Возможно, по пути вам повезёт, и вы поймаете пару рыбок."
+"Earn a silver medal or better in the Reuniting Lost Kryptis adventure.
+
+(Progress will update when you claim the rewards from this adventure.)","Получите серебряную медаль или выше в приключении «Воссоединение потерянных криптидов».
+
+(Прогресс будет обновлен после получения наград за это приключение.)"
+"Find all the ancient artifacts in Nyedra Surrounds to learn new weapon proficiencies.
+Players can also unlock this achievement by purchasing the artifacts in WvW from the Heroics Notary vendor.","Найдите все древние артефакты в окрестностях Найедры, чтобы изучить новые виды оружия.
+Игроки также могут получить это достижение, приобретая артефакты в PvP-режиме «Мировые против Мировых» у торговца «Героические награды»."
+"An esoteric artifact of a bygone age, it was originally designed to transfer essence past emotional blockages via constant and gradual microtransmutations.
+
+It was shattered and discarded when someone asked the inventor, ""Why don't you just tell them how you feel instead?""","Это эзотерический артефакт давно ушедшей эпохи, изначально созданный для передачи сущности сквозь эмоциональные барьеры посредством постоянных и постепенных микротрансмутаций.
+
+Его разбили и выбросили, когда кто-то спросил изобретателя: «Почему бы тебе просто не сказать им о своих чувствах?»"
+Defeat %num2% players in ranked matches during 3v3 Season Four.,Одолейте %num2% игроков в рейтинговых матчах во время четвёртого сезона режима «3 на 3».
+Play %num2% ranked matches during 3v3 Season Four.,Сыграйте %num2% рейтинговых матчей в формате 3 на 3 в четвёртом сезоне.
+"Deal 100,000 Damage to Enemy Players in Structured Player vs. Player or World vs. World",Нанесите 100 000 единиц урона вражеским игрокам в структурированных PvP-сражениях или в режиме «Мир против мира».
+Complete the Retrospective Runaround Jumping Puzzle,"Пройдите полосу препятствий ""Ретроспективная пробежка""."
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+Complete the Vexa's Lab minidungeon in Fireheart Rise.,"Завершите мини-подземелье ""Лаборатория Вексы"" в Огненном Подъёме."
+Complete the Long Way Around Minidungeon in Straits of Devastation,"Пройдите мини-подземелье ""Долгий путь"" в Проливах Разрушения."
+"Guild Wars 2: Secrets of the Obscure<br>
+Buy Now","Guild Wars 2: Тайны Забытых земель<br>
+Купить сейчас"
+"In Primal Maguuma, help the Ward Technician reduce the insect population using your skyscale.
+
+Using the Fireball Mastery grants more progress.","В Изначальной Магуме помогите технику по защите уменьшить популяцию насекомых с помощью вашего скайскела.
+
+Использование умения «Огненный шар» даёт больше прогресса."
+"At Wizard's Ascent, correctly prepare 45 ingredients for Alchemist Briella.
+
+If you have the Knowing Is Half the Battle achievement, progress is doubled for successful ingredient preparations.","В Визардовом Подъёме правильно подготовьте 45 ингредиентов для алхимика Бриеллы.
+
+Если у вас есть достижение «Знание — половина победы», прогресс за успешное приготовление ингредиентов увеличивается вдвое."
+"Earn a gold medal in the Nayos Recon Run adventure. 
+
+(This achievement can be completed in the race event or adventure. Progress will update when you claim the rewards.)","Завоюйте золотую медаль в приключении «Разведка Найоса».
+
+(Это достижение можно получить во время гонки или приключения. Прогресс будет обновляться, когда вы заберете награды.)"
+"Earn a silver medal or better in the Nayos Recon Run adventure.
+
+(This achievement can be completed in the race event or adventure. Progress will update when you claim the rewards.)","Завоюйте серебряную медаль или более высокую награду в приключении «Разведка Найоса».
+
+(Это достижение можно получить во время гонки или приключения. Прогресс будет обновляться, когда вы заберете награды.)"
+"Speak with Frode during or after Secrets of the Obscure chapter 3, Mother of Stars.
+
+Players can also unlock this achievement by purchasing the Weaponmaster Training Document in WvW from the Heroics Notary vendor.","Поговорите с Фроде во время или после третьей главы «Тайны Запределья», «Мать Звёзд».
+
+Игроки также могут получить это достижение, купив «Учебник по владению оружием» в PvP у торговца «Героические заслуги»."
+"Gained by defeating world bosses.
+Your skyscale egg will be sufficiently infused at 4 stacks.
+This will only appear in locations with world bosses.","Получено за победу над мировыми боссами.
+Ваш скэйскальный яйцо будет достаточно насыщено энергией после накопления 4 зарядов.
+Это будет отображаться только в локациях с мировыми боссами."
+"Gained by reviving allies.
+Your skyscale egg will be sufficiently infused at 20 stacks.","Получено за воскрешение союзников.
+Ваш скэйскальный яйцо будет достаточно насыщено энергией после накопления 20 зарядов."
+"Find others to help you explore the Skywatch Archipelago.
+Requires Guild Wars 2: Secrets of the Obscure expansion to access this map.","Найдите других игроков, чтобы вместе исследовать архипелаг Скайвотч.
+Для доступа к этой карте требуется дополнение Guild Wars 2: Secrets of the Obscure."
+"Find others to help you explore Amnytas.
+Requires Guild Wars 2: Secrets of the Obscure expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Амнитас.
+Для доступа к этой карте требуется дополнение Guild Wars 2: Secrets of the Obscure."
+"This collection can be a useful reference to what's needed for each gift. Multiples of some of these items may be required. 
+
+Ward Crafter Lucirae in Moon Camp Covert can offer assisted crafting if you do not have the appropriate crafting disciplines trained.","Эта подборка может служить полезным справочником, чтобы узнать, что нужно для каждого подарка. Некоторые из этих предметов могут потребоваться в большем количестве.
+
+Вард-мастер Лусира в тайном лагере на Луне может предложить помощь в создании предметов, если у вас нет необходимых навыков ремесла."
+"Purchase the Polychromatic Armor set from Deft Lahar in your homestead.
+Unlocking one skin's weight unlocks the other weights' skins.","Приобретите комплект брони ""Полихроматический"" у Дефта Лахара в своей резиденции.
+Разблокировка одного варианта внешнего вида разблокирует и другие варианты для этой же модели."
+"This collection can be a useful reference for crafting the precursor backpack, Orrax Contained.
+
+Completion of this achievement will also award a homestead decoration.","Эта коллекция может служить полезным справочником при создании рюкзака-предшественника «Орракс в контейнере».
+
+За выполнение этого достижения также будет предоставлен предмет декора для вашего дома."
+"Ley lines are flows of magical energy. To use ley lines, simply direct your skimmer into them and allow the energy flow to boost your mount along. <br>Updrafts are pillars of swirling wind. To use updrafts, simply fly your mount into them and receive an elevation boost.","Лей-линии — это потоки магической энергии. Чтобы использовать лей-линии, просто направьте свой глайдер в них и позвольте потоку энергии ускорить ваше транспортное средство. <br>Восходящие потоки — это столбы вращающегося ветра. Чтобы использовать восходящие потоки, просто поднимитесь на своем транспортном средстве в них и получите дополнительный импульс высоты."
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт. Совершите рывок к выбранной цели, сбрасывая по пути бомбы, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы пройдёте, тем больше будет сброшено бомб. </c>
+В течение короткого времени после использования этого умения вы продолжите сбрасывать дополнительные бомбы в своей текущей локации. <br> 
+"
+"Find others to help you explore Gyala Delve.
+Requires Guild Wars 2: End of Dragons expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Гиальские Копи.
+Для доступа к этой карте требуется дополнение Guild Wars 2: End of Dragons."
+"Unlock %num2% pieces of the Titanplate armor set by crafting them or purchasing them from the Trading Post and binding them to you.
+Unlocking one weight's skin unlocks the other weights' skins.","Создайте или приобретите в торговом центре и привяжите к себе %num2% предметов комплекта брони «Титан».
+Разблокировка одного варианта внешнего вида для веса разблокирует варианты внешнего вида для всех остальных весов."
+"Unlock the Woad armor set. Pieces can be obtained from skirmish supervisors, from the Janthir Wilds reward track, or from Rift Researcher Adam in Lowland Shore.
+Each armor weight's pieces must be unlocked individually.","Откройте доступ к комплекту брони «Войд». Отдельные части можно получить у командиров стычек, в наградах за прохождение этапов в локации «Дикие земли Джантир» или у Рифт-исследователя Адама на Нижнем берегу.
+Каждая деталь экипировки определенного веса должна быть разблокирована отдельно."
+"Defeat champion titanspawn in Sulfurous Springs.
+
+(Only champions from the ""Defeat the Champion Titanspawn"" event will increment progress.)","Победите чемпионов-титанов в Серных источниках.
+
+(Только победы над чемпионами в событии «Победите чемпиона-титанспоуна» будут учитываться для прогресса.)"
+"Purchase the Oneiros-Spun Armor set from the Wizard's Tower Outfitter.
+Unlocking one skin's weight unlocks the other weights' skins.","Приобретите комплект брони ""Ткань сновидений"" у торговца в Башне магов.
+Разблокировка одного варианта внешнего вида разблокирует и другие варианты для этой же модели."
+"Join a public version of Convergences in Mount Balrior with your party and other players.
+Difficulty scales based on group size.
+
+NOTE: This contains spoilers for Guild Wars 2: Janthir Wilds Chapter 13: Balrior Peak.","Присоединяйтесь к публичной версии ""Схождения"" в горе Бальриор вместе со своей группой и другими игроками.
+Сложность подстраивается под размер группы.
+
+ВНИМАНИЕ: этот текст содержит спойлеры к главе 13 «Дикие земли Джантир»: пик Бальриор из игры Guild Wars 2."
+"Create a private version of Convergences in Mount Balrior for your squad.
+
+NOTE: This content contains spoilers for Guild Wars 2: Janthir Wilds Chapter 13: Balrior Peak","Создайте частную версию ""Схождения"" в горе Бальриор для вашего отряда.
+
+ВНИМАНИЕ: этот текст содержит спойлеры к главе 13 «Дикие земли Джантира»: Пик Бальриора из игры Guild Wars 2."
+"Join a public version of Convergences in Mount Balrior with your party and other players.
+
+NOTE: This content contains spoilers for Guild Wars 2: Janthir Wilds Chapter 13: Balrior Peak","Присоединитесь к публичной версии ""Схождения"" в горе Бальриор вместе со своей группой и другими игроками.
+
+ВНИМАНИЕ: данный текст содержит спойлеры к главе 13 «Дикие земли Джантир»: Пик Бальриор из игры Guild Wars 2."
+"Find others to help you explore the Domain of Kourna!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""Long Live the Lich"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Домен Курны!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «Долгая жизнь лича» из сюжетной линии Living World."
+"Find others to help you explore the Domain of Istan!
+The Guild Wars 2: Path of Fire expansion and the Living World episode ""Daybreak"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Область Истана!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «Рассвет» из серии Living World."
+"Double-click to bind this glyph to your account.
+
+Grants a 33%% chance to receive a bonus fine crafting material after gathering in addition to your gathering results.","Дважды щелкните, чтобы привязать этот глиф к вашей учетной записи.
+
+Даёт 33%% шанс получить дополнительный материал для превосходной крафты при сборе ресурсов, помимо обычных результатов сбора."
+Completed Siren's Reef at Fractal Scale 76 or Higher,"Прошли ""Сирений риф"" на уровне сложности фракталов 76 или выше."
+<c=@abilitytype>Signet Passive:</c> Generates life force while in combat.<br><c=@abilitytype>Signet Active:</c> Sacrifice health to revive one nearby downed ally.,"<c=@abilitytype>Пассивная способность знака:</c> Генерирует жизненную силу в бою.<br><c=@abilitytype>Активная способность знака:</c> Пожертвуйте здоровьем, чтобы воскресить одного из находящихся рядом союзников."
+((188840)),((188840))
+"Gain Insight when disabling foes or removing boons. Full Counter refreshes all <c=@abilitytype>burst</c> skills on hit.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt and fear.","Получайте прозрение при ослаблении врагов или снятии благословений. Полная контратака восстанавливает все навыки <c=@abilitytype>быстрой атаки</c> после попадания.<br><c=@reminder>Ослабления включают оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем, насмешку и страх."
+"<c=@flavor>""Trick or treat!""</c>
+—Your Inner Child","<c=@flavor>«Сладость или гадость!»</c>
+— Твой внутренний ребёнок"
+"<c=@flavor>""Ugh. It's my sixth birthday all over again.""</c>
+—Prince Edrick Thorn","<c=@flavor>«Фу. Словно снова мой шестой день рождения».</c>
+— Принц Эдрикс Торн"
+Reach level 80 with one character on your account.,Достигните 80-го уровня одним персонажем в вашей учетной записи.
+"+7 Toughness
++5 Precision","+7 защиты
++5 точности"
+"+7 Condition Damage
++5 Vitality","+7 ед. урона от состояний
++5 к жизненной силе"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+Blind and poison foes near your target with a dark cloud.,Ослепляйте и отравляйте врагов рядом с вашей целью тёмным облаком.
+<c=@abilitytype>Signet Passive:</c> Your movement speed is increased.<br><c=@abilitytype>Signet Active:</c>Strike and remove boons from nearby foes. Heal for each foe you strike and for each boon removed.,<c=@abilitytype>Пассивная способность знака:</c> Ваша скорость передвижения увеличена.<br><c=@abilitytype>Активная способность знака:</c>Нанесите удар и снимите благословения с ближайших врагов. Восстановите здоровье за каждого пораженного врага и за каждое снятое благословение.
+Mac version developed by TransGaming Inc. using Cider™. Cider is Copyright © 2000-2013 TransGaming Inc. Additional copyright and license information for sub-components of Cider can be found online at http://transgaming.com/ciderlicense.,Версия для Mac разработана компанией TransGaming Inc. с использованием Cider™. Авторские права на Cider принадлежат компании TransGaming Inc. © 2000–2013 гг. Дополнительная информация об авторских правах и лицензиях на отдельные компоненты Cider доступна в Интернете по адресу http://transgaming.com/ciderlicense.
+"Throw a spear at your target. If it strikes a foe, it inflicts conditions and you may reactivate to teleport to that foe. <br><c=@reminder>This skill recharges when exiting death shroud.</c>","Бросьте копье в цель. Если оно поразит противника, на него будут наложены эффекты и вы сможете повторно активировать умение, чтобы телепортироваться к этому противнику. <br><c=@reminder>Это умение перезаряжается при выходе из состояния «Саван».</c>"
+"Deal increased strike damage to disabled or defiant foes. Outgoing stun duration increased. <br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Наносит увеличенный урон при ударе по ослабленным или находящимся в состоянии защиты противникам. Увеличена длительность оглушения. <br><c=@reminder>Ослабление включает в себя: оглушение, ошеломление, отбрасывание, подтягивание, сбивание с ног, погружение, поднятие в воздух, насмешку и страх.</c>"
+"DPS: %num1%
+Damage: %num2%
+Time: %num3%","Урон в секунду: %num1%
+Урон: %num2%
+Время: %num3%"
+"Unlimited use for two weeks.
+Summons a Banker NPC to your location for 15 minutes.","Неограниченное использование в течение двух недель.
+Призывает банкира к вам, и он останется здесь в течение 15 минут."
+<br><br>My first invention was a transatmospheric converter,<br><br>Моим первым изобретением был транс-атмосферный преобразователь.
+"<br><br>They tell me my sire is a loyal soldier. I plan to live up to his reputation, whatever it takes.","<br><br>Говорят, мой отец — верный солдат. Я намерен оправдать его репутацию, чего бы это ни стоило."
+"<br><br>They tell me my sire is a sorcerous shaman. I must overcome his reputation, whatever it takes.","<br><br>Говорят, мой отец — могущественный шаман. Я должен превзойти его репутацию, чего бы это ни стоило."
+<br><br>I work hard to maintain my physical strength and prowess.,<br><br>Я усердно работаю над поддержанием своей физической силы и ловкости.
+<br><br>I rely on cunning to protect myself and my allies.,"<br><br>Я полагаюсь на хитрость, чтобы защитить себя и своих союзников."
+Granting an ally a barrier removes conditions afflicting them and grants might.<br><c=@reminder>This effect only occurs with barrier from scourge skills and traits.</c>,"Наложение барьера на союзника снимает с него негативные эффекты и даёт благословение ""Мощь"".<br><c=@reminder>Этот эффект происходит только при использовании барьеров, создаваемых умениями и чертами чумы.</c>"
+"Find others to help you rescue crash survivors, build fortifications, and take down terrible creatures that inhabit the sky!
+Requires Guild Wars 2: Heart of Thorns expansion to access this map.","Найдите других игроков, чтобы помочь вам спасать выживших после крушения, строить укрепления и уничтожать ужасных существ, обитающих в небе!
+Для доступа к этой карте требуется дополнение Guild Wars 2: Heart of Thorns."
+"Find others to help you build alliances to take down a massive chak!
+Requires Guild Wars 2: Heart of Thorns expansion to access this map.","Найдите союзников, чтобы вместе одолеть огромного чака!
+Для доступа к этой карте требуется дополнение Guild Wars 2: Heart of Thorns."
+"Find others to help you reactivate the ancient pylons and defend the city of Tarir!
+Requires Guild Wars 2: Heart of Thorns expansion to access this map.","Найдите союзников, чтобы вместе с вами реактивировать древние пилоны и защитить город Тарир!
+Для доступа к этой карте требуется дополнение Guild Wars 2: Heart of Thorns."
+"Find others to help you take the fight to Mordremoth!
+Requires Guild Wars 2: Heart of Thorns expansion to access this map.","Найдите союзников, чтобы вместе сразиться с Мордремотом!
+Для доступа к этой карте требуется дополнение Guild Wars 2: Heart of Thorns."
+<c=@abilitytype>Beast</c> abilities inflict weakness on those struck.<br><c=@reminder>This effect will only occur once on each target struck by an ability.</c>,"<c=@abilitytype>Способности зверя </c> накладывают слабость на тех, кого они поразили. <br><c=@reminder>Этот эффект может произойти только один раз для каждого цели, поражённой способностью.</c>"
+Armament merchants from the Consortium can turn this into a nifty weapon.<br>Turn in to the Consortium weapon merchant at the Pearl Islet resort for your reward.,"Торговцы оружием из Консорциума могут превратить это в отличное оружие.<br>Отнесите это торговцу оружием Консорциума, который находится на курорте Острова Жемчуга, чтобы получить награду."
+"Through your mechanical genius, you have utilized Canthan jade technology to build a customized battle mech that will fight at your side.<br>Your mech inherits a percentage of all of your combat attributes except precision, which is added to its own. <br>Your tool belt skills are replaced with Mech Commands, customized by your trait choices. Mech Commands take longer to recharge when using them far away from your mech. <br>Gain access to signet utility skills.","Благодаря вашему инженерному гению вы использовали кантанские технологии и джад для создания уникального боевого меха, который будет сражаться на вашей стороне.<br>Ваш мех наследует процент от всех ваших боевых характеристик, за исключением точности, которая добавляется к его собственным показателям. <br>Навыки вашего пояса инструментов заменяются командами управления мехом, которые можно настроить с помощью выбранных вами талантов. Команды управления мехом перезаряжаются дольше, если использовать их на большом расстоянии от меха. <br>Получите доступ к специальным утилитарным навыкам."
+"Find others to help you reclaim fallen Orr!
+The Guild Wars 2: Heart of Thorns expansion and the Living World episode ""One Path Ends"" are required to access this map.","Найдите союзников, чтобы вместе вернуть Орр из небытия!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Heart of Thorns и пройти эпизод Живой истории «One Path Ends»."
+"Unlock Gobblers and Exchanges from different modes of acquisition. The Wizard's Gobbler uses this achievement to allow you to access most of these respective items.
+
+You may have to travel to Lion's Arch to update progress by doing the following:
+• Having the item in your inventory
+• Having the associated achievement completed","Разблокируйте ""Пожирателей"" и ""Обмены"", полученные разными способами. ""Пожиратель волшебника"" использует это достижение, чтобы предоставить вам доступ к большинству соответствующих предметов.
+
+Возможно, вам потребуется отправиться в Королевскую гавань, чтобы обновить прогресс, выполнив следующие действия:
+• Предмет находится в вашем инвентаре.
+• Соответствующее достижение выполнено"
+"Complete events in Domain of Vabbi. Group events will grant more progress.
+
+Earn bonus progress by defacing Joko during the ""Avoid detection and help cadets paint the great Palawa Joko monument"" event.","Выполняйте задания в Домене Вабби. За выполнение групповых заданий прогресс будет увеличиваться быстрее.
+
+Получите дополнительный прогресс за осквернение изображения Джоко во время события «Избегайте обнаружения и помогите кадетам раскрасить великий памятник Палаве Джоко»."
+"Complete events in the Domain of Istan. Group events will award more progress.
+
+Earn bonus progress by completing the ""Tear down the statue of Palawa Joko"" event.","Выполняйте задания в Домене Истана. За выполнение групповых заданий начисляется больше прогресса.
+
+Получите дополнительный прогресс за выполнение события «Разрушьте статую Палавы Джоко»."
+"This title can be purchased from Shiny King M'takk in Hooligan's Route in Lion's Arch if you meet the requirements. 
+
+Surely it must be an official title if a self-proclaimed skritt king gives it to you, right?","Этот титул можно приобрести у Блестящего короля М’такка в районе «Улица хулиганов» в Королевской гавани, если вы соответствуете требованиям.
+
+В конце концов, это должно быть официальное звание, если его дарит самопровозглашенный король скриттов, верно?"
+"Gain Health Every Second
++2%% to All Attributes
++10%% Experience from Kills","Восстанавливайте здоровье каждую секунду
++2%% ко всем характеристикам
++10%% опыта за убийства"
+"Find others to help you investigate Lake Doric!
+The Guild Wars 2: Heart of Thorns expansion and the Living World episode ""The Head of the Snake"" are required to access this map.","Найдите других игроков, чтобы помочь вам исследовать озеро Дорик!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Heart of Thorns и пройти эпизод «Голова змеи» из серии Living World."
+Break the Defiance of the Fallen Voice and Fallen Claw 5 times.,Пять раз сломайте защиту падшего голоса и падшего когтя.
+Inflict poison when striking a foe with a dual wield attack. Gain increased condition damage.<br><c=@reminder>Applies poison once per attack use.</c>,"При нанесении удара по противнику двойным оружием, отравляйте его. Получите бонус к урону от состояний.<br><c=@reminder>Отравление применяется один раз за использование атаки.</c>"
+Create a lightning field at your location. Then summon gyros to finish foes and revive allies within the field. The recharge of this skill is increased for each gyro created beyond the first.<br><c=@reminder>Interrupted gyros are destroyed.</c>,"Создайте в выбранной области поле молний. Затем призовите гиро, чтобы те наносили урон врагам и воскрешали союзников внутри поля. Время перезарядки этого умения увеличивается для каждого созданного после первого гиро.<br><c=@reminder>Прерванные гиро уничтожаются.</c>"
+"+10%% Outgoing Healing
++45 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исходящее лечение
++45 ко всем характеристикам
++10%% Кармы
++5%% Ко всему получаемому опыту
++20%% Шанс найти магические предметы
++20%% Шанс найти золото
++10%% Получаемого опыта для развития"
+<c=@abilitytype>Virtue:</c> Burn foes every few attacks.<br><c=@abilitytype>Activate:</c> You and your allies inflict burning on the next attack.,<c=@abilitytype>Добродетель:</c> Поджигает врагов каждые несколько атак.<br><c=@abilitytype>Активация:</c> Вы и ваши союзники поджигаете следующего противника при атаке.
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"Double-click to gain a Hylek Blowgun.
+<c=@flavor>""There and wood and poisons here, plenty enough to make weapons to defend our land and fight the undead.""<br>—Qoetl</c>","Дважды щелкните, чтобы получить гилекский духовой дротик.
+<c=@flavor>«Здесь есть дерево и яды, их предостаточно, чтобы сделать оружие для защиты нашей земли и борьбы с нежитью».<br> — Коэтл.</c>"
+"Convert damaging conditions to boons whenever you gain Distortion or become disabled.<br><c=@reminder>This trait can only trigger when disabled once per interval.<br>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Превращайте наносящие урон состояния в благословения, когда вы получаете эффект ""Искажение"" или становитесь невосприимчивым к воздействиям.<br><c=@reminder>Этот талант может сработать только один раз за интервал, когда персонаж находится в состоянии невосприимчивости.<br>Состояния невосприимчивости включают оглушение, ошеломление, отбрасывание, притягивание, поваленный, погружение, подъем, бросок, насмешку и страх.</c>"
+"Disabling a foe grants you boons based on your current state.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Оглушение противника даёт вам благословения в зависимости от вашего текущего состояния.<br><c=@reminder>К оглушениям относятся: стан, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, поднятие в воздух, насмешка и страх.</c>"
+<c=@abilitytype>Ambush.</c> Release phantasmal axes that seek out the nearest target after a short delay.,"<c=@abilitytype>Засада</c>. Выпускает призрачные топоры, которые через короткое время нацеливаются на ближайшую цель."
+"Find others to help you investigate Ember Bay!
+The Guild Wars 2: Heart of Thorns expansion and the Living World episode ""Rising Flames"" are required to access this map.","Найдите других игроков, чтобы помочь вам исследовать Эмбер-Бэй!
+Для доступа к этой карте необходимо установить дополнение Guild Wars 2: Heart of Thorns и пройти эпизод «Восходящие пламена» из серии «Живая история»."
+Gain condition damage based on your toughness. Inflict bleeding when you immobilize a foe.<br><c=@reminder>Bleeding can only occur on the same target once per interval.</c>,"Получайте дополнительный урон от состояний, основанный на вашей живучести. Наносите кровотечение при обездвиживании противника.<br><c=@reminder>Кровотечение может быть нанесено одной цели только один раз за интервал времени.</c>"
+"Duo has tips now! If you want to add new ones, navigate to System.DuoTips or Gw2.System.Tips and either add your tip to an existing DuoTipDef or add a new DuoTipDef.
+
+All tips support [CommonMark](https://commonmark.org/help/) markdown.","Теперь у системы «Дуо» есть подсказки! Если вы хотите добавить новые, перейдите в System.DuoTips или Gw2.System.Tips и либо добавьте свою подсказку к существующему DuoTipDef, либо создайте новый DuoTipDef.
+
+Все подсказки поддерживают синтаксис Markdown CommonMark."
+"Steal health from enemies when you or your pet disable them.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Восстанавливайте здоровье, нанося урон врагам, когда вы или ваш питомец обездвиживаете их.<br><c=@reminder>Обездвиживание включает в себя оглушение, дезориентацию, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешку и страх.</c>"
+"Complete achievements throughout Inner Nayos, or take a break to enjoy a few adventures.
+
+(Note: The Mastery point is a reward for partial completion of this achievement.)","Выполняйте задания в Внутреннем Найосе или отдохните и отправьтесь в небольшое приключение.
+
+(Примечание: очки мастерства начисляются за частичное выполнение этого достижения)."
+"Earn a gold medal in the Reuniting Lost Kryptis adventure.
+
+(Progress will update when you claim the rewards from this adventure.)","Завоюйте золотую медаль в приключении «Воссоединение потерянных криптидов».
+
+(Прогресс будет обновлен после получения наград за это приключение.)"
+"Avoid being hit too many times by Vialgos's malignant toxin.
+
+(Eligibility for achievement starts when you dismount on the platform. It is removed if you are hit too many times or leave the platform.)","Не позволяйте зловонному яду Виальго поразить вас слишком много раз.
+
+(Возможность получить достижение появляется, когда вы слезаете с маунта на платформе. Она отменяется, если вас слишком много раз ударят или вы покинете платформу.)"
+"""Thanks.""
+""Thanks.""
+""Thanks.""","Спасибо.
+Спасибо.
+Спасибо."
+Plundered 250 Bundles of Loot during the Labyrinthine Cliffs Treasure Hunt,Добыто 250 пачек добычи во время охоты за сокровищами в Лабиринтовых скалах.
+Defeated the Claw of Jormag,Победили Коготь Йормаги
+"Spend hero points to train a skill.
+
+<c=@reminder>Skills can be learned in the Training tab of the Hero panel by spending hero points. </c>","Потратьте очки героя, чтобы улучшить навык.
+
+<c=@reminder>Навыки можно изучать на вкладке «Обучение» панели героя, тратя очки героя. </c>"
+"View %num1%/%num2% vista[s] in Snowden Drifts, Diessa Plateau, Brisban Wildlands, or Kessex Hills.
+
+<c=@reminder>Vistas are scenic locations that show the world from a new perspective, and they are marked with a red triangle icon on the map.</c>","Осмотрите %num1%/%num2% виды в Сноуденских пустошах, на плато Диесса, в Брисбанских диких землях или в Кессекских холмах.
+
+<c=@reminder>Виды — это живописные места, с которых открывается новый вид на мир. На карте они отмечены красным треугольником.</c>"
+"View %num1%/%num2% vista[s] in Ruins of Orr or Frostgorge Sound.
+
+<c=@reminder>Vistas are scenic locations that show the world from a new perspective, and they are marked with a red triangle icon on the map.</c>","Осмотрите %num1%/%num2% панорамы в Руинах Орра или Фростгорж-Саунде.
+
+<c=@reminder>Панорамы — это живописные места, откуда открывается новый вид на мир; они отмечены красным треугольным значком на карте.</c>"
+"Mastery of tengu wind magic allows you to conjure the Cyclone Bow at will. Using arrow-consuming skills grants Wind Force. After you reach the Wind Force threshold, you are able to use Hawkeye. Gain access to <c=@abilitytype>Squalls</c>.<br><c=@reminder>Using Cyclone Bow skills consumes arrows. You generate arrows every interval.</c>","Благодаря мастерству владения магией ветра тэнгу вы можете по своему желанию создавать Циклонный лук. Использование навыков, потребляющих стрелы, дает эффект «Сила ветра». Достигнув определенного уровня эффекта «Сила ветра», вы сможете использовать умение «Ястребиный глаз». Получите доступ к <c=@abilitytype>Вихрям</c>.<br><c=@reminder>Использование навыков Циклонного лука потребляет стрелы. Стрелы восстанавливаются через определенные промежутки времени.</c>"
+"Find others to help you explore Bava Nisos.
+Requires the Guild Wars 2: Janthir Wilds expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Бава-Нисос.
+Для доступа к этой карте требуется дополнение Guild Wars 2: Янтарные дикие земли."
+"Listen to all of the exchanges between Aurene and Soo-Won in Dragon's End. 
+
+Only one exchange can be heard for each time the Battle for the Jade Sea meta-event is completed.","Послушайте все реплики Аурене и Су-Вон в ""Конце Дракона"".
+
+За время прохождения мета-события «Битва за Нефритовое море» можно услышать только одну реплику."
+"Find others to help you explore Jahai Bluffs!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""A Star to Guide Us"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Ущелья Джахаи!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «Звезда, что укажет нам путь» из серии Living World."
+Heal yourself when you create a light field or finish a combo in a light field.<br><c=@reminder>Whirl finishers can only trigger this trait once per interval.</c>,"Восстанавливайте себе здоровье, когда создаёте светящееся поле или завершаете комбо в светящемся поле.<br><c=@reminder>Завершающие удары умения «Вихрь» могут активировать этот эффект только один раз за интервал.</c>"
+"Collect items related to Cinder Steeltemper's history to earn her signature Steel Warband sword.
+<c=@reminder>Requires access to previous Icebrood Saga episodes to complete.</c>","Соберите предметы, связанные с историей Циндера Стилтемпера, чтобы получить его уникальный стальной клинок «Стальная Варварская Гвардия».
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам саги «Ледяная Братва».</c>"
+"Find others to help you explore Drizzlewood Coast!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""No Quarter"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать побережье Дризлвуда!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «No Quarter» из серии Living World."
+"When an allied faction aids you in a Dragon Response mission, you gain an enhancement to your stats.
+While wielding Dragon Essence, your critical hits now inflict a condition based on the essence.
+The allied faction weekly vendor now carries additional items.","Когда союзная фракция помогает вам в миссии по борьбе с драконами, ваши характеристики улучшаются.
+Во время использования силы дракона ваши критические удары теперь накладывают эффект состояния, зависящий от выбранной сущности.
+Еженедельный торговец союзной фракции теперь предлагает дополнительные товары."
+"Collect items related to Ryland Steelcatcher's history to earn his signature Steel Warband flamesaw.
+<c=@reminder>Requires access to previous Icebrood Saga episodes to complete.</c>","Соберите предметы, связанные с историей Райланда Стилкэтчера, чтобы получить его фирменную огненную пилу «Стальная Варварская Орда».
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам сюжетной линии «Ледяная Сага».</c>"
+"Collect 100 Misty Cape Scraps.
+Misty Cape Scraps are awarded from Strike Missions, Daily Strike achievements, and Weekly Emissary Chests in Eye of the North.","Соберите 100 обрывков туманной мантии.
+Осколки туманной накидки можно получить за выполнение заданий в режиме «Удар», ежедневные достижения режима «Удар» и еженедельные сундуки эмиссара в локации «Глаз Севера»."
+"Collect items related to Ranoah Grindsteel's history to earn her signature Steel Warband pistol.
+<c=@reminder>Requires access to previous Icebrood Saga episodes to complete.</c>","Соберите предметы, связанные с историей Раноа Грайндстил, чтобы получить её уникальный пистолет ""Стальная Варварская Сборня"".
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам сюжетной линии ""Ледяная Сага"".</c>"
+"Collect items related to Vishen Steelshot's history to earn her signature Steel Warband sniper rifle.
+<c=@reminder>Requires access to previous Icebrood Saga episodes to complete.</c>","Соберите предметы, связанные с историей Вишен Стилшот, чтобы получить её фирменную снайперскую винтовку ""Стальная Варварская"".
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам сюжетной линии ""Ледяная Сага"".</c>"
+"Collect items related to Nicabar Steelweaver's history to earn his signature Steel Warband staff.
+<c=@reminder>Requires access to previous Icebrood Saga episodes to complete.</c>","Соберите предметы, связанные с историей Никабара Стилвивера, чтобы получить его уникальный посох «Стальная ватага».
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам сюжетной линии «Ледяная сага».</c>"
+"Cripple enemies that you disable.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Ослабляйте врагов, которых вы обездвиживаете. <br><c=@reminder>К обездвиживанию относятся оглушение, дезориентация, отбрасывание, притягивание, сбивание с ног, погружение, подъем в воздух, отталкивание, насмешка и страх.</c>"
+"Find a collection of Snargle Goldclaw's books across Tyria to remind him of his literary genius and free him from his writer's block.
+<c=@reminder>Requires access to previous Living World episodes to complete.</c>","Найдите разбросанные по Тирии книги Снаргла Златокогтя, чтобы напомнить ему о его литературном гении и избавить от творческого кризиса.
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам «Живого мира».</c>"
+"Player,
+
+You've chosen to destroy an important quest item from your inventory that is required for certain steps in the Commander without a Cause story chapter of Guild Wars 2: Secrets of the Obscure. If you replay this chapter and are unable to continue due to missing this item, you can reacquire it from Taimi's work desk in the Eye of the North.
+
+Thank you, and happy playing!
+
+—ArenaNet","Игрок,
+
+Вы решили уничтожить важный предмет из инвентаря, необходимый для выполнения некоторых этапов сюжетной главы «Командир без причины» в дополнении Guild Wars 2: Secrets of the Obscure. Если вы повторно пройдёте эту главу и не сможете продолжить из-за отсутствия этого предмета, вы можете получить его снова на рабочем столе Тайми в локации «Око Севера».
+
+Спасибо и приятной игры!
+
+—ArenaNet"
+"Unlock gobblers obtained from the Black Lion Trading Company. The Wizard's Gobbler uses this achievement to allow you to purchase their respective items.
+
+You may have to travel to Lion's Arch with the item in your inventory to update progress.","Разблокируйте гоблинов, полученных в Черном торговом квартале. Волшебный гоблин использует это достижение, чтобы позволить вам приобретать соответствующие предметы.
+
+Возможно, вам потребуется отправиться в Королевскую гавань с этим предметом в инвентаре, чтобы обновить прогресс."
+"Gain 100 Toughness When Health Is above 90%%
++2%% to All Attributes
++10%% Experience from Kills","Получите 100 единиц живучести, когда уровень здоровья превышает 90% %%.
++2 %% ко всем характеристикам.
++10 %% опыта за убийства."
+"Unlock %num2% pieces of the True Sight armor set by crafting them or purchasing them from the Trading Post and binding them to you.
+
+Unlocking one weight's skin unlocks the other weights' skins.","Создайте или приобретите в торговом центре и привяжите к себе %num2% предмета экипировки из набора ""Истинное зрение"", чтобы открыть их.
+
+Разблокировка одного вида раскраски разблокирует все остальные виды раскрасок для этого предмета."
+"Complete events in Domain of Kourna. Group events will award more progress.
+
+Earn bonus progress by completing the ""Dance with the choya to assist Tebb's research"" event. Or don't.","Выполняйте задания в Домене Курны. За выполнение групповых заданий начисляется больше прогресса.
+
+Получите дополнительный прогресс, выполнив событие «Потанцуйте с чойей, чтобы помочь в исследованиях Тебба». Или не выполняйте."
+"Complete events in Jahai Bluffs. Group events will award more progress.
+
+Earn bonus progress by completing the ""Stop 'Joko' from recruiting the Awakened"" event.","Выполняйте задания в Ущелье Джахаи. За выполнение групповых заданий начисляется больше очков прогресса.
+
+Получите дополнительный прогресс за выполнение события «Остановите Джоко от вербовки пробужденных»."
+"Complete events in the Desolation. Group events will award more progress.
+
+Earn bonus progress by completing the ""Reach the finish line"" event in Sand Jackal Run.","Выполняйте задания в Пустошах. За выполнение групповых заданий начисляется больше прогресса.
+
+Получите дополнительный прогресс за выполнение события «Достигните финишной черты» в локации «Песчаная ящерица»."
+"+25%% Experience in the Open World
++10%% Reward Track Gain in PvP and WvW","+25%% опыта в открытом мире
++10%% к прогрессу наград в PvP и RvR"
+"Meta-events can include a majority of content from past expansions or Living World episodes.
+
+This achievement can be reset by purchasing Recollection of Bearkin's Adversaries to acquire additional copies of the reward.","В мета-события могут быть включены основные элементы контента из прошлых дополнений или эпизодов «Живой истории».
+
+Это достижение можно сбросить, приобретя «Воспоминания о врагах Медведя», чтобы получить дополнительные копии награды."
+"Collect %num2% calibrated essence[s] in Mount Balrior Convergences. 
+(Gain less progress when collecting essence as a wisp.)","Соберите %num2% откалиброванные эссенции в схождениях горы Бальриор. 
+(Получаете меньше прогресса при сборе эссенции в виде духа.)"
+"Grant boons to nearby allies when you successfully combo a field with a blast, leap, or whirl finisher. Your function gyro is now a blast finisher.<br><c=@reminder>Whirl finishers can only trigger this trait once per interval.</c>","Наносите благословения ближайшим союзникам при успешном завершении серии ударов взрывным, прыжком или вихревым приёмом. Теперь ваш функциональный гироскоп является взрывным приёмом.<br><c=@reminder>Вихревые приёмы могут активировать эту черту только один раз за интервал.</c>"
+"Gain protection when you are disabled.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.","Получайте эффект «Протекция», когда вы обездвижены. <br><c=@reminder>Обездвиживание включает в себя оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешку и страх."
+Inflict vulnerability when you interrupt a foe.<br><c=@reminder>This trait can only affect enemies with defiance bars once per interval.</c>,"Наносите уязвимость, прерывая действия противника.<br><c=@reminder>Этот талант может воздействовать на врагов с полосками сопротивления не чаще одного раза за интервал.</c>"
+"Disabling a foe also applies vulnerability.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Оглушение противника также накладывает уязвимость.<br><c=@reminder>К оглушениям относятся: стан, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем в воздух, выброс, насмешка и страх.</c>"
+A percentage of your condition damage heals you.<br><c=@reminder>Healing will not occur while life force replaces health.</c>,"Определённый процент урона от ваших состояний восстанавливает вам здоровье.<br><c=@reminder>Восстановление здоровья не произойдёт, пока действует жизненная сила вместо здоровья.</c>"
+Gain an attack of opportunity for you and your pet on interrupting a foe. Daze and stun durations that you inflict last longer.<br><c=@reminder>This trait can only grant an attack of opportunity against enemies with defiance bars once per interval.</c>,"При прерывании атаки противника вы и ваш питомец получаете возможность совершить дополнительную атаку. Длительность эффектов оглушения и ошеломления, которые вы накладываете, увеличивается.<br><c=@reminder>Этот талант позволяет получить возможность совершить дополнительную атаку только один раз за определенный промежуток времени против врагов с полоской сопротивления.</c>"
+"You did a good for us, so I give you advice. For most skritt, all food scavenged. Make a big pile, food will rot. Many young kitts are born, maybe pile not enough. But grubs you keep alive do not spoil. They make their own kitts. We learned this way, not past-looking, not now-looking. Think of the future. Bigjob like you? Many great things can come. Look at future, go toward the great things.<br>
+—Forager Sneckit","Ты хорошо поработал для нас, поэтому я дам тебе совет. Большинство скриттов едят только найденную пищу. Сделайте большую кучу, и пища начнет гнить. Возможно, родится много маленьких котят, и этой кучи будет недостаточно. Но личинки, которых вы сохраняете живыми, не портятся. Они сами производят новых котят. Мы узнали это таким образом, мы смотрим в будущее, а не в прошлое или настоящее. Подумайте о будущем. Ты делаешь большую работу? Тогда многое может произойти. Смотрите в будущее и стремитесь к великим свершениям.<br>
+—Собиратель Снекит"
+Plunder 25 bundles of loot during the Labyrinthine Cliffs treasure hunt.,Найдите и разграбьте 25 тайников во время охоты за сокровищами в Лабиринтовых скалах.
+"Koss was impressed. Braham was happy. Time to never mention this again—for Braham's sake.
+
+Story Instance: Legacy","Косс был впечатлен. Брейхам был доволен. Пора больше никогда об этом не упоминать — ради него.
+
+Сюжетный эпизод: «Наследие»"
+"You've never been a fan of that brand.
+
+Story Instance: Legacy","Тебе никогда не нравилась эта марка.
+
+Сюжетный инстанс: Наследие"
+"Nothing is allowed to have that many legs and stay alive.
+
+Story Instance: Legacy","Ни одно существо не должно иметь столько ног и при этом оставаться в живых.
+
+Сюжетный инстанс: Наследие"
+"Branded pods are not edible.
+
+Story Instance: Legacy","Брендированные капсулы нельзя есть.
+
+Сюжетный инстанс: Наследие"
+"Pressure plates must be activated in the specified order to initiate the corresponding mechanism function. Modes progressively unlock.
+
+Consult machine console for the next function in the sequence.
+
+REPLAERI: 135462
+
+EXHIERE: 236514
+
+CILEFEO: 654213
+
+FRIDAE: 541362
+
+VICCIMA: 416325
+
+DEICEPIS: 362145","Нажимные плиты необходимо активировать в указанном порядке, чтобы запустить соответствующую функцию механизма. Режимы открываются постепенно.
+
+Обратитесь к консоли устройства для получения информации о следующей функции в последовательности.
+
+REPLAERI: 135462
+
+EXHIERE: 236514
+
+CILEFEO: 654213
+
+FRIDAE: 541362
+
+VICCIMA: 416325
+
+DEICEPIS: 362145"
+Gain ferocity and quickness while in Reaper's Shroud. Hitting with Life Reap reduces the recharge time of shroud skills.<br><c=@reminder>Recharge reduction can only occur once per use of Life Reap.</c>,"Получайте ярость и проворство, находясь в Саване Жнеца. Атака умением «Жатва жизни» уменьшает время перезарядки умений савана.<br><c=@reminder>Уменьшение времени перезарядки происходит только один раз за использование умения «Жатва жизни».</c>"
+Completed Siren's Reef at Fractal Scale 51 or Higher,"Прошли ""Сирений риф"" на уровне сложности фракталов 51 или выше."
+Completed Siren's Reef at Fractal Scale 26 or Higher,"Прошли ""Сирений риф"" на уровне сложности фракталов 26 или выше."
+Complete laps of the roller beetle race in Snowden Drifts. (This achievement can be completed in the race event or adventure.),"Проведите несколько кругов на гоночном жуке в Сноуденских пустошах. (Это достижение можно получить как в событии ""Гонки"", так и в приключении.)"
+"Find others to help you explore Dragonfall!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""War Eternal"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Драконий водопад!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «Война вечности» из серии «Живая история»."
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы
+"
+Destroy the plague experiments in the Inquest lab.,Уничтожьте заражённые образцы в лаборатории Инквизитора.
+((1015694)),((1015694))
+Complete laps of the roller beetle race in Southsun Cove. (This achievement can be completed in the race event or adventure.),"Проведите несколько полных кругов на гоночном жуке в Южном Заливе. (Это достижение можно получить как во время гонки, так и в приключении.)"
+Equipping a <c=@abilitytype>Virtue</c> grants you quickness. Every third <c=@abilitytype>Tome</c> skill grants you pages.<br><c=@reminder>Stacks reset when exiting a tome.<br>Quickness can only be gained once per interval</c>,Надевание <c=@abilitytype>Добродетели</c> даёт вам эффект «Проворство». Каждое третье умение из <c=@abilitytype>Тома</c> даёт вам страницы.<br><c=@reminder>Бонусы сбрасываются при выходе из тома.<br>Эффект «Проворство» можно получить только один раз за интервал.</c>
+Fire a shot that inflicts vulnerability on your target. Applies additional vulnerability when used against your marked target.,"Выпустите снаряд, который накладывает эффект уязвимости на цель. При использовании против отмеченной цели дополнительно накладывает эффект уязвимости."
+"Story Instance: Turnabout
+It's raining cats and dogs out there.
+Except the cats are Dominion ordnance, and the dogs are also Dominion ordnance.","Сюжетный инстанс: Неожиданный поворот
+Там дождь льёт как из ведра.
+Кроме того, кошки – это оружие Доминиона, и собаки тоже являются оружием Доминиона."
+"<c=@abilitytype>Psionic.</c> Drop a massive blade on a location, immobilizing enemies. This attack deals increased damage against controlled, downed, or defiant foes. <c=@reminder>Does bonus defiance-bar damage to defiant foes.</c><br><c=@reminder>Controls include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","<c=@abilitytype>Псионический.</c> Обрушьте на цель огромный клинок, обездвиживая врагов. Эта атака наносит увеличенный урон целям, находящимся под контролем, в состоянии оглушения или сопротивления. <c=@reminder>Наносит дополнительный урон шкале сопротивления врагам, находящимся в состоянии сопротивления.</c><br><c=@reminder>Эффекты контроля включают оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание и страх.</c>"
+"Find others to help you explore Dragon's End.
+Requires Guild Wars 2: End of Dragons expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Драконий Предел.
+Для доступа к этой карте требуется дополнение Guild Wars 2: End of Dragons."
+"Find others to help you explore Seitung Province.
+Requires Guild Wars 2: End of Dragons expansion to access this map.","Найдите других игроков, чтобы вместе исследовать провинцию Сэйтунг.
+Для доступа к этой карте требуется дополнение Guild Wars 2: End of Dragons."
+"Collect Charr Commendations for the legions by defeating Dominion forces and accomplishing objectives in the Drizzlewood Coast.
+Speak with a quaestor in any allied base to change which legion your commendations go to.","Собирайте награды чарров для легионов, побеждая войска Доминиона и выполняя задания в Прибрежной зоне.
+Поговорите с квестором в любой союзной базе, чтобы изменить легион, которому будут отправляться ваши награды."
+"Find others to help you survive Bitterfrost Frontier!
+The Guild Wars 2: Heart of Thorns expansion and the Living World episode ""A Crack in the Ice"" are required to access this map.","Найдите союзников, чтобы вместе выжить в Ледяной Пустоши!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Heart of Thorns и пройти эпизод «Разлом во льдах» из сюжетной линии Living World."
+"While in Celestial Avatar form, your healing of others is significantly increased. Healing another player with a Celestial Avatar skill reduces the cooldown of Celestial Avatar. <br><c=@reminder>Cooldown can only be reduced once per outgoing heal and will occur even if the affected player is at full health.</c>","Находясь в форме Небесного Аватара, вы значительно увеличиваете исцеление других игроков. Использование умения Небесного Аватара для лечения другого игрока уменьшает время восстановления умения Небесный Аватар. <br><c=@reminder>Время восстановления можно уменьшить только один раз за каждое применение исцеления, и это произойдет даже в том случае, если у цели полное здоровье.</c>"
+Heal allies around yourself when using a <c=@abilitytype>Legend</c> skill. Heal allies around Ventari's Tablet when using a <c=@abilitytype>Legendary Centaur</c> skill.<br><c=@reminder>Dragon Facet skills and Ventari's Will cannot activate this trait.</c>,"Восстанавливайте здоровье союзникам вокруг себя при использовании навыка <c=@abilitytype>Легенды</c>. Восстанавливайте здоровье союзникам вокруг Плиты Вентари при использовании навыка <c=@abilitytype>Легендарного Кентавра</c>. Навыки <br>Драконьей грани<c=@reminder> и ""Воля Вентари"" не могут активировать эту черту.</c>"
+"Bash the demon! Smash the demon! Drive it right back into its den!
+Bash the demon! Smash the demon! May it never rise up again!","Бей демона! Раздави демона! Загони его обратно в логово!
+Раздави демона! Уничтожь демона! Пусть он больше никогда не восстанет!"
+"Energy from the legendary foe imbues you to gain more essence from rift hunting.
+• Increased Bonus Essence Gains from Using Motivations
+• +1%% Experience Gain (All Sources)","Энергия, полученная от легендарного противника, позволяет вам получать больше сущности при охоте на разломы.
+• Увеличение дополнительной сущности, получаемой за использование мотиваций.
+• +1%% к опыту (со всех источников)."
+"Find others to help you explore Eternity's Garden.
+The Guild Wars 2: Visions of Eternity expansion is required to access this map.","Найдите других игроков, чтобы вместе исследовать Сад Вечности.
+Для доступа к этой карте необходимо установить дополнение Guild Wars 2: Visions of Eternity."
+"Find others to help you explore Lowland Shore.
+Requires the Guild Wars 2: Janthir Wilds expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Низменное побережье.
+Для доступа к этой карте требуется дополнение Guild Wars 2: Янтарные дикие земли."
+"Find others to help you hunt rift enemies within Janthir Wilds.
+Requires the Guild Wars 2: Janthir Wilds expansion to access the relevant content.","Найдите союзников, чтобы вместе охотиться на врагов разлома в диких землях Джантира.
+Для доступа к соответствующему контенту требуется дополнение Guild Wars 2: Янтарные пустоши."
+"Find others to help you explore Janthir Syntri.
+Requires the Guild Wars 2: Janthir Wilds expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Янтир Синтри.
+Для доступа к этой карте требуется дополнение Guild Wars 2: Яндирские дикие земли."
+"Participate in successful events around Stricken Plains, Landfall, and Tumultuous Sea.
+
+(Some events can count toward multiple achievements.)","Примите участие в успешных событиях в окрестностях Изуродованных равнин, Лэндфолла и Бурного моря.
+
+(Некоторые события могут учитываться при выполнении нескольких достижений.)"
+"Participate in successful events around Moldering Greenwood, Festering Basin, and Slithering Outskirts.
+
+(Some events can count toward multiple achievements.)","Участвуйте в успешных событиях в окрестностях Гнилого Зеленолесья, Зловонного Бассейна и Ползущих Окраин.
+
+(Некоторые события могут учитываться при выполнении нескольких достижений.)"
+"<c=@abilitytype>Melee.</c> Hurl your weapon at your foe. If you are in close range, swing your weapon at them instead. Striking a foe reduces the cooldown of Abyssal Raze once per skill use.","<c=@abilitytype>Ближний бой.</c> Бросьте оружие во врага. Если вы находитесь на близком расстоянии, вместо этого ударьте его своим оружием. Удар по врагу сокращает время восстановления умения «Абиссальное разрушение» один раз за использование умения."
+"Participate in successful events around Forager's Hunt, River's Maw, and Storm's Border.
+
+(Some events can count toward multiple achievements.)","Примите участие в успешных событиях вокруг «Охотничьей рощи», «Пасти реки» и «Штормовой границы».
+
+(Некоторые события могут учитываться при выполнении нескольких достижений.)"
+"Participate in successful events around Dead Lab, Sanguine Crater, and Blood Hill.
+
+(Some events can count toward multiple achievements.)","Примите участие в успешных событиях в окрестностях Мёртвой лаборатории, Багрового кратера и Кровавого холма.
+
+(Некоторые события могут учитываться при выполнении нескольких достижений.)"
+"The lowland kodan empower you! Each stack awards additive bonuses while in Janthir.
+
+1 Stack: +10%% Experience
+2 Stacks: +10%% Karma
+3 Stacks: +10%% Gold
+4 Stacks: Gain additional unique map material from kodan caches
+5 Stacks: Gain fury when directly striking an enemy with the warclaw's dismount attack
+6 Stacks: Gain additional collectable coins from kodan caches
+7 Stacks: +5%% Damage vs. titanspawn","Низменные кодан даруют вам силу! Каждый стак дает дополнительные бонусы, пока вы находитесь в Джантуре.
+
+1 стак: +10%% опыта
+2 стака: +10%% кармы
+3 стака: +10%% золота
+4 стака: получение дополнительных уникальных материалов из тайников кодан
+5 стаков: получение ярости при прямом нанесении удара врагу атакой «сброс с боевого когтя»
+6 стаков: получение дополнительных коллекционных монет из тайников кодан
+7 стаков: +5%% урона против титанов"
+"Find others to help you explore New Kaineng City.
+Requires Guild Wars 2: End of Dragons expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Новый Кайненг.
+Для доступа к этой карте требуется дополнение Guild Wars 2: End of Dragons."
+"Find others to help you explore the Echovald Wilds.
+Requires Guild Wars 2: End of Dragons expansion to access this map.","Найдите других игроков, чтобы вместе исследовать дикие земли Эховальда.
+Для доступа к этой карте требуется дополнение Guild Wars 2: End of Dragons."
+"Find others to help you explore Thunderhead Peaks!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""All or Nothing"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Громоверхие вершины!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «All or Nothing» из сюжетной линии Living World."
+<c=@abilitytype>Stealth attacks<c/> siphon health if they hit.<br><c=@reminder>Cannot siphon the same target more than once per interval.</c>,"<c=@abilitytype>Скрытные атаки <c/> восстанавливают здоровье, если попадают по цели. <br><c=@reminder>Нельзя восстанавливать здоровье одной и той же целью чаще одного раза за определенный промежуток времени.</c>"
+"Guild Wars 2: Janthir Wilds<br>
+Buy Now","Guild Wars 2: Дикие земли Джантира<br>
+Купить сейчас"
+"Requires Guild Wars 2: Heart of Thorns. 
+Gliders can only be used in designated areas of the world.","Требуется дополнение Guild Wars 2: Сердце Бездны.
+Планерами можно пользоваться только в специально отведенных областях мира."
+<c=@abilitytype>Venom.</c> Apply vulnerability and torment with your next few attacks.,<c=@abilitytype>Яд.</c> Примените уязвимость и мучение следующими несколькими атаками.
+"Experience the epic conclusion of the dragon cycle in Guild Wars 2: End of Dragons!
+Unlock the siege turtle mount, jade bots, skiffs, fishing, nine new elite specializations, and more!","Переживите эпическую развязку цикла драконов в Guild Wars 2: End of Dragons!
+Откройте доступ к осадной черепахе, нефритовым ботам, скользким лодкам, рыбалке, девяти новым элитным специализациям и многому другому!"
+"When you interrupt a foe, recharge one of your equipped-weapon skills at random.<br><c=@reminder>Only affects weapon skills that are recharging.</c>","Когда вы прерываете атаку противника, одна из выбранных вами боевых навыков перезаряжается случайным образом.<br><c=@reminder>Влияет только на те навыки оружия, которые находятся в процессе перезарядки.</c>"
+"Complete %num2% renown heart[s] in Frostgorge Sound.
+
+<c=@reminder>Renown hearts are marked with a golden heart icon on the map. Every renown heart is different, so check your HUD when nearby to find out how you can assist.</c>","Выполните %num2% задания на повышение репутации в Фростгорж-Саунд.
+
+<c=@reminder>Задания на повышение репутации отмечены на карте золотым значком сердца. Каждое задание уникально, поэтому, когда вы окажетесь рядом, проверьте интерфейс, чтобы узнать, чем вы можете помочь.</c>"
+"Dodge %num2% incoming attack[s] from enemies.
+
+<c=@reminder>Dodging allows you to evade incoming attacks by spending endurance to roll out of danger, making you temporarily invulnerable. ""Evaded!"" will appear over your character when you successfully dodge an attack.</c>","Уклоняйтесь от %num2% атак противников.
+
+Уклонение позволяет избежать входящих атак, потратив выносливость на кувырок в сторону и временно становясь неуязвимым. Над вашим персонажем появится надпись «Уклонено!», если вам удалось успешно уклониться от атаки. <c=@reminder></c>"
+"Activate your profession mechanic skills %num2% times.
+
+<c=@reminder>Profession mechanic skills appear above your weapon skills, and they have unique effects depending on your character's profession.</c>","Активируйте навыки вашей профессии %num2% раз.
+
+<c=@reminder>Навыки профессии отображаются над вашими боевыми навыками и обладают уникальными эффектами в зависимости от выбранной вами профессии.</c>"
+"Gather %num2% material[s] from resource nodes.
+
+<c=@reminder>Resource nodes are clumps of ore, saplings, and plants that can be gathered using gathering tools. Nodes can be found by exploring the world.</c>","Собирайте %num2% материалы с ресурсных точек.
+
+<c=@reminder>Ресурсные точки — это скопления руды, саженцев и растений, которые можно добывать с помощью инструментов для сбора ресурсов. Точки можно найти, исследуя мир.</c>"
+"Earn experience to level up this character to level 10.
+
+<c=@reminder>Experience can be earned by defeating enemies, contributing to events and renown hearts, completing story chapters, and crafting items.</c>","Получайте опыт, чтобы повысить уровень этого персонажа до 10-го.
+
+<c=@reminder>Опыт можно получить за победу над врагами, участие в событиях и выполнении заданий, прохождение сюжетных глав и создание предметов.</c>"
+"Defeat %num2% of the world bosses in Queensdale, Wayfarer Foothills, Metrica Province, or Caledon Forest.
+
+<c=@reminder>World bosses are challenging events that appear at specific times of day across Tyria. Defeat them to receive chests containing rare equipment and crafting materials. </c>","Победите %num2% мировых боссов в Квинсдейле, Уайфарер-Футхиллз, Метрической провинции или Каледонском лесу.
+
+<c=@reminder>Мировые боссы — это сложные события, которые происходят в определенное время суток по всей Тирии. Победите их, чтобы получить сундуки с редким снаряжением и материалами для крафта. </c>"
+"Speak with %num2% scouts in Queensdale, Metrica Province, Caledon Forest, Wayfarer Foothills, or the Plains of Ashford to discover more about the local area.
+
+<c=@reminder>Scouts appear with a spyglass icon on your map. They can point you toward nearby goals and landmarks when you speak to them.</c>","Поговорите с %num2% разведчиками в Квинсдейле, провинции Метрика, Каледонском лесу, Холмах Путника или на Равнинах Эшфорда, чтобы узнать больше о местности.
+
+<c=@reminder> Разведчики отображаются на вашей карте значком подзорной трубы. Они могут указать вам ближайшие цели и достопримечательности, если вы с ними поговорите.</c>"
+"Use your utility skills %num2% time[s].
+
+<c=@reminder>Utility skills are unlocked from the training menu in the Hero panel after reaching level 11 by spending Hero points, and they are equipped to the three utility slots on the right side of the skill bar. </c>","Используйте свои вспомогательные умения %num2% раз(а).
+
+<c=@reminder>Вспомогательные умения открываются в меню обучения на панели героя после достижения 11-го уровня, за что нужно потратить очки героя. Они экипируются в три слота для вспомогательных умений справа от панели навыков. </c>"
+"Use the weapon-swap button to switch your active weapon %num2% time[s].
+
+<c=@reminder>Weapon swap allows you to change between your equipped weapons to access different skills. This mechanic is unlocked at level 10.</c>","Используйте кнопку смены оружия, чтобы переключить активное оружие %num2% раз(а).
+
+<c=@reminder>Смена оружия позволяет вам переключаться между экипированным оружием для доступа к различным навыкам. Эта механика открывается на 10-м уровне.</c>"
+"Use %num2% consumable food item[s] to obtain nourishment bonuses.
+
+<c=@reminder>Food consumables boost attributes when eaten. Hover your mouse over a consumable to see what it does.</c>","Используйте %num2% съедобные продукты, чтобы получить бонусы к характеристикам.
+
+<c=@reminder>Употребление пищи дает временное увеличение атрибутов. Наведите курсор на продукт, чтобы узнать, какие эффекты он оказывает.</c>"
+"Earn experience to level up this character to level 30.
+
+<c=@reminder>Experience can be earned by defeating enemies, contributing to events and renown hearts, completing story chapters, and crafting items.</c>","Получайте опыт, чтобы повысить уровень этого персонажа до 30-го.
+
+<c=@reminder>Опыт можно получить за победу над врагами, участие в событиях и выполнении заданий, прохождение сюжетных глав и создание предметов.</c>"
+"Complete chapter 1 of your story.
+
+<c=@reminder>You can select your active story and view your progress from the Story Journal menu in the Hero panel.</c>","Завершите 1-ю главу своей истории.
+
+<c=@reminder>Вы можете выбрать активную историю и просмотреть свой прогресс в меню «Журнал историй» на панели героя.</c>"
+"Deposit items in your material storage.
+
+<c=@reminder>Material storage is a tab within your account vault that allows you to store crafting materials for easy access when crafting. Items can be deposited directly to the material storage from your inventory at any time.</c>","Поместите предметы в хранилище материалов.
+
+<c=@reminder>Хранилище материалов — это вкладка в вашем личном хранилище, которая позволяет хранить материалы для крафта и легко получать к ним доступ во время создания предметов. Вы можете помещать предметы непосредственно в хранилище материалов из своего инвентаря в любое время.</c>"
+"Consume %num2% utility item[s] to obtain utility enhancements.
+
+<c=@reminder>Utility consumables are items that increase specific combat abilities. Double-click utility consumables to use them.</c>","Используйте %num2% предметы, чтобы получить улучшения характеристик.
+
+<c=@reminder>Предметы, повышающие характеристики, — это предметы, которые увеличивают определенные боевые способности. Дважды щелкните по предмету, чтобы использовать его.</c>"
+"Complete %num2% map[s].
+
+<c=@reminder>Map-complete rewards are special bonuses earned by visiting all points of interest, vistas, waypoints, hero challenges, and renown hearts on a map.</c>","Заверши %num2% карты.
+
+Награды за завершение <c=@reminder>карты — это особые бонусы, получаемые при посещении всех достопримечательностей, смотровых площадок, порталов героев, испытаний героя и известных сердец на карте.</c>"
+"Deposit %num2% item[s] in your account bank.
+
+<c=@reminder>The Bank tab of your account vault allows you to store items outside of your inventory and transfer them between characters.</c>","Внеси %num2% предмет[|а|ов] в банковский счёт своего персонажа.
+
+<c=@reminder>Вкладка «Банк» вашего личного хранилища позволяет хранить предметы вне инвентаря и передавать их между персонажами.</c>"
+"Defeat %num2% of the world bosses in Frostgorge Sound or Mount Maelstrom.
+
+<c=@reminder>World bosses are challenging events that appear at specific times of day across Tyria. Defeat them to receive chests containing rare equipment and crafting materials. </c>","Победите %num2% мировых боссов в Фростгорж-Саунд или на горе Мейлстром.
+
+<c=@reminder>Мировые боссы — это сложные события, которые происходят в определённое время суток по всей Тирии. Победив их, вы получите сундуки с редким снаряжением и материалами для крафта. </c>"
+"Use %num2% emote[s] to express yourself!
+
+<c=@reminder>Emotes allow your character to show their feelings to the world. Type ""/emotelist"" in your chat for a list of possible emotes.</c>","Используйте %num2% эмоции, чтобы выразить себя!
+
+<c=@reminder>Эмоции позволяют вашему персонажу демонстрировать свои чувства окружающим. Введите в чат команду ""/emotelist"", чтобы увидеть список доступных эмоций.</c>"
+"Complete 3 maps.
+
+<c=@reminder>Map-complete rewards are special bonuses earned by visiting all points of interest, vistas, waypoints, hero challenges, and renown hearts on a map.</c>","Выполните 3 карты.
+
+<c=@reminder>Награды за полное исследование карт — это особые бонусы, которые можно получить, посетив все интересные места, смотровые площадки, точки быстрого перемещения, выполнив испытания и задания на карте.</c>"
+"Participate in %num2% event[s].
+
+<c=@reminder>You can find events while exploring the world. Events are marked by an orange circle on your map when you're nearby.</c>","Участвуй в %num2% событиях.
+
+<c=@reminder>События можно найти, исследуя мир. На карте они обозначаются оранжевым кружком, когда вы находитесь поблизости.</c>"
+"Travel using a waypoint.
+
+<c=@reminder>Waypoints allow you to travel quickly around the world. They are unlocked by visiting them once. You can teleport to any unlocked waypoint for a small amount of coin.</c>","Перемещайтесь, используя точку телепортации.
+
+<c=@reminder>Точки телепортации позволяют быстро перемещаться по миру. Они открываются после первого посещения. Вы можете мгновенно перенестись в любую открытую точку телепортации за небольшую плату.</c>"
+"Apply %num2% conditions to enemies.
+
+<c=@reminder>Conditions are negative effects that apply damage and control effects in combat. Check the tooltip for your skills to determine if your attacks can apply conditions to enemies.</c>","Накладывайте %num2% состояния на врагов.
+
+<c=@reminder>Состояния — это негативные эффекты, которые наносят урон и применяют эффекты контроля в бою. Проверьте подсказку к своим умениям, чтобы узнать, могут ли ваши атаки накладывать состояния на врагов.</c>"
+"Craft %num2% item[s].
+
+<c=@reminder>Items can be crafted at crafting stations in cities and guild halls once you've been trained by an appropriate master craftsman. Crafting uses the crafting materials you collect from gathering nodes and defeated enemies as you explore the world.</c>","Создай %num2% предмет[|ов|а].
+
+<c=@reminder>Предметы можно создавать на специальных станциях в городах и гильдейских залах, после того как вас обучил соответствующий мастер-ремесленник. Для создания используются материалы, которые вы собираете с ресурсов и добываете у побежденных врагов во время исследования мира.</c>"
+"Dye %num2% piece[s] of equipment.
+
+<c=@reminder>Dye are colors that can be applied to equipped armor, outfits, mounts, and gliders, allowing you to personalize the look of your character. You can access your dyes from the Dye tab in your Hero panel.</c>","Окрась %num2% предмет[|а|ов] экипировки.
+
+<c=@reminder>Краски — это цвета, которые можно наносить на надеваемую броню, комплекты брони, ездовых животных и планеры, чтобы персонализировать внешний вид своего персонажа. Вы можете получить доступ к своим краскам во вкладке «Краски» в панели героя.</c>"
+"Earn 10 crafting levels.
+
+<c=@reminder>Craft items to earn crafting experience for that crafting discipline, allowing you to create more powerful items.</c>","Получите 10 уровней профессии.
+
+<c=@reminder>Создавайте предметы, чтобы получать опыт в выбранной профессии и создавать более мощные вещи.</c>"
+"Complete %num2% jumping puzzle[s].
+
+<c=@reminder>Jumping puzzles are discoverable environmental challenges that test your exploration and aerial abilities. Search these puzzles out to learn what secrets they hold!</c>","Выполните %num2% головоломки с прыжками.
+
+<c=@reminder>Головоломки с прыжками — это скрытые испытания, которые проверят ваши навыки исследования и передвижения по воздуху. Найдите эти головоломки, чтобы узнать, какие секреты они хранят!</c>"
+"Use %num2% elite skill[s].
+
+<c=@reminder>Elite skills are powerful abilities assigned to the last slot of your skill bar.</c>","Используйте %num2% элитные умения.
+
+<c=@reminder>Элитные умения — это мощные способности, которые назначаются последнему слоту панели умений.</c>"
+"Use a salvage kit to salvage %num2% item[s].
+
+<c=@reminder>Some items you'll find will be salvageable. Use a salvage kit to break them down into crafting materials.</c>","Используйте набор для разборки, чтобы разобрать %num2% предмет/предметов.
+
+<c=@reminder>Некоторые предметы можно разобрать на компоненты для крафта. Используйте набор для разборки, чтобы получить из них материалы.</c>"
+"Create %num2% item[s] in the Mystic Forge.
+
+<c=@reminder>The Mystic Forge transforms items in a variety of ways, including raising the tier of crafting materials and upgrading equipment. The forge can be accessed from major cities throughout Tyria.</c>","Создайте %num2% предмет(ы) в Мистической кузнице.
+
+<c=@reminder>Мистическая кузница преобразует предметы различными способами, включая повышение уровня материалов для крафта и улучшение снаряжения. Кузница доступна из крупных городов по всей Тирии.</c>"
+"Discover %num2% point[s] of interest in Queensdale, Metrica Province, Caledon Forest, Wayfarer Foothills, or the Plains of Ashford.
+
+<c=@reminder>Points of interest are special locations marked by name in the world, indicated by a square icon on the map. </c>","Откройте %num2% интересных мест в Квинсдейле, провинции Метрика, лесу Каледон, предгорьях Вэйфарера или равнинах Эшфорда.
+
+<c=@reminder>Интересные места — это особые локации, отмеченные на карте квадратным значком и выделенные названием. </c>"
+"View %num1%/%num2% vista[s].
+
+<c=@reminder>Vistas are scenic locations that show the world from a new perspective, and they are marked with a red triangle icon on the map.</c>","Осмотр %num1%/%num2% видов.
+
+<c=@reminder>Виды — это живописные места, с которых открывается новый вид на мир. На карте они отмечены красным треугольным значком.</c>"
+"Loot %num2% defeated enemies.
+
+<c=@reminder>Sometimes enemies will drop items when defeated, indicated by a golden sparkle around their body. Interact with these enemies to loot these items and add them to your inventory.</c>","Добыча из побежденных врагов %num2%.
+
+<c=@reminder>Иногда при поражении враги сбрасывают предметы, о чём свидетельствует золотое мерцание вокруг их тела. Взаимодействуйте с этими врагами, чтобы собрать эти предметы и добавить их в свой инвентарь.</c>"
+"Rally from a downed state %num2% time[s].
+
+<c=@reminder>Rallying allows you to recover from a downed state by defeating a foe that grants experience.</c>","Восстановитесь после падения за %num2% время.
+
+<c=@reminder>Восстановление позволяет оправиться от состояния падения, победив врага, дающего опыт.</c>"
+"Complete %num2% renown heart[s].
+
+<c=@reminder>Renown hearts are marked with a golden heart icon on the map. Every renown heart is different, so check your HUD when nearby to find out how you can assist.</c>","Выполните %num2% задания для получения очков репутации.
+
+<c=@reminder>Значки заданий для повышения репутации отмечены на карте золотым сердечком. Каждое задание уникально, поэтому обращайте внимание на подсказки в интерфейсе, когда будете рядом, чтобы узнать, как вы можете помочь.</c>"
+"Use %num2% combo skill[s].
+
+<c=@reminder>Combo skills are performed by using a skill marked as a combo finisher while inside a combo field generated by another ability. Check the tooltips for your weapon and utility skills to find potential combinations!</c>","Используйте %num2% комбо-навыки.
+
+<c=@reminder>Комбо-навыки выполняются при использовании навыка, помеченного как завершающий удар комбо, находясь в зоне комбо, созданной другим умением. Проверьте подсказки для вашего оружия и вспомогательных навыков, чтобы найти возможные комбинации!</c>"
+"Train in a crafting discipline from a crafting master.
+
+<c=@reminder>Items can be crafted at crafting stations in cities and guild halls once you've been trained by an appropriate master craftsman. Crafting uses the crafting materials you collect from gathering nodes and defeated enemies as you explore the world.</c>","Пройдите обучение у мастера, чтобы освоить ремесло.
+
+<c=@reminder>После обучения у соответствующего мастера вы сможете создавать предметы на специальных станках в городах и гильдейских залах. Для создания предметов требуются материалы, которые можно найти на различных объектах и получить с побежденных врагов во время исследования мира.</c>"
+"Discover 5 points of interest in the Fields of Ruin, Blazeridge Steppes, Lornar's Pass, Dredgehaunt Cliffs, or the Harathi Hinterlands.
+
+<c=@reminder>Points of interest are special locations marked by name in the world, indicated by a square icon on the map. </c>","Найдите 5 интересных мест в Пустошах Руин, Равнинах Блейзерриджа, Проходе Лорнара, Скалах Дреджхаунта или Харатиских Запустьях.
+
+<c=@reminder>Интересные места — это особые локации, отмеченные на карте квадратным значком и выделенные названием в игровом мире. </c>"
+"Discover 5 waypoints in Sparkfly Fen, Mount Maelstrom, Iron Marches, Fireheart Rise, or Timberline Falls.
+
+<c=@reminder>Waypoints allow you to travel quickly around the world. They are unlocked by visiting them once. You can teleport to any unlocked waypoint for a small amount of coin.</c>","Найдите 5 точек быстрого перемещения в локациях: Болотистая низина Спаркфлай, гора Мейлстром, Железные марши, Огненный пик или Тиберлинские водопады.
+
+<c=@reminder>Точки быстрого перемещения позволяют быстро путешествовать по миру. Они открываются после первого посещения. Вы можете телепортироваться к любой открытой точке быстрого перемещения за небольшую плату.</c>"
+"View %num1%/%num2% vista[s] in the Fields of Ruin, Blazeridge Steppes, Lornar's Pass, Dredgehaunt Cliffs, or the Harathi Hinterlands.
+
+<c=@reminder>Vistas are scenic locations that show the world from a new perspective, and they are marked with a red triangle icon on the map.</c>","Осмотрите %num1%/%num2% виды в Полях Руин, Высотницах Блейзерриджа, Проходе Лорнара, Скалах Дреджхаунта или Харатиских Запустениях.
+
+<c=@reminder>Виды — это живописные места, с которых открывается новый вид на мир. На карте они отмечены красным треугольным значком.</c>"
+"Discover 5 waypoints in in the Fields of Ruin, Blazeridge Steppes, Lornar's Pass, Dredgehaunt Cliffs, or the Harathi Hinterlands.
+
+<c=@reminder>Waypoints allow you to travel quickly around the world. They are unlocked by visiting them once. You can teleport to any unlocked waypoint for a small amount of coin.</c>","Найдите 5 точек быстрого перемещения в Полях Руин, Пустошах Блейзербриджа, Проходе Лорнара, Обрывах Дреджхонта или Харати-Хинтерлендсе.
+
+<c=@reminder>Точки быстрого перемещения позволяют быстро путешествовать по миру. Они открываются после однократного посещения. Вы можете телепортироваться к любой открытой точке быстрого перемещения за небольшую плату.</c>"
+"Earn 150 crafting levels.
+
+<c=@reminder>Craft items to earn crafting experience for that crafting discipline, allowing you to create more powerful items.</c>","Получите 150 уровней мастерства.
+
+<c=@reminder>Создавайте предметы, чтобы получать опыт в выбранной профессии и создавать более мощные вещи.</c>"
+"Discover 5 waypoints in Snowden Drifts, Diessa Plateau, Brisban Wildlands, or Kessex Hills.
+
+<c=@reminder>Waypoints allow you to travel quickly around the world. They are unlocked by visiting them once. You can teleport to any unlocked waypoint for a small amount of coin.</c>","Найдите 5 точек быстрого перемещения в Сноуден Дрифтс, Диесса Плато, Брисбан Уайлдлендс или Кессекс Хиллз.
+
+<c=@reminder>Точки быстрого перемещения позволяют быстро путешествовать по миру. Они открываются после первого посещения. Вы можете телепортироваться к любой открытой точке быстрого перемещения за небольшую плату.</c>"
+"View %num1%/%num2% vista[s] in Sparkfly Fen, Mount Maelstrom, Iron Marches, Fireheart Rise, or Timberline Falls.
+
+<c=@reminder>Vistas are scenic locations that show the world from a new perspective, and they are marked with a red triangle icon on the map.</c>","Осмотрите %num1%/%num2% виды в Топких Болотах, на горе Мейлстром, в Железных Землях, в Огненной Долине или у Водопада Тимберлайн.
+
+<c=@reminder>Виды — это живописные места, с которых открывается новый вид на мир. На карте они отмечены красным треугольным значком.</c>"
+"Discover 5 points of interest in Sparkfly Fen, Mount Maelstrom, the Iron Marches, the Fireheart Rise, or Timberline Falls.
+
+<c=@reminder>Points of interest are special locations marked by name in the world, indicated by a square icon on the map. </c>","Найдите 5 интересных мест в Болотистой низине Спаркфлай, горе Мейлстром, Железных маршах, Огненной возвышенности или у Водопада Тимберлайн.
+
+<c=@reminder>Интересные места — это особые локации с названиями, которые отображаются на карте квадратным значком. </c>"
+"Enter %num2% World vs. World map[s].
+
+<c=@reminder>Storm castles and conquer territories in World vs. World! Enter the Mists from Eternal Battlegrounds asura gates in Lion's Arch, which can be traveled to from major cities, or by clicking the castle icon in the top-left corner of your screen.</c>","Войдите в %num2% карту режима «Мир против Мира».
+
+<c=@reminder>Штурмуйте замки и захватывайте территории в режиме «Мир против Мира»! Воспользуйтесь вратами асуры из Вечных битв, расположенными в Туманах, чтобы попасть туда. Врата можно найти в крупных городах или нажав на значок замка в верхнем левом углу экрана.</c>"
+"Use a healing skill %num2% time[s].
+
+<c=@reminder>Healing skills are located on the sixth skill slot of every character's skill bar.</c>","Используйте навык лечения %num2% раз(а).
+
+<c=@reminder>Навыки лечения находятся на шестой ячейке панели умений у каждого персонажа.</c>"
+"Complete chapter 3 of your story.
+
+<c=@reminder>You can select your active story and view your progress from the Story Journal menu in the Hero panel.</c>","Завершите третью главу своей истории.
+
+<c=@reminder>Вы можете выбрать активную историю и просмотреть свой прогресс в меню «Журнал историй» на панели героя.</c>"
+"Complete chapter 7 of your story.
+
+<c=@reminder>You can select your active story and view your progress from the Story Journal menu in the Hero panel.</c>","Завершите 7-ю главу своей истории.
+
+<c=@reminder>Вы можете выбрать активную историю и просмотреть свой прогресс в меню «Дневник историй» на панели героя.</c>"
+"Complete chapter 5 of your story.
+
+<c=@reminder>You can select your active story and view your progress from the Story Journal menu in the Hero panel.</c>","Завершите 5-ю главу своей истории.
+
+<c=@reminder>Вы можете выбрать активную историю и просмотреть свой прогресс в меню «Дневник историй» на панели героя.</c>"
+"Istan stinks of death and deception only to those who fail to see...
+
+Note: Completion of this achievement requires completion of the Riding Skyscales achievements.","Истан пропитан запахом смерти и обмана лишь для тех, кто не способен увидеть…
+
+Примечание: для получения этого достижения необходимо выполнить достижения «Укрощение небесных ящеров»."
+"<c=@abilitytype>Shatter.</c> Destroy all your clones, damaging nearby foes. Strikes again after a delay.<br><c=@reminder>Shatter traits only affect the first strike of this skill.</c>","<c=@abilitytype>Осколки</c>. Уничтожьте всех своих клонов, нанося урон ближайшим врагам. Наносит повторный удар после небольшой задержки.<br><c=@reminder>Таланты «Осколки» влияют только на первый удар этой способности.</c>"
+"-10%% Incoming Damage
++100 Concentration
++70 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++100 концентрация
++70 сила
++10%% карма
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% получаемый опыт WXP"
+"-10%% Incoming Damage
++100 Vitality
++70 Toughness
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон по прибытии
++100 Жизнеспособность
++70 Защита
++10%% Карма
++5%% Получаемый опыт
++20%% Шанс найти магический предмет
++20%% Шанс найти золото
++10%% Получаемый опыт WXP"
+"Gain barrier when you strike foes with a stealth attack. When you apply stealth to allies, you also grant them barrier.<br><c=@reminder>This effect can only be received once and will reset when stealth is removed.</c>","Получайте барьер при нанесении урона врагам в скрытом режиме. При применении скрытности к союзникам вы также даете им барьер.<br><c=@reminder>Этот эффект можно получить только один раз, и он сбросится после снятия скрытности.</c>"
+"After a number of missile hits, release a volley of arrows at your target and gain an arrow.<br><c=@reminder>Missiles from this trait do not count toward its next trigger.</c>","После нескольких попаданий ракет выпустите залп стрел по цели и получите дополнительную стрелу.<br><c=@reminder>Ракеты, выпущенные этой чертой умения, не учитываются при следующем использовании.</c>"
+Gain concentration. Gain life force when you summon a creature.<br><c=@reminder>Spirits and minions are creatures.</c>,Получите концентрацию. Получайте жизненную силу при призыве существа. <br><c=@reminder> Духи и прислужники — это существа.</c>
+"Gain access to spirit innervation skills, allowing you to channel energy to your spirits for an additional effect. <br>Gain life force when you use an innervate skill.","Получите доступ к навыкам духовной иннервации, позволяющим направлять энергию своим духам для получения дополнительного эффекта. <br>При использовании навыка иннервации вы получаете жизненную силу."
+"Your enemies greatly outnumber your forces. Be careful out there!
++50%% Participation
++20%% Magic Find
++25%% World Experience
+Take no armor damage on death.
+Being killed by the enemy team will not grant War Score.","Ваши враги значительно превосходят вас числом. Будьте осторожны!
++50%% Участие
++20%% Шанс выпадения магических предметов
++25%% Опыт в мире
+Не получайте урон от брони при смерти.
+Смерть от рук вражеской команды не приносит очков войны."
+"-10%% Incoming Damage
++45 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++45 ко всем характеристикам
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс получить больше золота
++10%% опыта в мире"
+"-10%% Incoming Damage
++100 Concentration
++70 Toughness
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++100 концентрация
++70 живучесть
++10%% карма
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% получаемый опыт за события"
+"-10%% Incoming Damage
++100 Power
++70 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++100 силы
++70 точности
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% ко всему получаемому опыту мира"
+"-10%% Incoming Damage
++100 Expertise
++70 Condition Damage
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++100 мастерства
++70 урона от состояний
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магический предмет
++20%% шанс найти золото
++10%% опыта"
+"-10%% Incoming Damage
++100 Healing Power
++70 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++100 сила исцеления
++70 концентрация
++10%% карма
++5%% весь получаемый опыт
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% получаемый опыт WXP"
+"-10%% Incoming Damage
++100 Concentration
++33%% Chance to Gain Might on Critical Hit
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон по попаданию
++100 Концентрация
++33%% Шанс получить эффект «Мощь» при критическом ударе
++10%% Карма
++5%% Ко всем получаемым очкам опыта
++20%% Шанс найти магический предмет
++20%% Шанс найти золото
++10%% Получаемые очки WXP"
+"Double-click to bind this glyph to your account.
+
+Grants a 33%% chance to gain an extra strike while gathering.","Дважды щелкните, чтобы привязать этот глиф к своей учетной записи.
+
+Даёт 33%% шанс получить дополнительный удар при сборе ресурсов."
+"Complete all %num2% achievements for ""The Dragon's Reach, Part 1.""","Выполните все %num2% достижения для «Путь Дракона, часть 1»."
+Burst skills inflict vulnerability if they hit and inflict additional vulnerability if the attack is a critical hit.<br><c=@reminder>Can only occur once per interval per target for multihit burst skills.</c>,"Нанесение урона умениями, активируемыми нажатием клавиши, вызывает уязвимость. Если атака является критической, то на цель дополнительно накладывается эффект уязвимости.<br><c=@reminder>Для многократных атак умений, активируемых нажатием клавиши, это может произойти только один раз за определенный промежуток времени для каждой цели.</c>"
+"Original Music Written (and soon to be performed!) by the Strand Band  
+  
+Each member of the band has made their own snippet of a song. We've recorded it below. Remember, the numbers correlate to the notes your trumpet can produce.  
+  
+Sander: 6 2 4 5 1  
+  
+Daisy: 2 4 7 5 3  
+  
+Gealan: 7 4 8 1 2  
+  
+We're always hanging out on the beach west of town. Come find us and...LET'S JAM!","Оригинальная музыка, написанная (и скоро исполняемая!) группой «Странд».
+  
+Каждый участник группы сочинил свою собственную часть песни. Мы записали её ниже. Помните, что цифры соответствуют нотам, которые может извлекать ваша труба.
+  
+Сандер: 6 2 4 5 1
+  
+Дейзи: 2 4 7 5 3
+  
+Геалан: 7 4 8 1 2
+  
+Мы всегда тусуемся на пляже к западу от города. Приходите, найдёте нас и… ПОИГРАЕМ ВМЕСТЕ!"
+"Original Music Written (and soon to be performed!) by the Strand Band  
+  
+Each member of the band has made their own snippet of a song. We've recorded it below. Remember, the numbers correlate to the notes your trumpet can produce.  
+  
+Sander: 8 4 1 3 5  
+  
+Daisy: 1 3 7 8 2  
+  
+Gealan: 5 1 3 2 6  
+  
+If you find this, come jam with the Strand Band members, just west of town, as always!","Оригинальная музыка, написанная (и скоро исполняемая!) группой ""The Strand"".
+  
+Каждый участник группы создал свой фрагмент песни. Мы записали его ниже. Помните, что числа соответствуют нотам, которые может извлечь ваша труба.
+  
+Сандер: 8 4 1 3 5
+  
+Дейзи: 1 3 7 8 2
+  
+Геалан: 5 1 3 2 6
+  
+Если увидите это сообщение, приходите поучаствовать в джеме с участниками группы Strand Band, они как всегда будут играть к западу от города!"
+"Primary Applicant
+Name: Gorrik
+
+Secondary Applicant
+Name: Rama
+
+Company Name: The Friends Detective Agency
+
+The Ministry of Investigatory Services hereby grants The Friends Detective Agency, a Dually Recognized Partnership, authority to perform all duties, functions, and obligations pertaining to the operation and administration of a private investigation agency, subject to the laws, rules, and regulations set forth in MIS Private Investigation Agency Laws, Rules, and Regulations Code 512-PIA (attached).","Основной заявитель
+Имя: Горрик
+
+Второй заявитель
+Рама
+
+Название компании: Агентство частных сыщиков ""Друзья""
+
+Министерство следственных служб настоящим предоставляет детективному агентству «The Friends Detective Agency», являющемуся официально признанным партнёрством, право выполнять все обязанности и функции, связанные с деятельностью частного сыскного агентства, в соответствии с законами, правилами и нормами, изложенными в Кодексе о частных сыскных агентствах Министерства следственных служб 512-PIA (прилагается)."
+Play %num2% ranked matches during 2v2 Season Five.,Сыграйте %num2% рейтинговых матчей в режиме 2 на 2 в пятом сезоне.
+Win %num2% ranked matches during 2v2 Season Five.,Выиграйте %num2% рейтинговых матчей в режиме 2 на 2 в Пятом сезоне.
+Overheat now blasts damage to nearby foes and no longer deals its initial damage to you. The tool belt recharge penalty for Overheat is reduced. Heat can only be lost after overheating.<br><c=@reminder>Damage over time from Overheat is still applied.</c>,Перегрев теперь наносит урон ближайшим врагам и больше не наносит начальный урон вам. Штраф к скорости перезарядки инструментов за использование Перегрева уменьшен. Тепло можно потерять только после перегрева.<br><c=@reminder>Урон от Перегрева со временем по-прежнему применяется.</c>
+Gain health per unit of heat lost.<br><c=@reminder>This trait does not function while cooling due to an overheat unless Photonic Blasting Module is equipped.</c>,"Восстанавливайте здоровье за каждую единицу потерянного тепла.<br><c=@reminder>Эта черта не действует во время охлаждения из-за перегрева, если не оснащён модуль «Фотонный взрыв».</c>"
+"Complete %num2% renown heart[s] in the Fields of Ruin, Blazeridge Steppes, Lornar's Pass, Dredgehaunt Cliffs, or the Harathi Hinterlands.
+
+<c=@reminder>Renown hearts are marked with a golden heart icon on the map. Every renown heart is different, so check your HUD when nearby to find out how you can assist.</c>","Выполните %num2% задания в локациях: Поля Руин, Равнины Блейзербридж, Перевал Лорнара, Скалы Дреджхаунт или Харати-Хинтерлендс.
+
+<c=@reminder>Задания отмечены на карте золотым значком сердца. Каждое задание уникально, поэтому, оказавшись рядом, проверьте интерфейс, чтобы узнать, чем вы можете помочь.</c>"
+"Earn experience to level up this character to level 70.
+
+<c=@reminder>Experience can be earned by defeating enemies, contributing to events and renown hearts, completing story chapters, and crafting items.</c>","Получайте опыт, чтобы повысить уровень этого персонажа до 70-го.
+
+<c=@reminder>Опыт можно получить за победу над врагами, участие в событиях и выполнении заданий на получение репутации, прохождение сюжетных глав и создание предметов.</c>"
+"Complete %num2% renown heart[s] in Sparkfly Fen, Mount Maelstrom, Iron Marches, Fireheart Rise, or Timberline Falls.
+
+<c=@reminder>Renown hearts are marked with a golden heart icon on the map. Every renown heart is different, so check your HUD when nearby to find out how you can assist.</c>","Выполните %num2% задания на получение репутации в локациях: Болотистая низина Спаркфлай, Гора Мэлстром, Железные марши, Огненная возвышенность или Тимберлайн-Фолс.
+
+<c=@reminder>Задания на получение репутации отмечены на карте золотым значком сердца. Каждое задание уникально, поэтому, оказавшись рядом, проверьте интерфейс, чтобы узнать, чем вы можете помочь.</c>"
+"Complete %num2% renown heart[s] in Snowden Drifts, Diessa Plateau, Brisban Wildlands, or Kessex Hills.
+
+<c=@reminder>Renown hearts are marked with a golden heart icon on the map. Every renown heart is different, so check your HUD when nearby to find out how you can assist.</c>","Выполните %num2% задания на получение репутации в Сноуден Дрифтс, Диесса Плато, Брисбан Уайлдлендс или Кессекс Хиллз.
+
+<c=@reminder>Задания на получение репутации отмечены золотым значком сердца на карте. Каждое задание уникально, поэтому проверяйте интерфейс, когда будете рядом, чтобы узнать, чем вы можете помочь.</c>"
+"Harvest %num2% material[s] from resource nodes in the Ruins of Orr, Frostgorge Sound, or Southsun Cove.
+
+<c=@reminder>Resource nodes are clumps of ore, saplings, and plants that can be gathered using gathering tools. Nodes can be found by exploring the world.</c>","Добывайте %num2% материалы из ресурсных узлов в Руинах Орра, Фростгорж-Саунде или Саутсан-Кове.
+
+<c=@reminder>Ресурсные узлы — это скопления руды, саженцев и растений, которые можно собирать с помощью инструментов для сбора ресурсов. Узлы можно найти, исследуя мир.</c>"
+"Participate in %num2% event[s].
+
+<c=@reminder>You can find events while exploring the world. Events in progress are marked by an orange circle on your map when you're nearby.</c>","Участвуй в %num2% событиях.
+
+<c=@reminder>События можно найти, исследуя мир. Идющие события отмечены на карте оранжевым кружком, когда вы находитесь рядом.</c>"
+"Gather %num2% material[s] with a logging axe in Sparkfly Fen, Mount Maelstrom, the Iron Marches, Fireheart Rise, or Timberline Falls.
+
+<c=@reminder>Resource nodes are clumps of ore, saplings, and plants that can be gathered using gathering tools. Nodes can be found by exploring the world.</c>","Собирайте %num2% материалы с помощью лесорубного топора в Болотистой низине, на горе Мейлстром, в Железных маршах, Огненной возвышенности или у Водопадных скал.
+
+<c=@reminder>Ресурсные узлы — это скопления руды, саженцы и растения, которые можно собирать с помощью инструментов для сбора ресурсов. Узлы можно найти, исследуя мир.</c>"
+"Participate in %num2% event[s] in the Fields of Ruin, Blazeridge Steppes, Lornar's Pass, Dredgehaunt Cliffs, or the Harathi Hinterlands.
+
+<c=@reminder>You can find events while exploring the world. Events in progress are marked by an orange circle on your map when you're nearby.</c>","Участвуйте в %num2% событиях в Пустошах Руин, Равнинах Блейзерриджа, Проходе Лорнара, Скалах Дреджхаунта или Харатиских Заземьях.
+
+<c=@reminder>Вы можете найти события, исследуя мир. Идющие события отмечены оранжевым кружком на карте, когда вы находитесь рядом.</c>"
+"Transmute %num2% item[s].
+
+<c=@reminder>Transmutation expends transmutation charges to replace the skin of a piece of equipment with a different one from your account wardrobe. Transmutation charges can be found in daily reward chests, earned by completing maps, or purchased from the Gem Store.</c>","Преобразуйте %num2% предмет[|а|ов].
+
+<c=@reminder>При трансмутации расходуются заряды трансмутации, чтобы заменить внешний вид предмета экипировки на другой из вашего гардероба. Заряды трансмутации можно найти в ежедневных сундуках с наградами, получить за прохождение карт или приобрести в игровом магазине за самоцветы.</c>"
+"Earn 75 crafting levels.
+
+<c=@reminder>Craft items to earn crafting experience for that crafting discipline, allowing you to create more powerful items.</c>","Получите 75 уровней профессии.
+
+<c=@reminder>Создавайте предметы, чтобы получать опыт в выбранной профессии, что позволит вам создавать более мощные предметы.</c>"
+"Earn 30 crafting levels.
+
+<c=@reminder>Craft items to earn crafting experience for that crafting discipline, allowing you to create more powerful items.</c>","Получите 30 уровней профессии.
+
+<c=@reminder>Создавайте предметы, чтобы получать опыт в выбранной профессии и создавать более мощные вещи.</c>"
+"Earn experience to level up this character to level 50.
+
+<c=@reminder>Experience can be earned by defeating enemies, contributing to events and renown hearts, completing story chapters, and crafting items.</c>","Получайте опыт, чтобы повысить уровень этого персонажа до 50-го.
+
+<c=@reminder>Опыт можно получить за победу над врагами, участие в событиях и выполнении заданий, прохождение сюжетных глав и создание предметов.</c>"
+"Discover 5 points of interest in Snowden Drifts, Diessa Plateau, Brisban Wildlands, or Kessex Hills.
+
+<c=@reminder>Points of interest are special locations marked by name in the world, indicated by a square icon on the map. </c>","Найдите 5 интересных мест в Сноуден Дрифтс, на плато Диесса, в Брисбан Уайлдлендс или в Кессекс Хиллз.
+
+<c=@reminder>Интересные места — это особые локации, отмеченные названием на карте и выделенные квадратным значком. </c>"
+"Mine %num2% ore with a mining pick from resource nodes in Dredgehaunt Cliffs, Harathi Hinterlands, or Blazeridge Steppes.
+
+<c=@reminder>Resource nodes are clumps of ore, saplings, and plants that can be gathered using gathering tools. Nodes can be found by exploring the world.</c>","Добывайте %num2% руду с помощью кирки на ресурсных точках в Скалах Дреджхаунт, Харатийских Загорьях или Равнинах Блейзерридж.
+
+<c=@reminder>Ресурсные точки — это скопления руды, саженцы и растения, которые можно собирать с помощью инструментов для сбора ресурсов. Точки можно найти, исследуя мир.</c>"
+"Participate in %num2% event[s] in Sparkfly Fen, Mount Maelstrom, Iron Marches, Fireheart Rise, or Timberline Falls.
+
+<c=@reminder>You can find events while exploring the world. Events in progress are marked by an orange circle on your map when you're nearby.</c>","Участвуйте в %num2% событиях в Топких болотах, на горе Мэлстром, в Железных маршах, Огненной возвышенности или в Таймберлейн-Фолс.
+
+<c=@reminder>Вы можете найти события, исследуя мир. Идющие события отмечены оранжевым кружком на вашей карте, когда вы находитесь рядом.</c>"
+"Participate in %num2% event[s] in the Ruins of Orr, Frostgorge Sound, or Southsun Cove.
+
+<c=@reminder>You can find events while exploring the world. Events in progress are marked by an orange circle on your map when you're nearby.</c>","Участвуйте в %num2% событиях в Руинах Орра, Фростгорж-Саунде или Саутсан-Кове.
+
+<c=@reminder>Вы можете найти события, исследуя мир. Идющие события отмечены на карте оранжевым кругом, когда вы находитесь рядом.</c>"
+"Defeat %num2% of the world bosses in Bloodtide Coast, Blazeridge Steppes, or Harathi Hinterlands.
+
+<c=@reminder>World bosses are challenging events that appear at specific times of day across Tyria. Defeat them to receive chests containing rare equipment and crafting materials. </c>","Победите %num2% мировых боссов в локациях «Кровавый прилив», «Пламенные степи» или «Харатийские просторы».
+
+<c=@reminder>Мировые боссы — это сложные события, которые происходят в определенное время суток по всей Тирии. Победив их, вы получите сундуки с редким снаряжением и материалами для крафта. </c>"
+"Death Shroud is replaced with Harbinger Shroud, granting powerful offensive skills but leaving you vulnerable to attack.<br>As you remain in Harbinger Shroud, you accumulate stacking Blight.<br><c=@reminder>Blight decreases your maximum health.</c>","«Смертельная саван» заменена на «Саван предвестника», дарующая мощные атакующие умения, но делающая вас уязвимым для атак.<br>Пока вы находитесь в состоянии «Саван предвестника», вы накапливаете эффект «Зловоние».<br><c=@reminder>«Зловоние» уменьшает ваш максимальный запас здоровья.</c>"
+"Find others to help you explore Bjora Marches!
+The Guild Wars 2: Path of Fire™ expansion and the Living World episode ""Whisper in the Dark"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Бьорнские Топи!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Path of Fire™ и пройти эпизод «Шёпот во тьме» из серии «Живая история»."
+"Bind all %num2% Lightborne weapon skins. These skins can be crafted from recipes purchased from Ward Trader Sampaguita in Bava Nisos or by purchasing them from the Trading Post and binding them to you. 
+
+Ward Trader Sampaguita can also craft Lightborne weapons at a premium if you have the proper materials.","Привяжите все %num2% вида оружия ""Светящийся"". Эти виды можно создать по рецептам, которые продаёт торговец Варда Сампагита в Бава-Нисос, или купить их на торговой площадке и привязать к себе.
+
+Торговец Варда Сампагита также может изготавливать оружие из светящихся материалов за дополнительную плату, если у вас есть необходимые компоненты."
+"Original Music Written (and soon to be performed!) by the Strand Band  
+  
+Each member of the band has made their own snippet of a song. We've recorded it below. For new learners, the numbers correlate to the notes your trumpet can produce.  
+  
+Sander: 1 3 5 2 7  
+  
+Daisy: 5 6 3 2 4  
+  
+Gealan: 3 8 4 6 1  
+  
+If this music is found, bring it to the members of the Strand Band and let's jam! We're always hanging out on the beach west of town!","Оригинальная музыка, написанная (и скоро исполняемая!) группой «Странд».
+  
+Каждый участник группы сочинил свою часть мелодии. Мы записали её ниже. Для начинающих: цифры соответствуют нотам, которые можно извлечь на трубе.
+  
+Сандер: 1 3 5 2 7
+  
+Дейзи: 5 6 3 2 4
+  
+Геалан: 3 8 4 6 1
+  
+Если найдёте эту музыку, принесите её участникам группы ""Strand Band"", и давайте вместе поиграем! Мы обычно тусуемся на пляже к западу от города!"
+<c=@abilitytype>Command.</c> Break stun while granting boons to nearby allies. The cooldown of this skill is increased if used to break a stun.<br><c=@abilitytype>Echo.</c> Grant additional boons to nearby allies after a set interval or after you use a burst skill.,"<c=@abilitytype>Команда.</c> Снимает оглушение и накладывает благословения на ближайших союзников. Время перезарядки этого умения увеличивается, если оно используется для снятия оглушения.<br><c=@abilitytype>Эхо.</c> Накладывает дополнительные благословения на ближайших союзников через определенный промежуток времени или после использования умения с эффектом «взрыва»."
+"Collect magic from the extractors in the Defiled Cradle.
+Gain more progress if Follow the Magic is completed.","Соберите магию с экстракторов в Осквернённой Колыбели.
+Получите больше прогресса, если пройдете задание «Следуйте за магией»."
+Defeat %num2% players in ranked matches during 3v3 Season Ten.,Одолейте %num2% игроков в рейтинговых матчах во время десятого сезона режима «3 на 3».
+"Find others to help you hunt Kryptis and complete Convergences.
+The Guild Wars 2: Secrets of the Obscure expansion is required to access Convergences.","Найдите других игроков, чтобы вместе охотиться на Криптиса и выполнять задачи «Схождение».
+Для доступа к схождениям необходимо приобрести дополнение Guild Wars 2: Secrets of the Obscure."
+Play %num2% ranked matches during 3v3 Season Ten.,Сыграйте %num2% рейтинговых матчей в 3 на 3 в десятом сезоне.
+"Double-click to gain a Jar of Bees.
+<c=@flavor>""Don't shake it!""<br>—Fiona</c>","Дважды щелкните, чтобы получить банку с пчелами.
+<c=@flavor>«Не трясите!»<br> — Фиона</c>"
+End the transformation and return to your true form.,Прекрати превращение и прими свой истинный облик.
+"Find others to help you investigate the disturbance around the bloodstone!
+The Guild Wars 2: Heart of Thorns expansion and the Living World episode ""Out of the Shadows"" are required to access this map.","Найдите других игроков, чтобы вместе расследовать происходящее вокруг кровавого камня!
+Для доступа к этой карте необходимо установить дополнение Guild Wars 2: Heart of Thorns и пройти эпизод Живой истории «Из тени»."
+"WvW WXP is now account bound! Enter a map with each character to have its WXP added to your account.
+
+—ArenaNet Staff","Теперь очки опыта для PvP (WvW) привязаны к учетной записи! Чтобы добавить их в свою учетную запись, зайдите на карту с каждым персонажем.
+
+—Сотрудник ArenaNet"
+"I learned many songs while tracing the steps of the heroes who ventured forth into the heart of the Maguuma Jungle.
+—Chief Melodist Flac","Я выучил много песен, следуя по стопам героев, отправившихся в самое сердце джунглей Магуума.
+—Главный мелодист Флак"
+"Many old medical reports point to some mass event where Tyrians woke up to a searing, white light while the symphony piece ""Overture"" blared in their minds. How fascinating!
+—Chief Melodist Flac","Многие старые медицинские отчеты указывают на некое массовое явление, когда жители Тирии просыпались от ослепительного белого света, а в их головах звучала музыкальная композиция «Увертюра». Как интересно!
+—Главный мелодист Флак"
+"There are many claims that ""wizard music"" from Garenhoff exists, but I've never heard it.
+—Chief Melodist Flac","Существует множество утверждений о том, что в Гаренхоффе есть «волшебная музыка», но я никогда её не слышал.
+—Главный мелодист Флак"
+"Awakened musicians are highly sought after. When you've honed your craft for over a century in a state of undeath, Elonian bands will bend over backward to get you to join their ensemble. 
+—Chief Melodist Flac","Пробужденные музыканты очень востребованы. Если вы оттачивали свое мастерство более века в состоянии нежити, элонийские музыкальные группы будут готовы на все, чтобы заполучить вас в свой ансамбль.
+—Главный мелодист Флак"
+"A rare, one-of-a-kind recording of the Metal Legion? I'll take three!
+—Chief Melodist Flac","Редкая уникальная запись выступлений Метал Легиона? Возьму три!
+—Главный мелодист Флак"
+"Hoo hoo. Quaggan wasn't sure quaggan could find anyone to help Soggorsort, but then there you were. Thank you for standing by quaggans. Quaggan only wishes more were so brave.<br><br>—Leudap","Ух-ух. Кваккан не был уверен, что найдется кто-то, кто поможет Соггорсорту, но вот вы и появились. Спасибо, что поддерживаете квакканов. Кваккан только надеется, что будет больше таких же смелых.<br><br>—Лейдап"
+"Your help? Recent, but change is seen already. Inventors, they mostly talk-talk because no materials to build, not safe to scavenge. Now they still talk-talk but hands are busy making. We make things and make them go. We are proud. We are grateful. Thank you.<br>
+—Twitchok","Нужна ваша помощь? Недавно изменения стали заметны. Изобретатели, они в основном только болтают, потому что нет материалов для строительства и небезопасно искать их. Теперь они всё ещё болтают, но руки заняты изготовлением. Мы делаем вещи и заставляем их работать. Мы гордимся этим. Мы благодарны. Спасибо.<br>
+— Твичок"
+"Melee attacks become ranged, have an increased chance to critically hit, and apply vulnerability. Unlocks the Mech Command skill Spark Revolver.<br>","Атаки в ближнем бою становятся дальнобойными, имеют повышенный шанс критического удара и накладывают уязвимость. Открывает навык «Механизированное управление» — «Искровая пушка».<br>"
+Endurance regeneration increased by 50%%; stacks duration.,Регенерация выносливости увеличена на 50%%; увеличена длительность эффекта.
+Heal nearby allies when you summon a creature.<br><c=@reminder>Spirits and minions are creatures.</c>,Восстанавливайте здоровье ближайших союзников при призыве существа. <br><c=@reminder>Духи и фамильяры — это существа.</c>
+"Find others to help you explore Mistburned Barrens.
+Requires the Guild Wars 2: Janthir Wilds expansion to access this map.","Найдите других игроков, чтобы вместе исследовать Изувеченные Туманами Пустоши.
+Для доступа к этой карте требуется дополнение Guild Wars 2: Янтарные дикие земли."
+"Complete 10 events for the Olmakhan in the Underworld.
+Required to gain access to the Olmakhan quartermaster.","Выполните 10 заданий для Олмакхана в Подземном мире.
+Необходимо для получения доступа к квартальному снабженцу Олмахана."
+"Find others to aid Steel Warband's passage north in this vision of the past.
+Guild Wars 2: Path of Fire expansion and the Living World episode ""Steel and Fire"" are required to access this content, which is launched from the Eye of the North Scrying Pool.","Найдите других, кто поможет отряду ""Стальная сталь"" пройти на север в этом видении прошлого.
+Для доступа к этому контенту, который запускается из Оракула в Глазе Севера, необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод ""Сталь и пламя"" сюжетной линии Living World."
+"Gain access to the Mech Command skill Sky Circus. While dismissed or away for repairs, your mech supports you with an occasional aerial bombardment.<br>Signet skills gain improved passive effects and continue to grant their passive bonuses while recharging.","Получите доступ к навыку «Механизированное командование» — «Небесный цирк». Пока ваш мех находится в режиме ожидания или на ремонте, он периодически поддерживает вас воздушными ударами.<br>Навыки-сигналы получают улучшенные пассивные эффекты и продолжают давать свои пассивные бонусы во время перезарядки."
+"Emercadani onese,  
+Maladretti Sidony icnatare,  
+Isgarren, in soltira maereca,  
+Solu in Amnytas.
+
+Survesa Tyria, pervescimi vindicare,  
+Famira jus ladattire,  
+Posira jus surifiate, percresa jus escaletri,  
+Aera etrona odi te icnatare. 
+
+Chi ad portesa stacare,  
+Chi damrecus est onia costedi,  
+Suvara terrona stani,  
+Vrigalanate, sempi escivicume.
+
+Isgarren, fatira, frustriame clamarite,  
+Tirsu in passivrea suplicazione covate,  
+Pontese caeluma purtibe.  
+Potistanu aera soltira infinictu fenera?
+
+Cima senescalis omrina vectese iretasa,  
+Caelu grava ium non ampri occruse.  
+Sec locatire Sidony,  
+Sec scritima aes, sec faede.","Эмеркадани, один из вас.
+Маладретти Сидонари,
+Исгаррен, в солтирской маэреке.
+Солу в Амнитесе.
+
+Исследуй Тирию, чтобы отомстить.
+Фамира просит тебя помочь.
+Позира, пусть твои шаги будут быстрыми, а твой меч – острым.
+Я не понимаю твой язык.
+
+Кто умеет, тот и отвязывает.
+Чи дамрекус есть ония костеди.
+Сувара террона стани.
+Вригаланате, полубоги-воины.
+
+Исгаррен, извини, но я не понимаю, о чем ты говоришь.
+Тырсу в пассивной молитве колыхается.
+Пожалуйста, не трогайте небесные сферы.
+Потеряна ли сила бесконечного феникса?
+
+Симона Сенискалис, омнира-вектеса, иретаса.
+Каэлу не смог найти подходящий камень для гравировки.
+Ищите Сидони.
+Секрет скрыт, секрет найден."
+"You would not believe the hurdles I surmounted to get this recording out. I still see angry clouds when I close my eyes...
+—Chief Melodist Flac","Вы не поверите, какие препятствия мне пришлось преодолеть, чтобы закончить эту запись. Даже сейчас, когда я закрываю глаза, я вижу грозные тучи…
+—Главный мелодист Флак"
+<c=@abilitytype>Signet Passive:</c> Grants health every time you cast a spell. <br><c=@abilitytype>Signet Active:</c> Heal yourself.,"<c=@abilitytype>Пассивный навык знака:</c> Восстанавливает здоровье каждый раз, когда вы используете заклинание. <br><c=@abilitytype>Активный навык знака:</c> Лечит вас."
+"Story Instance: Scion & Champion
+
+Hint: A veteran ogre appears each time a crystal reaches a 50%% charge.","Сюжетный инстанс: «Преемник и чемпион»
+
+Подсказка: Каждый раз, когда заряд кристалла достигает 50 %%, появляется ветеран-огр."
+"Cantha has some...fascinating musical genres. What was it called again? Jade-pop? Can-pop? The music is catchy, but the fans are of an incalculable intensity. 
+—Chief Melodist Flac","В Канте есть несколько… весьма интересных музыкальных жанров. Как же он назывался? ""Джейд-поп""? Или ""Кан-поп""? Музыка довольно запоминающаяся, но фанаты просто невообразимо преданные.
+—Вождь-мелодист Флак"
+"The lowland kodan took the original music culture of the kodan and splintered in a wildly different direction. I could spend a lifetime writing books about this!
+—Chief Melodist Flac","Низменные кодан переняли изначальную музыкальную культуру своего народа, но развили её в совершенно ином направлении. Я мог бы посвятить этому всю свою жизнь и написать целую серию книг!
+—Главный мелодист Флак"
+"Deal increased strike damage to weakened foes. Disabling a foe applies weakness.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, fear, taunt, and launch.</c>","Наносит увеличенный урон при ударе по ослабленным противникам. Ослабление противника накладывает состояние слабости.<br><c=@reminder>Ослабления включают оглушение, дезориентацию, отбрасывание, подтягивание, сбивание с ног, погружение, поднятие в воздух, испуг, насмешку и отброс.</c>"
+"I'm still impressed that you infiltrated the Nightmare Court. It takes a special kind of sneak to pull that off. My heart aches when I think about the terrible, terrorizing abuse they heap on the innocent. If they'd infected those poor souls with nightmare, it would have brought suffering to the entire region. You have our thanks.<br>
+—Alarin","Я до сих пор поражаюсь тому, как тебе удалось внедриться в Ночной двор. Для этого нужно обладать особым талантом к скрытности. У меня сердце сжимается от мысли о том ужасном и жестоком обращении, которому они подвергают невинных. Если бы они заразили этих несчастных кошмаром, это принесло бы страдания всему региону. Мы благодарим тебя.<br>
+— Алари"
+"+25 Power
++25 Ferocity
++12 Precision
++12 Vitality","+25 силы
++25 ярости
++12 точности
++12 к жизненной силе"
+"Straight from the windswept canyons of Highjump Ranch comes the last guidebook you'll ever need on springer care! After years of working alongside Stablemaster Unja and her expertly trained family of ranch hands, we've compiled the ultimate list of dos and don'ts for the responsible springer owner.
+
+Whether you're looking to construct the ideal living environment, grow the right crossbreed of carrot, or learn just how high your springer can safely jump without injury, this guide will offer all the answers and then some!
+
+A portion of all profits from this book goes to support Highjump Ranch and its efforts to find homes for springers all throughout the Crystal Desert.","Прямо из продуваемых всеми ветрами каньонов ранчо Хайджампп – последняя книга, которая вам понадобится по уходу за спрингерами! После многих лет работы вместе со смотрительницей конюшен Унджей и ее командой опытных работников ранчо, мы составили исчерпывающий список того, что можно и чего нельзя делать ответственным владельцам спрингеров.
+
+Независимо от того, хотите ли вы создать идеальную среду обитания, вырастить нужный сорт моркови или узнать, на какую высоту ваш спрингер может безопасно прыгать без травм, в этом руководстве вы найдете все ответы и даже больше!
+
+Часть прибыли от продажи этой книги идет на поддержку приюта Highjump Ranch и его усилий по поиску новых хозяев для собак породы спрингер-спаниель во всем Хрустальном Пустыне."
+"Two Adventures. One Price.<br>
+Buy Path of Fire and Get Heart of Thorns FREE","Два приключения. Одна цена.<br>
+Купите «Path of Fire» и получите «Heart of Thorns» в подарок!"
+"Save Tyria from the God of Fire and War in Guild Wars 2: Path of Fire!
+Unlock six world-class mounts, each with unique abilities that will change the way you play forever. Explore five new maps in the Crystal Desert, nine elite specializations, and more!","Спасите Тирию от Бога Огня и Войны в Guild Wars 2: Path of Fire!
+Открой шесть уникальных мировых ездовых животных высшего класса, каждое из которых обладает особыми способностями, навсегда меняющими твой стиль игры. Исследуй пять новых локаций в Кристальной Пустыне, девять элитных специализаций и многое другое!"
+"Grants swiftness when applied. Applies defensive boons upon entering combat.
++150 Toughness
++150 Vitality","Даёт быстроту при применении. Накладывает защитные благодати при вступлении в бой.
++150 к живучести
++150 жизненной силы"
+Win %num2% ranked matches during 3v3 Season Five.,Выиграйте %num2% рейтинговых матчей в течение 5-го сезона режима 3 на 3.
+"Using the first round of ammo on an ammunition skill reduces the recharge of all warrior skills. <br><c=@reminder>Does not affect the recharge of Unsheathe Gunsaber, Sheathe Gunsaber, and Dragon Trigger. </c>","Использование первого заряда боеприпасов в умении, связанном с боеприпасами, уменьшает время перезарядки всех умений воина. <br><c=@reminder>Не влияет на время перезарядки умений «Выхватить пистолет-саблю», «Спрятать пистолет-саблю» и «Драконья трансформация». </c>"
+Play %num2% ranked matches during 3v3 Season Five.,Сыграйте %num2% рейтинговых матчей в 3v3 в пятом сезоне.
+"The first time a <c=@abilitytype>phantasm</c> would become a clone, it instead resummons itself and attacks again. Resummoned phantasms inflict a percentage of the original's damage.<br><c=@reminder>(Resummoned phantasms are briefly dazed.)</c>","В первый раз, когда <c=@abilitytype>иллюзия</c> должна была бы превратиться в клон, она вместо этого призывает себя заново и атакует снова. Повторно призванные иллюзии наносят процент от урона оригинала.<br><c=@reminder>(Повторно призванные иллюзии ненадолго оглушаются.)</c>"
+Defeat %num2% players in ranked matches during 3v3 Season Eight.,Одолейте %num2% игроков в рейтинговых матчах во время восьмого сезона режима «3 на 3».
+"Gain a fire aura, and damage nearby foes when you attune to fire.<br><c=@reminder>Also triggers on overload skills.</c>","Получите огненную ауру и наносите урон ближайшим врагам при использовании умения ""Огненная связь"".<br><c=@reminder>Также активируется навыками перегрузки.</c>"
+"Select an element to specialize in, greatly reducing its recharge time and gaining a familiar of that element. The familiar's basic skill charges as you use weapon skills, charging more rapidly when you use a weapon skill of its element. Using the familiar's basic skill three times will enable its empowered skill. <br>Gain access to <c=@abilitytype>meditation</c> skills.","Выберите элемент для специализации, чтобы значительно сократить время его перезарядки и получить фамильяра этого элемента. Базовая способность фамильяра заряжается при использовании навыков оружия, а скорость зарядки увеличивается при использовании навыка оружия соответствующего элемента. Использование базовой способности фамильяра три раза позволит использовать его усиленную способность. <br>Получите доступ к навыкам <c=@abilitytype>медитации</c>."
+"Through asuran ingenuity, you are host to a mercurial mold. You are able to command it using selectable <c=@abilitytype>morph</c> skills that replace your toolbelt skills or even fully merge with it to evolve into a superior being.<br><c=@abilitytype>Morph</c> skills selected will alter the composition of the mercurial mold, changing the bonuses it grants you when you evolve.<br>Gain access to <c=@abilitytype>stance</c> utility skills.","Благодаря асурийской изобретательности, вы стали носителем изменчивой плесени. Вы можете управлять ею с помощью специальных навыков <c=@abilitytype>трансформации</c>, которые заменяют навыки вашего пояса инструментов или даже полностью сливаются с ним, чтобы превратить вас в существо высшего порядка.<br>Выбранные навыки <c=@abilitytype>трансформации</c> изменят состав изменчивой плесени, изменяя бонусы, которые она предоставляет вам при трансформации.<br>Получите доступ к утилитарным навыкам <c=@abilitytype>стойки</c>."
+"Collect various teleportation gizmos. 
+
+You can update progress for this achievement by traveling to Lion's Arch and meeting one of these conditions:
+• You have the item in your inventory.
+• You have put a scroll in a portal tome.
+• You have completed a related achievement.","Соберите различные устройства для телепортации.
+
+Вы можете обновить прогресс выполнения этого достижения, посетив город Лайонс-Арх и выполнив одно из следующих условий:
+У вас этот предмет есть в инвентаре.
+Вы поместили свиток в портальный том.
+• Вы выполнили связанное достижение."
+"Summon a swirling spore cloud around your pet, destroying projectiles and chilling disabled or defiant enemies.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Создайте вокруг своего питомца вращающееся облако спор, уничтожающее снаряды и замораживающее обездвиженных или сопротивляющихся врагов.<br><c=@reminder>Обездвиживание включает в себя оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем, подброс, насмешку и страх.</c>"
+"Disabling a foe applies conditions to that foe based on your current state.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Оглушение противника накладывает на него эффекты в зависимости от вашего текущего состояния.<br><c=@reminder>К эффектам оглушения относятся: стан, дезориентация, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешка и страх.</c>"
+"Your pet teleports to your target and lashes out, poisoning enemies and applying vulnerability to disabled or defiant enemies.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Ваш питомец телепортируется к цели и наносит удар, отравляя врагов и накладывая уязвимость на обездвиженных или сопротивляющихся противников.<br><c=@reminder>Обездвиживание включает в себя оглушение, дезориентацию, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешку и страх.</c>"
+"Your pet strikes nearby enemies with vines, removing boons. Disabled or defiant enemies are also slowed.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Ваш питомец атакует ближайших врагов лозами, снимая благословения. Оглушенные или неподдающиеся воздействию враги также замедляются.<br><c=@reminder>Оглушение включает в себя: оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешку и страх.</c>"
+"Requires Guild Wars 2: End of Dragons.
+
+Equip your fishing pole with bait and a lure to catch fish all over Tyria.","Требуется дополнение Guild Wars 2: End of Dragons.
+
+Оснастите свою удочку приманкой и блесной, чтобы ловить рыбу по всей Тирии."
+Deal increased strike damage with active upkeep skills.<br><c=@reminder>Herald and weapon upkeep skills grant less damage but can be stacked.</c>,"Наносит увеличенный урон при нанесении ударов, когда активны поддерживающие умения.<br><c=@reminder>Умения «Знамя» и поддерживающие умения оружия дают меньше урона, но их можно комбинировать.</c>"
+"Double-click to gain a Hylek Poison Pot.
+<c=@flavor>""Hylek tribes know how to make good poisons. We should learn something about pot making though.""<br>—Potatlan</c>","Дважды щелкните, чтобы получить склянку с ядом хилек.
+<c=@flavor>«Племена хилек умеют делать хорошее оружие. Нам тоже стоит научиться готовить зелья».<br> — Потатлан.</c>"
+"Smash the ground, creating three shock waves that deal damage. Deal increased damage to disabled enemies, defiant enemies, and enemies with conditions.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Ударьте по земле, создавая три ударные волны, наносящие урон. Наносите увеличенный урон ослабленным, непоколебимым противникам и противникам с эффектами.<br><c=@reminder>Ослабление включает в себя оглушение, ошеломление, отбрасывание, притягивание, повал, погружение, подъем, отброс, насмешку и страх.</c>"
+Recharge steal and inflict a pulmonary impact when you interrupt an enemy.<br><c=@reminder>This trait can only affect enemies with defiance bars once per interval.</c>,"Восстанавливайте навык кражи и наносите удар по легким, когда прерываете действия противника.<br><c=@reminder>Эта черта может воздействовать на врагов с полосками сопротивления не чаще одного раза за интервал.</c>"
+Enemies struck by Time Sink are affixed with a time bomb. Time bombs increase your strike damage dealt to the target and explode when they expire.<br><c=@reminder>Only a certain number of time bombs may be active at once.</c>,"Враги, пораженные умением «Искажение времени», получают временную бомбу. Временные бомбы увеличивают урон от ваших атак по цели и взрываются после истечения срока действия.<br><c=@reminder>Одновременно может быть активным только определенное количество временных бомб.</c>"
+"Blinding, immobilizing, or affecting a foe with crowd control heals nearby allies.<br><c=@reminder>Skills that strike many foes at the same time can heal multiple times.</c>","Ослепление, обездвиживание или применение контроля над противником восстанавливает здоровье ближайшим союзникам. <br><c=@reminder>Навыки, поражающие нескольких врагов одновременно, могут несколько раз восстановить здоровье.</c>"
+<c=@abilitytype>Venom</c> utility skills siphon life from struck foes. Gain stacks of Spider Venom when you enter or exit stealth.<br><c=@reminder>Siphoning can only occur once per strike.</c>,"<c=@abilitytype>Яд</c>: умения этой категории вытягивают жизненную силу из поражённых врагов. При входе или выходе из режима невидимости получайте стаки ""Яда паука"".<br><c=@reminder>Эффект вытягивания жизненной силы может применяться только один раз за удар.</c>"
+"Disabling a foe slows them.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c><br><c=@reminder>This trait can only affect the same enemy with once per interval.</c>","Оглушение противника замедляет его.<br><c=@reminder>К оглушению относятся: стан, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем в воздух, насмешка и испуг.</c><br><c=@reminder>Этот эффект может применяться к одной и той же цели не чаще одного раза за интервал времени.</c>"
+"<c=@flavor>WARNING: Some fractals may cause injury, psychic trauma, blindness, or death.</c>","<c=@flavor>Внимание: некоторые фракталы могут привести к травмам, психическим расстройствам, слепоте или смерти.</c>"
+"Find others to help you explore Starlit Weald.
+The Guild Wars 2: Visions of Eternity expansion is required to access this map.","Найдите других игроков, чтобы вместе исследовать Звёздную Рощу.
+Для доступа к этой карте необходимо расширение Guild Wars 2: Visions of Eternity."
+"Find others to help you explore Shipwreck Strand.
+The Guild Wars 2: Visions of Eternity expansion is required to access this map.","Найдите других игроков, чтобы вместе исследовать Затонувшую Косу.
+Для доступа к этой карте необходимо установить дополнение Guild Wars 2: Visions of Eternity."
+"Based on my findings, I believe uttering the following seer enchantments will help reground the steward's arcane tuning devices and sever the Inquest interference.  
+  
+If the steward has become irate, perform the following spell:  
+*Sonno Lieve Frusto*  
+  
+If the steward has become confused, perform the following spell:  
+*Lieve Frusto Sonno*","Основываясь на моих исследованиях, я полагаю, что произнесение следующих заклинаний провидца поможет восстановить связь аркановых устройств смотрителя и прервать вмешательство Инквизиции.
+  
+Если распорядитель рассердился, произнесите следующее заклинание:
+*Сонно Лив Фрусто*
+  
+Если распорядитель сбился с толку, произнесите следующее заклинание:
+*Lieve Frusto Sonno*"
+"Find others to help you hunt rift enemies within Castora.
+The Guild Wars 2: Visions of Eternity expansion is required to access the relevant content.","Найдите других игроков, чтобы вместе охотиться на врагов разлома в Касторе.
+Для доступа к соответствующему контенту необходимо приобрести дополнение Guild Wars 2: Visions of Eternity."
+"Gain resolution and aegis when disabled.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Получайте эффект «Решимость» и «Эгида», когда находитесь в состоянии отключения.<br><c=@reminder>К состояниям отключения относятся оглушение, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подброс, насмешка и страх.</c>"
+"Bind %num2% legendary rune[s].
+(Players with existing legendary runes can update this achievement when visiting Lion's Arch or the Wizard's Tower.)","Привяжите %num2% легендарную руну (руны).
+(Игроки, у которых уже есть легендарные руны, могут выполнить это достижение при посещении Королевского города или Башни магов.)"
+Destroy the Forged Assemblers keeping the barrier active.,"Уничтожьте созданные кузнецы, поддерживающие барьер."
+"Interrupting a foe inflicts blind, and blinding a foe inflicts confusion.<br><c=@reminder>This trait can only activate on enemies with defiance bars once per interval.</c>","Прерывание действия противника вызывает ослепление, а ослепление противника — смятение. <br><c=@reminder>Эта черта может активироваться только на врагах с полосками сопротивления не чаще одного раза за интервал.</c>"
+Awesomium © 2012 Khrona LLC.  All rights reserved.  Additional copyright and license information for sub-components of Awesomium can be found online at http://www.awesomium.com/agreements/awesomium-pro-eula-v6.txt,Awesomium © 2012 Khrona LLC. Все права защищены. Дополнительная информация об авторских правах и лицензиях для отдельных компонентов Awesomium доступна в Интернете по адресу http://www.awesomium.com/agreements/awesomium-pro-eula-v6.txt
+"Obtained by fighting enemies with the Essence of Vigilance and picking up their essence, which grants fury, endurance, and swiftness.
+
+Build 30 stacks to gain increased magic find, bonus rewards, and a 75%% chance to steal life on critical hits to enemies with the Essence of Resilience for 30 minutes.","Получается в бою с врагами, обладающими Эссенцией Бдительности, и при сборе их эссенции, которая даёт ярость, выносливость и быстроту.
+
+Накопите 30 единиц эффекта, чтобы получить повышенный шанс обнаружения магических предметов, дополнительные награды и 75%%-й шанс кражи здоровья при критических ударах по врагам в течение 30 минут с помощью «Эссенции стойкости»."
+"Obtained by fighting enemies with the Essence of Valor and picking up their essence, which grants quickness and swiftness.
+
+Build 30 stacks to gain increased magic find and bonus rewards, and gain a 30%% damage reduction from enemies with the Essence of Vigilance for 30 minutes.","Получается в бою с врагами, обладающими Сущностью Доблести, и при сборе их сущности, которая даёт эффект «Проворство» и «Быстрота».
+
+Накопите 30 единиц эффекта, чтобы получить повышенный шанс выпадения магических предметов и дополнительные награды, а также на 30 минут уменьшить получаемый урон от врагов на 30%%, используя «Эссенцию бдительности»."
+"Strike nearby enemies, inflicting damage. Deals increased damage to disabled or defiant enemies.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Наносит урон ближайшим врагам. Наносит увеличенный урон ослабленным или находящимся в состоянии защиты врагам.<br><c=@reminder>Ослабление включает оглушение, дезориентацию, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешку и страх.</c>"
+"Find others to help you investigate Draconis Mons!
+The Guild Wars 2: Heart of Thorns expansion and the Living World episode ""Flashpoint"" are required to access this map.","Найдите других игроков, чтобы вместе исследовать Драконис Монс!
+Для доступа к этой карте необходимо приобрести дополнение Guild Wars 2: Heart of Thorns и пройти эпизод «Точка невозврата» из серии «Живая история»."
+"When you cast a cantrip, gain a random new stolen skill. Stolen skills deal more damage.<br><c=@reminder>(Requires a marked target. Overwrites existing stolen skills.)</c>",При произнесении заклинания получаете случайную новую украденную способность. Украденные способности наносят больше урона.<br><c=@reminder>(Требуется отмеченная цель. Заменяет существующие украденные способности.)</c>
+"Term of employment: 1845–present
+
+Current title: Subject Matter Expert
+
+Status: Consultant
+
+Deep knowledge of many subjects, including dragon magic, asuran golemancy, and cybernetics. Adept at pattern recognition and complex systems. Loves to speak and is not discouraged by even the most pointed silence, must be assertive in need for quiet to focus. Blueprints for the jade exoskeleton we designed together to aid her mobility have been sent to MedTech for redesign to fit the human form. Her improvements to the design resulted in a reduction in both the incidence and intensity of her physical symptoms across the board, often by a self-reported fifty percent or more.","Срок трудового договора: 1845 год – настоящее время.
+
+Текущий ранг: эксперт в своей области
+
+Статус: консультант
+
+Обладает глубокими знаниями в различных областях, включая магию драконов, асурийскую големотехнику и кибернетику. Прекрасно распознаёт закономерности и разбирается в сложных системах. Любит говорить и не смущается даже самым явным молчанием, но при необходимости умеет настойчиво требовать тишины для концентрации. Чертежи экзоскелета из жадеита, который мы вместе разработали для улучшения её мобильности, отправлены в MedTech для переработки под человеческие пропорции. Благодаря её усовершенствованиям удалось снизить как частоту, так и интенсивность физических симптомов, причем, по её собственным оценкам, на пятьдесят процентов и более."
+"Term of employment: 1843–present
+
+Current title: Associate Engineer
+
+Status: Full-time
+
+Notes: No formal education but extremely gifted. Designed their own jade prosthesis. Previous association with the ""Jade Brotherhood"" but denies any current association—gets angry enough at the mention of the Brotherhood that it seems sincere. Do not assign to projects with Mai Trin. Expressed desire to transition to project leader in MedTech department. Avoid topics ""cats"" and ""holodramas"" as Yao has difficulty not talking about those subjects once they have been brought up.","Срок службы: 1843 – настоящее время.
+
+Текущая должность: помощник инженера
+
+Статус: полный рабочий день
+
+Примечание: Не имеет формального образования, но обладает выдающимися способностями. Разработал собственный нефритовый протез. Ранее был связан с «Нефритовым братством», но отрицает какие-либо текущие связи — настолько сердится при упоминании Братства, что это кажется искренним. Не назначать на проекты с Май Трин. Выразил желание перейти на должность руководителя проекта в отделе медицинских технологий. Следует избегать тем «кошки» и «мелодрамы», так как Яо испытывает трудности с тем, чтобы не говорить об этих темах после того, как они были затронуты."
+"Your critical hits deal more damage. Critical hit damage against disabled foes, or foes below the health threshold, is further increased.<br><c=@reminder>Disabled foes are affected by stun, daze, knockback, pull, knockdown, sink, float, fear, taunt, or launch.","Ваши критические удары наносят больше урона. Урон от критических ударов по обездвиженным противникам или противникам с низким уровнем здоровья дополнительно увеличивается.<br><c=@reminder>Обездвиженные противники находятся под воздействием оглушения, ошеломления, отбрасывания, притягивания, опрокидывания, погружения, поднятия в воздух, страха, насмешки или запуска."
+"Using a stolen skill grants additional boons to allies around you. Stolen skills will always be Steal Time, regardless of the target's profession. <br>","Использование украденного умения дарует дополнительные благословения союзникам вокруг вас. Украденные умения всегда будут представлять собой «Кражу времени», независимо от профессии цели. <br>"
+Torment you inflict deals increased damage and causes your foes to burn.<br><c=@reminder>This trait can only inflict burning on a particular target once every three seconds. </c>,"Наносимый вами мучительный урон увеличен, и ваши враги получают эффект горения.<br><c=@reminder>Эта черта может накладывать эффект горения на конкретную цель не чаще одного раза в три секунды.</c>"
+Summon only one shade at a time. This greater shade has a modified recharge. Influence a larger area with <c=@abilitytype>shade</c> skills. <br><c=@reminder>A greater shade counts as three shades for related traits.</c>,"Призывайте не более одной тени за раз. У этой усиленной тени изменен период восстановления. Используйте способности, чтобы воздействовать на большую область с помощью <c=@abilitytype>тени</c>. Для связанных черт усиленная тень считается тремя тенями. <br><c=@reminder></c>"
+"Manifest Sand Shade grants a barrier to allies near it. When you apply barrier, grant boons to the affected target.<br><c=@reminder>This effect only occurs with barrier from scourge skills and traits.</c>","Проявление песчаной тени дарует барьер союзникам рядом с ней. При применении барьера на цель, она получает благословения.<br><c=@reminder>Этот эффект происходит только при использовании барьера от умений и черт чумы.</c>"
+"+25%% Experience from Kills
++25%% Gold from Kills
++25%% Reward Track Gain in PvP and WvW","+25%% опыта за убийства
++25%% золота за убийства
++25%% прогресса в системе наград в PvP и RvR"
+"Use /shiver in the highest parts of all the Shiverpeak Mountains.
+<c=@reminder>Requires access to previous Living World episodes to complete.</c>","Используйте команду /shiver в самых высоких точках всех гор Шиверпик.
+<c=@reminder>Для выполнения задания требуется доступ к предыдущим эпизодам «Живого мира».</c>"
+"The end is in sight.
+The feeling, everlasting.
+<c=@flavor>""Stand against me, and you stand alone.""—Jormag</c>
+What would Aurene think?","Конец близок.
+Чувство, которое останется навсегда.
+<c=@flavor>«Встаньте против меня, и вы останетесь один».— Йормаг</c>
+Что бы подумала Аурене?"
+"Do you miss the frost when it leaves you?
+It stays with you longer now.
+<c=@flavor>""You need not fear me, Champion, for I can set you free.""—Jormag</c>
+This is but the second step on a long road.","Не скучаешь ли ты по холоду, когда он покидает тебя?  
+Теперь он остаётся с тобой надолго.  
+<c=@flavor>«Тебе нечего бояться меня, чемпион, ибо я могу освободить тебя.»—Йорманг</c>  
+Это лишь второй шаг на долгой дороге."
+"The journey continues.
+There is no end in sight.
+<c=@flavor>""Fear is your enemy, not I.""—Jormag</c>
+How long will this go on?","Путешествие продолжается.
+Кажется, этому не будет конца.
+<c=@flavor>«Страх — твой враг, а не я».— Йормаг</c>
+Как долго это будет длиться?"
+"Disabling a foe grants barrier to nearby allies. Your function gyro dazes foes when cast. <br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Оглушение противника даёт барьер находящимся рядом союзникам. Ваша способность «Гиро» оглушает врагов при использовании. <br><c=@reminder>К оглушению относятся: стан, оглушение, отбрасывание, подтягивание, сбивание с ног, погружение, поднятие в воздух, насмешка и страх.</c>"
+"Complete the fractal dungeon at this difficulty in the Fractals of the Mists through the portal in Lion's Arch.
+Requires the mastery Follows Advice.","Пройдите фрактальный данж на этой сложности в «Фракталах Туманов», используя портал в Королевской Гавани.
+Требуется знание ""Следуй советам""."
+Deal increased strike damage to foes above the health threshold. Also deal more damage to foes with barrier.<br><c=@reminder>Damage bonuses do not stack.</c>,"Наносит увеличенный урон при попадании по противникам, чей уровень здоровья превышает заданный порог. Также наносит больше урона противникам с барьером.<br><c=@reminder>Бонусы к урону не суммируются.</c>"
+<c=@abilitytype>Minions</c> have increased health. Gain <c=@abilitytype>carapace</c> for each minion you control.<br><c=@reminder>Your minions are destroyed when this trait is reassigned.</c>,"У <c=@abilitytype>прислужников</c> увеличено количество здоровья. Вы получаете <c=@abilitytype>защитную броню</c> за каждого прислужника, которым вы управляете.<br><c=@reminder>При переназначении этой черты все ваши прислужники уничтожаются.</c>"
+Enemies you interrupt are inflicted with torment.<br><c=@reminder>This trait can only affect enemies with defiance bars once per interval.</c>,"Враги, прерванные вами, получают эффект «мучение».<br><c=@reminder>Этот талант может воздействовать на врагов с полосками сопротивления не чаще одного раза за интервал.</c>"
+Interrupts deal damage and inflict weakness while granting you a damage increase.</c><br><c=@reminder>This trait can only damage enemies with defiance bars once per interval.</c>,"Прерывания наносят урон и ослабляют цель, а также увеличивают ваш урон. </c><br><c=@reminder>Эта черта может наносить урон врагам с полосками защиты только один раз за интервал.</c>"
+"+32 Precision
++18 Power
++18 Ferocity","+32 точность
++18 силы
++18 ярости"
+"<c=@abilitytype>Commands</c> copy boons from yourself to your pet.<br><c=@reminder>Soulbeast: when merged, extend the duration of boons on yourself instead.</c>","<c=@abilitytype>Команды</c> копируют бонусы с вас на вашего питомца.<br><c=@reminder>Духоохотник: при объединении продлевает длительность бонусов у себя, а не у питомца.</c>"
+"You and your pet deal increased strike damage to disabled, defiant, or movement-impaired foes.<br><c=@reminder>Affected conditions are stun, taunt, daze, cripple, fear, immobilize, and chilled.</c>","Вы и ваш питомец наносите увеличенный урон при ударе по врагам, находящимся в состоянии оглушения, насмешки или с ограниченной подвижностью.<br><c=@reminder>На это влияют следующие состояния: оглушение, насмешка, ошеломление, хромота, страх, неподвижность и заморозка.</c>"
+Gain bonuses for each dagger you equip:<br>Main hand—Strike damage is increased versus foes with no boons.<br>Off hand—Heal for a percent of your outgoing strike damage.,Получайте бонусы за каждый экипированный кинжал: <br>В основной руке — урон от удара увеличен против целей без благословений.<br>Во второстепенной руке — восстанавливайте процент от наносимого вами урона от ударов.
+<c=@abilitytype>Virtue: </c>Burn foes every few attacks.<br><c=@abilitytype>Activate: </c>Pull forth a magical tome on the dangers of the blazing heat in Kourna.,"<c=@abilitytype>Добродетель:</c> Поджигайте врагов каждые несколько атак.<br><c=@abilitytype>Активация:</c> Призовите волшебный том, повествующий об опасностях палящего жара в Курне."
+"Gain knowledge of Elonian lore, igniting a fierce drive to purge corruption and manifesting your <c=@abilitytype>Virtues</c> as mystic tomes. Gain access to <c=@abilitytype>Mantras</c>.<br><c=@reminder>Using Tome skills consumes pages. You regenerate pages every interval.</c>","Получите знание элонской истории, пробуждая яростное стремление очистить коррупцию и проявляя ваши <c=@abilitytype>Добродетели</c> в виде мистических томов. Получите доступ к <c=@abilitytype>Мантрам</c>.<br><c=@reminder>Использование навыков тома расходует страницы. Вы восстанавливаете страницы каждые интервалы.</c>"
+"When Renewing Gaze triggers, this trait restores a portion of the recharge time needed by your healing, utility, and elite skills.<br><c=@reminder>Excludes racial skills.</c>","При срабатывании умения «Обновляющий взгляд» оно восстанавливает часть времени перезарядки для ваших целебных, вспомогательных и элитных умений.<br><c=@reminder>Не распространяется на расовые умения.</c>"
+"Retain <c=@abilitytype>Courage</c> passive while it is on cooldown. Grant boons to nearby allies when you disable, immobilize, or slow an enemy.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Сохраняйте пассивное умение <c=@abilitytype>«Отвага»</c>, пока оно находится в состоянии перезарядки. Даруйте благословения ближайшим союзникам, когда вы оглушаете, обездвиживаете или замедляете врага.<br><c=@reminder>Оглушение включает в себя: стан, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем, выброс, насмешку и страх.</c>"
+"Return these to Awakened Servant Tooraj near the Vehjin Mines.
+<c=@Flavor>As Awakened age, having physical reminders of their origins and history becomes increasingly important.</c><br>Renown Item","Верните их пробужденному слуге Тооражу возле шахт Веджин.
+<c=@Flavor>С возрастом пробужденные начинают все больше ценить физические напоминания о своем происхождении и истории.</c><br>Предмет славы"
+<c=@abilitytype>Virtue: </c>Regenerate health.<br><c=@abilitytype>Activate: </c>Draw forth an enchanted tome that recounts the trials undergone by the people of Vabbi.,"<c=@abilitytype>Добродетель:</c> Восстанавливает здоровье.<br><c=@abilitytype>Активация:</c> Призывает зачарованное издание, в котором рассказывается о испытаниях, пережитых жителями Вабби."
+"<br>—You've entered a Costume Brawl.
+—Attack other players with skills from toys, bundles, and tonics in this free-for-all.
+—If you attempt real combat, you'll exit the brawl.","<br>—Вы вступили в Костюмированный поединок.
+—Атакуйте других игроков умениями из игрушек, комплектов и зелий в этом свободном для всех сражении.
+—Если вы попытаетесь вести настоящий бой, вас исключат из поединка."
+Win %num2% ranked matches during 3v3 Season Eight.,Выиграйте %num2% рейтинговых матчей в течение восьмого сезона режима 3 на 3.
+Play %num2% ranked matches during 3v3 Season Eight.,Сыграйте %num2% рейтинговых матчей в 3v3 во время восьмого сезона.
+"Site Name: TBD  
+ 
+Location: East of Gyala Hatchery site  
+ 
+Viability: High  
+ 
+Pros: Partially excavated previously, but long abandoned. Exposed rich deposits remain. Previous dig attempt(s) appear Luxon given the structural remains; possible salvage opportunities, though most appear to be corroded and/or irreparable. Jade readily accessible.  
+ 
+Risks: Local fauna remarkably aggressive. Surveyors report possible air-quality issues—typical air filtration equipment may be required. Rail access inconvenient/convoluted but plausible—perhaps this is positive if avoiding regulatory scrutiny is preferred?","Название сайта: будет определено позже.
+ 
+Местоположение: к востоку от места расположения Гиальской фермы.
+ 
+Эффективность: высокая.
+ 
+Плюсы: Часть раскопок уже проводилась в прошлом, но место было заброшено. Здесь сохранились богатые залежи. Судя по остаткам конструкций, предыдущие попытки раскопок могли быть предприняты люксонами; возможно, удастся что-то спасти, хотя большая часть, похоже, повреждена коррозией или не подлежит восстановлению. К яшме можно легко добраться.
+ 
+Риски: Местная фауна отличается необычайной агрессивностью. По данным геологов, возможно наличие проблем с качеством воздуха — может потребоваться стандартное оборудование для фильтрации воздуха. Доступ по железной дороге затруднен и сложен, но возможен — возможно, это даже плюс, если предпочтительнее избегать пристального внимания регулирующих органов?"
+"Create a holographic launch pad and leap to your foe. The pad remains behind for a short duration, granting increased movement speed to allies who touch it.","Создайте голографическую стартовую площадку и совершите прыжок в сторону врага. Площадка остаётся на месте некоторое время, давая союзникам, которые её коснутся, повышенную скорость передвижения."
+<c=@abilitytype>Spectral.</c> Create a spectral ring that protects allies and inflicts fear on foes. Gain life force when a foe is inflicted by fear from this skill.<br><c=@reminder>This skill can only inflict fear on the same foe once per interval.</c>,"<c=@abilitytype>Призрачный.</c> Создайте призрачное кольцо, которое защищает союзников и вселяет страх во врагов. Получайте жизненную силу, когда с помощью этого умения на врага накладывается эффект страха.<br><c=@reminder>Это умение может вызывать страх у одного и того же противника только один раз за интервал.</c>"
+"+7 Precision
++5 Ferocity","+7 точности
++5 ярости"
+Win %num2% ranked matches during 2v2 Season Three.,Выиграйте %num2% рейтинговых матчей в режиме 2 на 2 в третьем сезоне.
+Defeat %num2% players in ranked matches during 2v2 Season Three.,Одолейте %num2% игроков в рейтинговых матчах во время третьего сезона игры 2 на 2.
+"Obtained by fighting enemies with the Essence of Resilience and picking up their essence, which grants might, health, and swiftness.
+
+Build 30 stacks to gain increased magic find and bonus rewards, and gain a 60%% damage reduction from conditions from enemies with the Essence of Valor for 30 minutes.","Получается в бою с врагами, обладающими сущностью стойкости, и при сборе их сущности, которая даёт мощь, здоровье и быстроту.
+
+Накопите 30 единиц, чтобы получить повышенный шанс выпадения магических предметов и дополнительные награды, а также снижение урона от состояний на 60%% от врагов, обладающих сущностью доблести, в течение 30 минут."
+"Find others to fight back against the dragon threat across Tyria!
+Guild Wars 2: Path of Fire expansion and the Living World episode ""Champions"" are required to launch this content and earn achievements from it.","Найдите союзников и вместе сражайтесь против угрозы драконов по всей Тирии!
+Для запуска этого контента и получения достижений необходимо приобрести дополнение Guild Wars 2: Path of Fire и пройти эпизод «Чемпионы» из цикла «Живая история»."
+"Increase experience gain from kills by 15%%.
+Increase gold gain from kills by 15%%. 
+Increase chance to loot rare items by 15%%. 
+Increase karma gain by 15%%. 
+Increase chance to find rare materials from mining, logging, and harvesting by 15%%.
+Does not stack with other guild banner enhancements.","Увеличивает получаемый опыт за убийства на 15%%.
+Увеличивает количество золота, получаемого за убийства, на 15%%.
+Увеличивает шанс получения редких предметов на 15%%.
+Увеличивает получаемую карму на 15%%.
+Увеличивает шанс найти редкие материалы при добыче руды, древесины и сборе ресурсов на 15%%.
+Не суммируется с другими улучшениями от гильд-флага."
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии. <br>Традиционная песня олмаханцев. <c=@flavor>«Пусть солнце осветит все наши будущие дни, когда эта буря утихнет...»</c>
+"
+"Greetings Explorer, 
+
+We write to you today to express our congratulations! You have successfully charted all of Kessex Hills. When you entered the region, it was but a blank slate, and now you leave it with no stone left unturned. Fantastic! Your persistence is admirable. Through centaurs, krait, bandits, and necrominions, you pressed onward. We urge you to continue your quest.
+
+Gendarran Fields to the northeast offers new challenges. If you are looking for a change of scenery, head due west into the Brisban Wildlands. I'm sure this won't be the last time you hear from us. <br>Congratulations again. 
+
+—Tyrian Explorers Society","Приветствую, Исследователь!
+
+Мы обращаемся к вам сегодня, чтобы выразить наши поздравления! Вы успешно исследовали все Кessex Hills. Когда вы вошли в этот регион, он был чистым листом, а теперь вы покидаете его, не оставив ни одного камня без внимания. Замечательно! Ваша настойчивость достойна восхищения. Преодолев центавров, крайте, бандитов и некромантов, вы продолжали двигаться вперед. Мы призываем вас продолжить ваше путешествие.
+
+Гендарранские поля к северо-востоку предлагают новые испытания. Если вы хотите сменить обстановку, отправляйтесь на запад в Брисбанские пустоши. Уверен, это не последний раз, когда вы услышите от нас. <br>Еще раз поздравляем!
+
+—Тирийское общество исследователей"
+<c=@abilitytype>Meditation.</c> Strike foes around you and remove their boons. Deal more damage to foes that lose a boon.,"<c=@abilitytype>Медитация.</c> Нанесите удар по врагам вокруг и снимите с них благословения. Наносите больше урона врагам, потерявшим благословение."
+"Gain access to <c=@abilitytype>Stances</c>. Survival in the desert has enhanced your connection to your pet, granting you the ability to meld with them by entering beastmode.<br><c=@reminder>Traits that affect your pet may affect you differently while in beastmode.</c>","Получите доступ к <c=@abilitytype>стойкам</c>. Выживание в пустыне усилило вашу связь с питомцем, даровав вам возможность сливаться с ним, переходя в режим зверя.<br><c=@reminder>Черты, влияющие на вашего питомца, могут по-разному воздействовать на вас во время пребывания в режиме зверя.</c>"
+"Requires Guild Wars 2: Path of Fire.
+Mounts can only be used in designated areas of the world.","Требуется дополнение Guild Wars 2: Path of Fire.
+Верховые ездовые животные могут использоваться только в специально отведённых областях мира."
+"Gain stability when disabling an enemy. Deal increased strike damage to disabled, exposed, or defiant foes.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Получайте эффект «Устойчивость» при обездвиживании противника. Наносите увеличенный урон от атак целям, находящимся в состоянии обездвиживания, без защиты или в состоянии вызова.<br><c=@reminder>Обездвиживание включает оглушение, дезориентацию, отбрасывание, подтягивание, сбивание с ног, погружение, поднятие в воздух, насмешку и страх.</c>"
+"Build up elemental energy when you strike foes. Energy is consumed to imbue the <c=@abilitytype>jade sphere</c> with different elements, creating combo fields and granting boons to allies in the area. <br>Gain access to <c=@abilitytype>Augments</c>.","Накапливайте элементальную энергию при нанесении ударов по врагам. Энергия расходуется для наделения <c=@abilitytype>изумрудной сферы</c> различными элементами, создавая комбинационные поля и даруя благословения союзникам в области действия. <br>Получите доступ к <c=@abilitytype>улучшениям</c>."
+"Explore the Maguuma Jungle and take on the Elder Dragon Mordremoth in Guild Wars 2: Heart of Thorns!
+Unlock the Mastery system, gliders, the revenant class, nine elite specializations, and more!","Исследуйте джунгли Магуума и сразитесь со Старшим драконом Мордремотом в дополнении Guild Wars 2: Сердце терний!
+Откройте систему мастерств, планеры, класс ревенант, девять элитных специализаций и многое другое!"
+"Cast Lightning Rod when you disable a foe.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.","Примените умение «Громоотвод», когда вы обездвиживаете противника. <br><c=@reminder>Обездвиживание включает в себя оглушение, дезориентацию, отбрасывание, притягивание, сбивание с ног, погружение, подъем, отталкивание, насмешку и страх."
+"Double-click to transform into a truffle-hungry porcine hero.
+<c=@flavor>""Oink!""<br>—Truffle Pig Motto</c>","Дважды щелкните, чтобы превратиться в свиного героя, одержимого трюфелями.
+<c=@flavor>«Хрю!»<br> — девиз Трюфельной Свиньи.</c>"
+((434742)),((434742))
+You take reduced strike damage for a duration of time after entering or exiting earth attunement.<br><c=@reminder>Remaining effect duration is lost when exiting.</c>,Вы получаете уменьшенный урон от атак в течение определенного времени после перехода в состояние «Слияние с землей» или выхода из него.<br><c=@reminder>При выходе из состояния оставшаяся длительность эффекта пропадает.</c>
+Breinda Morkoy,Брейнде Моркой
+"+32 Vitality
++18 Condition Damage
++18 Healing Power","+32 к жизненной силе
+Урон по состоянию +18
++18 к силе исцеления"
+"+32 Condition Damage
++18 Toughness
++18 Vitality","+32 урона от состояний
++18 к силе
++18 к жизненной силе"
+The action's all at Southforge. Move it!,Вся активная жизнь кипит в Южном Ковочном районе. Отправляйся туда!
+"Destroy all your clones and create a rift in the space-time continuum. When it expires, you will revert back to your original point with your previous health, endurance, and skill recharges. Duration increases with each illusion shattered.<br><c=@reminder>This skill's recharge cannot be reset by other mesmer skills.</c>","Уничтожьте все свои клоны и создайте разлом в пространственно-временном континууме. По истечении времени действия вы вернётесь к своей исходной точке, сохранив прежний уровень здоровья, выносливости и восстановленные навыки. Продолжительность увеличивается с каждым уничтоженным иллюзорным двойником.<br><c=@reminder>Время перезарядки этого навыка нельзя сократить другими умениями месмера.</c>"
+"Because of your recent selfless efforts in helping to rid the cave of the Flame intruders and their equipment, I can now say with confidence that the area is Flame proof. Or, at least, Flame resistant. 
+
+I will see to it that the brass is informed of your heroic actions. 
+
+—Latera Painstorm","Благодаря вашим недавним самоотверженным усилиям по изгнанию огненных захватчиков и уничтожению их снаряжения, я могу с уверенностью сказать, что эта область теперь защищена от огня. Или, по крайней мере, обладает повышенной устойчивостью к нему.
+
+Я позабочусь о том, чтобы начальство узнало о твоих героических поступках.
+
+— Латера Пейнсторм"
+((1014723)),((1014723))
+((1012763)),((1012763))
+"-10%% Incoming Damage
++60 Power
++50 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++60 силы
++50 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% опыта за прохождение событий"
+Centaurs inbound! Man your positions. They're going to try and take back the camps.,Кентавры приближаются! Занимайте свои позиции. Они попытаются отбить лагеря.
+"Hold steady, Seraph. They can't keep this up forever!","Держись, Серафима. Они не смогут так долго продолжать!"
+"Southforge is down! Hold Northpasture, or the camps will be lost.","Южная кузница пала! Удержите Нортпастур, иначе лагеря будут потеряны."
+Centaurs incoming from Southforge! Watch your flanks!,"Внимание, кентавры приближаются с Южной Кузницы! Остерегайтесь флангов!"
+Hold the lines! We took these camps fair and square!,Держите позиции! Мы захватили эти лагеря честным путем!
+Sound the retreat! Fall back and regroup at Bridgewatch. The centaurs have won.,Отступаем! Перегруппируемся у Бриджуоча. Кентавры победили.
+Modniir Warleader,Военачальник Моднир
+"+5 Toughness
++2 Precision","+5 к живучести
++2 точности"
+"You are resting in the homestead. If you rest for 4 hours, you will become Well Rested and earn bonus experience. The amount of bonus experience depends on your Homesteading Mastery level.
+
+If you are already Well Rested, any elapsed time will be returned to you when you leave the homestead unless you log out.","Вы отдыхаете в своём жилище. Если отдохнуть здесь 4 часа, вы почувствуете себя бодрым и получите дополнительный опыт. Количество бонусного опыта зависит от вашего уровня владения навыком «Домоводство».
+
+Если у вас уже есть эффект «Отдохнувший», то при выходе из дома вам будет возвращено прошедшее время, если только вы не выйдите из учетной записи."
+((931918)),((931918))
+"You are resting in the Wizard's Tower. If you rest for 4 hours, you will become Well Rested and earn bonus experience.
+
+If you are already Well Rested, any elapsed time will be returned to you when you leave the tower unless you log out.","Вы отдыхаете в башне мага. Если отдохнуть здесь 4 часа, вы почувствуете себя бодрым и получите дополнительный опыт.
+
+Если у вас уже есть эффект «Отдохнувший», то покинув башню (но не выйдя из игры), вы получите обратно потраченное время."
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+"+15%% Magic Find
++25%% Increased Movement Speed
+-5%% Incoming Condition Damage","+15%% Шанс выпадения магических предметов
++25%% Увеличение скорости передвижения
+-5%% Урон от входящих эффектов"
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт. </c> Совершите рывок к выбранной цели, сбрасывая по пути бомбы, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы перемещаетесь, тем больше бомб сбрасывается. <br>
+В течение короткого времени после применения этого умения вы продолжаете сбрасывать дополнительные бомбы в текущей области. 
+"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+"You've got a spring in your step and a tune in your head.
+Combat will remove your groove.","У тебя лёгкая походка и весёлая мелодия в голове.
+Бой прервёт вашу ритмичную атаку."
+"66%% Chance to Steal Life on Critical Hit
++50 Power
++40 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% Шанс украсть жизнь при критическом ударе  
++50 Мощи  
++40 Точности  
++10%% Кармы  
++5%% Всего опыта получено  
++20%% Магического поиска  
++20%% Золотого поиска  
++10%% Получаемых WXP"
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"+10%% Outgoing Healing
++60 Healing Power
++50 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исходящее лечение
++60 Сила лечения
++50 Концентрация
++10%% Карма
++5%% Ко всему получаемому опыту
++20%% Шанс найти магические предметы
++20%% Шанс найти золото
++10%% Получаемый опыт WXP"
+"Enlightenment from spending time at the training grounds.
++ 20%% Experience Gain (All Sources)
++ 10%% Magic Find","Просвещение, полученное во время тренировок на полигоне.
++20%% к получаемому опыту (из всех источников).
++10%% к шансу найти магические предметы."
+"+15%% Experience in the Open World
++6%% Reward Track Gain in PvP and WvW","+15%% опыта в открытом мире
++6%% прогресса в системе наград в PvP и RvR"
+"+20%% Experience in the Open World
++8%% Reward Track Gain in PvP and WvW","+20%% опыта в открытом мире
++8%% прогресса в системе наград в PvP и RvR"
+((1014246)),((1014246))
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы
+"
+((932989)),((932989))
+"In Dragon's End, gain 10 seconds of might, fury, and swiftness when entering and exiting combat. 5%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи, ярости и быстроты. Увеличивается на 5%% здоровье, опыт за убийства и исходящий урон.
+
+Каждый стак этого эффекта дает доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"You are resting in the Arborstone Inn. If you rest for 4 hours, you will become Well Rested and earn bonus experience. The amount of bonus experience depends on your Arborstone mastery level.
+
+If you are already Well Rested, any elapsed time will be returned to you when you leave the inn unless you log out.","Вы отдыхаете в таверне «Арборстоун». Если вы отдохнёте здесь 4 часа, вы почувствуете себя бодрым и получите дополнительный опыт. Количество дополнительного опыта зависит от вашего уровня владения навыками в Арборстоуне.
+
+Если у вас уже есть эффект «Отдохнувший», то при выходе из таверны вам будет возвращено время, прошедшее с момента его получения, если только вы не выйдите из игры."
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии. <br>Традиционная песня олмаханцев. <c=@flavor>«Пусть солнце освещает все наши будущие дни, когда эта буря утихнет...»</c>
+"
+((473701)),((473701))
+"Disabling a foe inflicts torment on them.<br><c=@reminder>Disables include stun, daze, knockback, pull, knockdown, sink, float, launch, taunt, and fear.</c>","Оглушение противника накладывает на него мучение.<br><c=@reminder>К оглушениям относятся: стан, ошеломление, отбрасывание, притягивание, сбивание с ног, погружение, подъем в воздух, выброс, насмешка и страх.</c>"
+Bleeds • Poisons • Stuns • Heals Self,Кровотечения • Отравления • Оглушения • Лечит себя
+((789471)),((789471))
+((789920)),((789920))
+Elise,Элиз
+Giant Grub[s],гигантская личинк[а|и|ок]
+%str1%(%str2%),%str1%(%str2%)
+((306163)),((306163))
+((325610)),((325610))
+((718104)),((718104))
+((837198)),((837198))
+"Obtained by fighting enemies with the Essence of Resilience and picking up their essence, which grants might, health, and swiftness.
+
+Build 30 stacks to gain increased magic find and 50%% damage reduction from conditions from enemies with the Essence of Valor for 30 minutes.","Получается в бою с врагами, обладающими «Сущностью стойкости», и при подборе их сущности, которая даёт мощь, здоровье и быстроту.
+
+Накопите 30 стаков, чтобы получить повышенный шанс выпадения магических предметов и 50%% снижение урона от состояний, наносимых врагами с «Сущностью доблести», в течение 30 минут."
+"Obtained by fighting enemies with the Essence of Vigilance and picking up their essence, which grants fury, endurance, and swiftness.
+
+Build 30 stacks to gain a 33%% chance to steal life on critical hits to enemies with Essence of Resilience for 30 minutes.","Получается в бою с врагами, обладающими «Сущностью бдительности», и при подборе их сущности, которая даёт ярость, выносливость и быстроту.
+
+Накопите 30 единиц, чтобы получить 33%%% шанс красть жизнь при критических ударах по врагам с «Сущностью стойкости» в течение 30 минут."
+"In Dragon's End, gain 10 seconds of might and fury when entering and exiting combat. 4%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи и ярости, а также 4%% увеличение к здоровью, опыту за убийства и исходящему урону.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"Gained by defeating enemies near the Blood Hill Camps.
+Your skyscale egg will be sufficiently infused at 100 stacks.","Получено за победу над врагами возле лагерей у Кровавого Холма.
+Ваш скэйскальный яйцо будет достаточно насыщено энергией после накопления 100 зарядов."
+"+10%% Experience in the Open World
++4%% Reward Track Gain in PvP and WvW","+10%% опыта в открытом мире
++4%% прогресса в системе наград в PvP и RvR"
+((465378)),((465378))
+((527283)),((527283))
+((397527)),((397527))
+"+7 Healing
++5 Vitality","+7 исцеления
++5 жизненной силы"
+"—Successful hits against other brawlers.
+
+—A score of 25 will grant you champion status.","Успешные попадания по другим бойцам.
+
+—Набрав 25 очков, вы получите статус чемпиона."
+((743497)),((743497))
+"While in Bjora Marches:
+Earn extra Essence of Vigilance on qualifying kills.
+No more than once every 60 seconds, applies chill to your target for the first 5 seconds of combat when you first engage.
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""We sacrifice so much—safety from the claws of death, knowledge of the ages, a steadfast reign—to propel ourselves forward. But if we move too fast, do we risk the inability to stop?""</c>","Находясь в Бьормарсхе:
+Получайте дополнительную Эссенцию бдительности за выполнение определенных условий при убийстве врагов.
+Не чаще одного раза каждые 60 секунд наносит эффект ""Заморозка"" цели в течение первых 5 секунд боя после первого столкновения.
+
+<c=@Reminder>Получается за прохождение испытаний Равен-санктума.</c>
+<c=@Flavor>«Мы жертвуем столь многим — безопасностью от когтей смерти, знаниями веков и стабильным правлением — чтобы двигаться вперед. Но если мы будем двигаться слишком быстро, не рискуем ли мы потерять способность остановиться?»</c>"
+"66%% Chance to Steal Life on Critical Hit
++20 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс на кражу здоровья при критическом ударе
++20 ко всем характеристикам
++10%% кармы
++5%% к получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемым очкам WXP"
+"In Dragon's End, gain 10 seconds of might when entering and exiting combat. 1%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи. 1%% увеличение к здоровью, опыту за убийство и наносимому урону.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"In Dragon's End, gain 10 seconds of might and fury when entering and exiting combat. 3%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи и ярости. Также увеличивается здоровье на 3%%, опыт за убийства и исходящий урон.
+
+Каждый стак этого эффекта позволит открыть дополнительный сундук в конце мета-события «Конец Дракона»."
+"+5%% Experience in the Open World
++2%% Reward Track Gain in PvP and WvW","+5%% опыта в открытом мире
++2%% прогресса в системе наград в PvP и RvR"
+((1009058)),((1009058))
+((1088522)),((1088522))
+((1087320)),((1087320))
+((1087618)),((1087618))
+((1089316)),((1089316))
+"Obtained by fighting enemies with the Essence of Resilience and picking up their essence, which grants might, health, and swiftness.
+
+Build 30 stacks to gain increased magic find and bonus rewards, and a 60%% damage reduction from conditions from enemies with the Essence of Valor for 30 minutes.","Получается в бою с врагами, обладающими сущностью стойкости, и при подборе их сущности, которая даёт мощь, здоровье и быстроту.
+
+Накопите 30 стаков, чтобы получить повышенный шанс выпадения магических предметов и дополнительные награды, а также снижение урона от состояний на 60%% от врагов с сущностью доблести на 30 минут."
+"In Dragon's End, gain 10 seconds of might, fury, swiftness, regeneration, and protection when entering and exiting combat. 20%% increase to health and outgoing damage. 10%% increase to kill experience.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи, ярости, быстроты, регенерации и защиты. Увеличение здоровья и исходящего урона на 20%%. Увеличение опыта за убийство на 10%%.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"Stats only apply in WvW:
+-10%% Incoming Damage
++40 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Статы действуют только в PvP:
+-10%% входящего урона
++40 ко всем характеристикам
++10%% к карме
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому количеству очков опыта мира"
+((305056)),((305056))
+"Is that you, Forgal? Well met, old man! Are you still fighting for the Vigil?","Это ты, Форгал? Рад встрече, старик! Ты всё ещё сражаешься за Стражу?"
+"Warmaster Forgal Kernsson: You may win the battle, dragon, but you will never defeat our spirit!","Военачальник Форгал Кернссон: Ты можешь выиграть битву, дракон, но ты никогда не сломишь наш дух!"
+"Warmaster Forgal Kernsson: I am Forgal, son of Kern. My father was the last Dolyak Shaman! I am a Warmaster of the Vigil! You will never make me kneel!","Военачальник Форгал Кернссон: Я — Форгал, сын Керна. Мой отец был последним шаманом Дольяков! Я — военачальник Стражи! Вы никогда не заставите меня преклонить колено!"
+"-10%% Incoming Damage
++35 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++35 ко всем характеристикам
++10%% кармы
++5%% к получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% к получаемому опыту мира"
+Read Almorra's letter.,Прочитайте письмо Альморры.
+Report to General Almorra at Fort Marriner.,Доложите генералу Алморре в форте Марринер.
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт.</c> Совершите рывок к указанной цели, попутно сбрасывая бомбы вдоль своего пути, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы пройдёте, тем больше бомб будет сброшено. <br>
+В течение короткого времени после использования этого умения вы продолжаете сбрасывать дополнительные бомбы в текущей области. 
+"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы
+"
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии. <br>Традиционная песня олмакханцев. <c=@flavor>«Пусть солнце осветит все наши будущие дни, когда эта буря утихнет...»</c>
+"
+All who injure us will pay!,"Все, кто причинит нам вред, поплатятся!"
+Effort Up Minor 01,Небольшой бонус к усилиям I
+Effort Up Minor 02,Небольшой бонус к приложенным усилиям 02
+Effort Up Minor 03,Небольшой предмет: Увеличение эффективности 03
+Effort Up Minor 04,Небольшой предмет: Увеличение эффективности 04
+"66%% Chance to Steal Life on Critical Hit
++30 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++30 силы
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу получения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+I've known battle since the earliest moments of my dream. Would you care to test yourself against me?,Я познала битву ещё в самом начале своего существования. Не желаете ли испытать себя в поединке со мной?
+I'll gladly fight you.,С удовольствием сражусь с тобой.
+I've no time for play fighting.,У меня нет времени на детские игры.
+I hope you prove more of a challenge than the others.,"Надеюсь, ты окажешься достойным противником."
+"Double-click to gain a rock.
+<c=@flavor>""You throw them. It's fun.""<br>—Flannum</c>","Дважды щелкните, чтобы получить камень.
+<c=@flavor>«Вы их бросаете. Это весело».<br> — Фланнум</c>"
+We're collecting spikeroot fruit. Care to help?,Мы собираем плоды шипокорня. Не хотите помочь?
+((837930)),((837930))
+[lbracket][lbracket]909545[rbracket][rbracket],[lbracket][lbracket]909545[rbracket][rbracket]
+[lbracket][lbracket]910007[rbracket][rbracket],[lbracket][lbracket]910007[rbracket][rbracket]
+"66%% Chance to Steal Life on Critical Hit
++20 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++20 силы
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому количеству очков опыта"
+"While in Bjora Marches:
+Earn extra Essence of Valor on qualifying kills.
+No more than once every 60 seconds, blinds your target for the first 5 seconds of combat when you first engage.
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""We seek to destroy monsters with sharp claws and icy breath, but do we protect ourselves from the beasts shaped like us, who prey on the young and vulnerable, who seek to rule us?""</c>","Находясь в Бьёра-Маршес:
+Получайте дополнительную Эссенцию Доблести за выполнение определенных условий убийства.
+Не чаще одного раза каждые 60 секунд ослепляйте цель в течение первых 5 секунд боя при первом столкновении.
+
+<c=@Reminder>Получается за прохождение испытаний Равен-Санктума.</c>
+<c=@Flavor>«Мы стремимся уничтожать монстров с острыми когтями и ледяным дыханием, но защищаем ли мы себя от зверей, похожих на нас, которые охотятся на молодых и беззащитных, стремясь править нами?»</c>"
+((951681)),((951681))
+"In Dragon's End, gain 10 seconds of might, fury, swiftness, and regeneration when entering and exiting combat. 7%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи, ярости, быстроты и регенерации. Также увеличивается на 7%% здоровье, опыт за убийства и исходящий урон.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"Obtained by fighting enemies with the Essence of Valor and picking up their essence, which grants quickness and swiftness.
+
+Build 30 stacks to gain a 10%% damage reduction from enemies with the Essence of Vigilance for 30 minutes.","Получается в бою с врагами, обладающими Эссенцией Доблести, и при сборе их эссенции, которая даёт эффект «Проворство» и «Быстрота».
+
+Накопите 30 стаков, чтобы получить уменьшение входящего урона от противников на 10%% в течение 30 минут благодаря эффекту «Сущность бдительности»."
+"Obtained by fighting enemies with the Essence of Valor and picking up their essence, which grants quickness and swiftness.
+
+Build 30 stacks to gain increased magic find and a 20%% damage reduction from enemies with the Essence of Vigilance for 30 minutes.","Получается при сражении с врагами, наделенными Сущностью Доблести, и подбирании их сущности, которая дает эффект «Проворство» и «Быстрота».
+
+Накопите 30 стаков, чтобы получить повышенный шанс выпадения магических предметов и снижение получаемого урона от врагов на 20%% в течение 30 минут благодаря эффекту «Сущность бдительности»."
+"66%% Chance to Steal Life on Critical Hit
++50 Power
++40 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++50 силы
++40 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу получения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+"While in Bjora Marches:
+Earn extra Essence of Vigilance on qualifying kills.
+No more than once every 60 seconds, applies alacrity to you when you land a critical hit.
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""When wisdom is favored in all things—a healing hand, a text of old, a beloved queen—we lose the sharpened sword of the truly bold.""</c>","Находясь в Бьорнских маршах:
+Получайте дополнительную Эссенцию бдительности за убийства определенных целей.
+Не чаще одного раза каждые 60 секунд, при критическом ударе вы получаете эффект «Рвение».
+
+<c=@Reminder>Получается за прохождение испытаний в Равен-санктуме.</c>
+<c=@Flavor>«Когда мудрость ценится превыше всего — будь то целитель, древний текст или любимая королева — мы теряем острую сталь истинно смелых».</c>"
+"While in Bjora Marches:
+Earn extra Essence of Resilience on qualifying kills.
+No more than once every 60 seconds, applies vulnerability to your target when you land a critical hit.
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""We try so hard to do the right thing. We heal, we protect our people, we preserve stability. But we cannot control how the winds of fate may shift, and a tight grip can sometimes hurt more than it helps.""</c>","Находясь в Бьорнских маршах:
+Получайте дополнительную Эссенцию Стойкости за выполнение определенных условий убийства.
+Не чаще одного раза каждые 60 секунд наносит уязвимость цели при критическом ударе.
+
+<c=@Reminder>Получается за прохождение испытаний Равен Санктум.</c>
+<c=@Flavor>«Мы так стараемся поступать правильно. Мы исцеляем, мы защищаем наш народ, мы сохраняем стабильность. Но мы не можем контролировать, как изменятся ветры судьбы, и иногда слишком сильная хватка может причинить больше вреда, чем пользы».</c>"
+"-10%% Incoming Damage
++80 Power
++60 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++80 силы
++60 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс получить больше золота
++10%% опыта"
+"While in Bjora Marches:
+Earn extra Essence of Resilience on qualifying kills.
+Benefit from regeneration when your health falls below 33%% (60-second cooldown).
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""When the fear of beastly claws and a child's pain is made sharp by the knowledge of elders, we make no mistakes. But do we grow?""</c>","Находясь в Бьёра-Марчес:
+Получайте дополнительную Эссенцию стойкости за убийства подходящих целей.
+Восстанавливайте здоровье при падении ниже 33%% (перезарядка — 60 секунд).
+
+<c=@Reminder>Получается за прохождение испытаний Святилища Ворона.</c>
+<c=@Flavor>«Когда страх перед звериными когтями и боль ребенка обостряются знанием старших, мы не совершаем ошибок. Но растем ли мы?»</c>"
+"In Dragon's End, gain 10 seconds of might when entering and exiting combat. 2%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи. Также увеличивается здоровье, опыт за убийства и наносимый урон на 2%%.
+
+Каждый стак этого эффекта даёт возможность получить дополнительный сундук в конце мета-события «Конец Дракона»."
+"In Dragon's End, gain 10 seconds of might, fury, and swiftness when entering and exiting combat. 6%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи, ярости и быстроты. Также увеличивается на 6%% здоровье, опыт за убийства и исходящий урон.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"Not yet. Still, the city's taking precautions.","Пока ещё нет, но город всё же принимает меры предосторожности."
+"Those sound promising. I could go, ma'am, and speak on behalf of the order.","Звучит многообещающе. Я могу пойти и выступить от имени ордена, госпожа."
+"-15%% Incoming Condition Duration
++45 to All Attributes
++1%% All Experience Gained","-15%% Длительность активных эффектов снижена
++45 ко всем характеристикам
++1%% Получаемый опыт увеличен"
+[lbracket][lbracket]910151[rbracket][rbracket],[lbracket][lbracket]910151[rbracket][rbracket]
+"-10%% Incoming Damage
++80 Healing Power
++60 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++80 сила исцеления
++60 концентрация
++10%% карма
++5%% ко всему получаемому опыту
++20%% шанс найти магический предмет
++20%% шанс найти золото
++10%% получаемый опыт"
+"-10%% Incoming Damage
++80 Condition Damage
++60 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++80 урона от состояний
++60 мастерство
++10%% карма
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс получить больше золота
++10%% получаемый опыт за события"
+"+10%% Outgoing Healing
++80 Healing Power
++60 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исходящее лечение
++80 Сила исцеления
++60 Концентрация
++10%% Карма
++5%% Ко всему получаемому опыту
++20%% Шанс найти магические предметы
++20%% Шанс найти золото
++10%% Получаемый опыт WXP"
+"In Dragon's End, gain 10 seconds of might, fury, swiftness, and regeneration when entering and exiting combat. 8%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Драконий Предел» при входе и выходе из боя получайте 10 секунд мощи, ярости, быстроты и регенерации. Также увеличивается на 8%% максимальное количество здоровья, получаемый опыт за убийства и исходящий урон.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Драконий Предел»."
+"Call down an ice storm on the targeted area. The number of final ice shards are increased for each stack of Water Arrow.
+<c=@reminder>Damage is reduced per target each time foes are struck by this skill.</c>","Обрушьте на выбранную область ледяной шторм. Количество финальных ледяных осколков увеличивается с каждым применением умения «Водная стрела».
+<c=@reminder>Урон по каждой цели уменьшается при каждом попадании этим умением.</c>"
+((537567)),((537567))
+[lbracket][lbracket]909690[rbracket][rbracket],[lbracket][lbracket]909690[rbracket][rbracket]
+"Gain Health Every Second
++60 Power
++50 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Восстанавливайте здоровье каждую секунду.
++60 силы
++50 точности
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% опыта мира"
+"66%% Chance to Steal Life on Critical Hit
++80 Power
++60 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++80 силы
++60 ярости
++10 %% кармы
++5%% ко всему получаемому опыту
++20%% к шансу нахождения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+"-10%% Incoming Damage
++50 Power
++40 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон по цели
++50 Силы
++40 Точности
++10%% Кармы
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому опыту мира"
+"-10%% Incoming Damage
++50 Condition Damage
++40 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон от входящих атак
++50 Урона по состояниям
++40 Экспертиза
++10%% Карма
++5%% Ко всему получаемому опыту
++20%% Шанс найти магический предмет
++20%% Шанс получить больше золота
++10%% Получаемый опыт WXP"
+"66%% Chance to Steal Life on Critical Hit
++80 Condition Damage
++60 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++80 урона от состояний
++60 мастерства
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу нахождения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+"-10%% Incoming Damage
++20 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++20 сила
++10%% карма
++5%% весь получаемый опыт
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% получаемый опыт"
+"Grants resistance for 5 seconds every 30 seconds while in Bjora Marches.
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""We favor the skill of healers and the wisdom of elders over the uncertainty of the future. But the young take chances, and the young push us forward.""</c>","Предоставляет сопротивление на 5 секунд каждые 30 секунд, пока вы находитесь в Бьорна-Марч.
+
+<c=@Reminder>Получено за прохождение испытаний Равен-Санктума.</c>
+<c=@Flavor>«Мы ценим мастерство целителей и мудрость старших больше, чем неопределенность будущего. Но молодые рискуют, и именно они двигают нас вперед».</c>"
+"-10%% Incoming Damage
++80 Concentration
++28%% Chance to Gain Might on Critical Hit
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон по попаданию
++80 Концентрация
++28%% Шанс получить эффект «Мощь» при критическом ударе
++10%% Карма
++5%% Бонус к получаемому опыту
++20%% Бонус к шансу найти магические предметы
++20%% Бонус к получаемому золоту
++10%% Бонус к получаемому опыту мира"
+"+10%% Outgoing Healing
++30 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10 %% Исходящее лечение
++30 Экспертизы
++10 %% Кармы
++5 %% Получаемого опыта
++20 %% Шанса найти магические предметы
++20 %% Шанса найти золото
++10 %% Получаемого опыта для развития"
+"Gain Health Every Second
++40 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Восстанавливайте здоровье каждую секунду.
++40 ко всем характеристикам.
++10 %% кармы.
++5 %% к получаемому опыту.
++20 %% к шансу найти магические предметы.
++20 %% к шансу найти золото.
++10 %% к получаемому опыту мира."
+"66%% Chance to Steal Life on Critical Hit
++50 Concentration
++40 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++50 концентрации
++40 силы
++10 %% кармы
++5%% ко всему получаемому опыту
++20%% к шансу нахождения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+"-10%% Incoming Damage
++30 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон по цели
++30 силы
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% опыта"
+"-10%% Incoming Damage
++60 Power
++50 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон от входящих атак
++60 Силы
++50 Точности
++10%% Кармы
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому опыту мира"
+"While in Bjora Marches:
+Earn extra Essence of Valor on qualifying kills.
+Applies resolution to you when your health falls below 33%% (no more than once every 60 seconds).
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""We long for the comfort of a healing touch, an ancestral word of wisdom, a leader we know and trust. But comfort is fleeting, and with it comes inertia.""</c>","Находясь в Бьёра-Марч:
+Получайте дополнительную Эссенцию Доблести за выполнение условий на врагах.
+Применяет эффект «Решимость» к вам, когда ваше здоровье падает ниже 33%% (не чаще одного раза каждые 60 секунд).
+
+<c=@Reminder>Получается при прохождении испытаний в Равен Санктум.</c>
+<c=@Flavor>«Мы жаждем утешения исцеляющего прикосновения, древнего слова мудрости, лидера, которого мы знаем и которому доверяем. Но утешение мимолетно, и вместе с ним приходит инертность».</c>"
+"-10%% Incoming Damage
++80 Power
++60 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон по попаданию
++80 Силы
++60 Точности
++10%% Кармы
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому опыту мира"
+"Stats only apply in WvW:
+-10%% Incoming Damage
++35 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Статы действуют только в PvP:
+-10%% входящего урона
++35 ко всем характеристикам
++10%% к карме
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому количеству очков опыта мира"
+"Stats only apply in WvW:
+-10%% Incoming Damage
++60 Power
++50 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Характеристики действуют только в PvP-режиме «Захват территорий»:
+-10%% входящего урона
++60 силы
++50 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому количеству очков опыта мира"
+Throw the potion.,Брось зелье.
+((258161)),((258161))
+[lbracket][lbracket]909844[rbracket][rbracket],[lbracket][lbracket]909844[rbracket][rbracket]
+Shoot from the hip while moving.,Стреляйте с ходу.
+Fire a blast strong enough to knock you and your foe back at the same time.,"Выпустите мощный взрыв, который отбросит вас и вашего противника одновременно."
+((267286)),((267286))
+Flee! Flee for your lives!,Бегите! Спасайте свои жизни!
+Enfeeblement Aura,Аура ослабления
+"Your help gets people killed! I don't need it, and I don't need you.","Твоя помощь только людям вредит! Мне она не нужна, и ты мне тоже."
+"I am. And we've got more imporant things to worry about. We need to find the Inquest, and, more importantly, find their leader.","Я знаю. И у нас есть дела поважнее. Нам нужно найти «Инквизицию» и, что ещё важнее, их лидера."
+"Once, we fought together as one. Myself, Rytlock, Logan. Eir and her wolf. Snaff and his apprentice.","Когда-то мы сражались плечом к плечу. Я, Ритлок и Логан. Эйр со своим волком. Снафф и его ученик."
+We called ourselves Destiny's Edge. We were the best the world had seen. We fought dragon minions from the Sea of Sorrows to the Crystal Desert.,Мы называли себя «Край Судьбы». Мы были лучшими во всём мире. Мы сражались с прислужниками драконов от Моря Скорбей до Кристальной Пустоши.
+And then we failed.,И потом мы потерпели неудачу.
+"We encountered Glint. She was a legendary creature that served Kralkatorrik, the crystal dragon...until she betrayed her master.","Мы встретили Глинт. Она была легендарным существом, служившим Кралькаторрику, кристальному дракону… пока не предала своего господина."
+"Kralkatorrik awoke, and flew south to slay its traitorous lieutenant, leaving devastation in its wake.","Кралькаторрик пробудился и полетел на юг, чтобы уничтожить своего предательского лейтенанта, сея разрушения на своем пути."
+"We stood beside Glint, ready to face an Elder Dragon, but Logan was suddenly called away.","Мы стояли рядом с Глинт, готовые сразиться со Старшим драконом, но Логана внезапно отозвали."
+"We were weakened, but Eir thought we could still stand and fight.","Мы ослабли, но Эйр считала, что мы всё ещё можем держаться и сражаться."
+Eir was...incorrect.,Эйр немного ошиблась.
+We were defeated. Kralkatorrik killed Glint. We lost Snaff as well.,Нас победили. Кралькаторрик убил Глинта. Мы также потеряли Снаффа.
+And Eir blames herself. She lost something more than just a friend that day.,"И Эйр винит себя. В тот день она потеряла нечто большее, чем просто друга."
+"I've tried to bring them back together, without success. I know I'm missing something, but what?","Я пытался их помирить, но безуспешно. Я знаю, что упускаю что-то важное, но что именно?"
+((1055698)),((1055698))
+((267284)),((267284))
+"Obtained by fighting enemies with the Essence of Resilience and picking up their essence, which grants might, health, and swiftness.
+
+Build 30 stacks to gain 33%% damage reduction from conditions from enemies with the Essence of Valor for 30 minutes.","Получается в бою с врагами, обладающими сущностью стойкости, и при подборе их сущности, которая даёт мощь, здоровье и быстроту.
+
+Накопите 30 единиц, чтобы получить уменьшение урона от состояний на 33%% от врагов, обладающих сущностью доблести, на 30 минут."
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт. Совершите рывок к указанной цели, сбрасывая по пути бомбы, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы пройдете, тем больше будет сброшено бомб. </c>
+В течение короткого времени после использования этого навыка вы продолжаете сбрасывать дополнительные бомбы в своей текущей локации. <br> 
+"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"Grants protection for 5 seconds every 30 seconds while in Bjora Marches.
+
+<c=@Reminder>Obtained by completing the Raven Sanctum's trials.</c>
+<c=@Flavor>""When we flee from the things we fear most—the teeth of beasts, the storm of a dragon, a change of power—we risk running backward.""</c>","Предоставляет защиту на 5 секунд каждые 30 секунд, пока вы находитесь в Бьорна-Марч.
+
+<c=@Reminder>Получено за прохождение испытаний Равен-Санктума.</c>
+<c=@Flavor>«Когда мы бежим от того, чего боимся больше всего — клыков зверей, ярости дракона, смены власти — мы рискуем пойти назад».</c>"
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы
+"
+"In Dragon's End, gain 10 seconds of might, fury, swiftness, and regeneration when entering and exiting combat. 9%% increase to health, kill experience, and outgoing damage.
+
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд эффектов: мощь, ярость, быстрота и регенерация. Также увеличивается на 9%% максимальное здоровье, количество получаемого опыта за убийство и исходящий урон.
+
+Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии. <br>Традиционная песня олмакханцев. <c=@flavor>«Пусть солнце освещает все наши будущие дни, когда эта буря утихнет...»</c>
+"
+Ley-Energy Sickness,Лей-энергетическая болезнь
+((745477)),((745477))
+Come to hear tales of my great exploits?,Пришёл послушать рассказы о моих великих подвигах?
+A challenger has arrived to fight the great Fibharr! Gather 'round.,"Появился новый претендент, готовый сразиться с великим Фибхарром! Собирайтесь вокруг."
+Stupendous!,Потрясающе!
+Great glory! We'll celebrate tonight.,Великая слава! Сегодня вечером мы отпразднуем это.
+Outstanding!,Превосходно!
+"Impressive! I must admit, I didn't expect this much talent from the Vigil. Perhaps your order is more formidable than I'd thought.","Впечатляет! Должен признать, я не ожидал увидеть столько талантов в рядах Стражей. Похоже, ваш орден куда могущественнее, чем я думал."
+Shoo! You've already destroyed my beer.,Убирайся! Ты уже всю мою кружку опрокинул.
+It is a good time.,Сейчас подходящее время.
+"No rest for the dedicated scholar, then?","Значит, усердному ученому не до отдыха?"
+"Another great moot. I've missed these, since I joined the Vigil.","Еще одно отличное собрание. Я скучал по ним с тех пор, как присоединился к Стражам."
+I see you've been talking to Tholin. I'd best return to my work.,"Похоже, ты разговаривал с Толином. Мне лучше вернуться к работе."
+Taunting Skritt,Насмешка над скриттом
+Have you seen my drinking buddy? He ran off chasing a skritt and now he's probably lost in the snow.,"Видел ли ты моего приятеля по выпивке? Он побежал за скриттом, и теперь, наверное, заблудился в снегу."
+Brewmaster Burna,"Бурна, мастер пивоварения"
+" I prefer the appellation ""privateer.""", Я предпочитаю название «приватный корсар».
+((170306)),((170306))
+"66%% Chance to Steal Life on Critical Hit
++35 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс на кражу здоровья при критическом ударе
++35 ко всем характеристикам
++10%% кармы
++5%% к получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому опыту мира"
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт. </c> Совершите рывок к указанной цели, сбрасывая по пути бомбы, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы пройдете, тем больше будет сброшено бомб. <br>
+В течение короткого времени после использования этого умения вы продолжаете сбрасывать дополнительные бомбы в текущей области. 
+"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы
+"
+"Obtained by fighting enemies with the Essence of Vigilance and picking up their essence, which grants fury, endurance, and swiftness.
+
+Build 30 stacks to gain increased magic find, bonus rewards, and a 66%% chance to steal life on critical hits to enemies with the Essence of Resilience for 30 minutes.","Получается в бою с врагами, обладающими сущностью Бдительности, и при сборе их сущности, которая даёт ярость, выносливость и быстроту.
+
+Накопите 30 единиц, чтобы получить повышенный шанс выпадения магических предметов, дополнительные награды и 66%%% шанс кражи здоровья при критических ударах по врагам с сущностью Стойкости в течение 30 минут."
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии. <br>Традиционная песня олмаханцев. <c=@flavor>«Пусть солнце освещает все наши грядущие дни, когда эта буря утихнет...»</c>
+"
+Shoot a jet of water at foes that also heals allies within its blast radius.,"Выпускает струю воды во врагов, одновременно исцеляя союзников в радиусе поражения."
+Call down a healing rain for your allies at the target area. Applies regeneration and removes conditions.,Обрушьте целительный дождь на союзников в выбранной области. Применяет регенерацию и снимает негативные эффекты.
+"Throw a blast of life force at foe, dealing more damage the more life force you have.","Обрушьте на врага поток жизненной силы, нанося больше урона по мере накопления этой силы."
+Desch Temperbones,Деш Темпербоунс
+Strike target foe repeatedly.,Наносите удары по цели несколько раз подряд.
+Send out a shield wave that damages foes and applies protection to allies.,"Создайте волну щита, которая наносит урон врагам и дарует защиту союзникам."
+MONSTER ONLY Graveling Unarmed Breeder,"Гравилинг-размножитель (только для монстров), безоружный"
+Kholer Sword,Меч Холера
+"Stab your foe, then quickly retreat backward.","Ударь врага, а затем быстро отступи назад."
+"Leap back in to the fight, crippling your foe.","Совершите прыжок и вернитесь в бой, чтобы ослабить врага."
+Evade and stab your foe in the back twice.,Уклонитесь и дважды ударьте врага в спину.
+Kholer Dagger,Кхолерский кинжал
+Open Sarcophagus,Открыть саркофаг.
+"Randomly strike the surrounding area with lightning.
+<c=@reminder>Damage is reduced per target each time foes are struck by this skill.</c>","Случайным образом обрушивайте молнии на окружающую область.
+<c=@reminder>Урон уменьшается для каждой цели при каждом применении этого умения к врагам.</c>"
+"Gain Health Every Second
++80 Power
++60 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Восстанавливайте здоровье каждую секунду
++80 силы
++60 точности
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% опыта мира"
+"Gain Health Every Second
++50 Concentration
++40 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Восстанавливает здоровье каждую секунду
++50 концентрации
++40 силы
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% опыта мира"
+"Gain Health Every Second
++35 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Восстанавливайте здоровье каждую секунду.
++35 ко всем характеристикам.
++10 %% кармы.
++5 %% к получаемому опыту.
++20 %% к шансу найти магические предметы.
++20 %% к шансу найти золото.
++10 %% к получаемому опыту мира."
+"-20%% Incoming Condition Duration
++80 Condition Damage
++60 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-20%% Длительность входящих эффектов
++80 Урон от состояний
++60 Экспертиза
++10%% Карма
++5%% Получаемый опыт
++20%% Шанс найти магические предметы
++20%% Шанс получить золото
++10%% Получаемый опыт WXP"
+"-10%% Incoming Damage
++20 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++20 ко всем характеристикам
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс получить больше золота
++10%% к получаемому количеству очков опыта"
+"-20%% Incoming Condition Duration
++50 Concentration
++40 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-20%% Длительность входящих эффектов
++50 Концентрация
++40 Сила
++10%% Карма
++5%% Ко всем получаемым очкам опыта
++20%% Шанс найти магические предметы
++20%% Шанс найти золото
++10%% Получаемые очки WXP"
+"66%% Chance to Steal Life on Critical Hit
++60 Power
++50 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++60 силы
++50 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу нахождения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+"+10%% Outgoing Healing
++50 Healing Power
++40 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исходящее лечение
++50 силы лечения
++40 концентрации
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса нахождения магических предметов
++20%% шанса нахождения золота
++10%% получаемого опыта"
+"-10%% Incoming Damage
++50 Power
++40 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++50 силы
++40 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% опыта от заданий"
+"+10%% Outgoing Healing
++40 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10 %% Исходящее лечение
++40 ко всем характеристикам
++10 %% Кармы
++5 %% к получаемому опыту
++20 %% к шансу найти магические предметы
++20 %% к шансу найти золото
++10 %% к получаемому опыту мира"
+"+150 Fishing Power
++20 Vitality
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+150 к силе рыбалки
++20 к жизненной силе
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% опыта мира"
+"Stats only apply in WvW:
+-10%% Incoming Damage
++80 Power
++60 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Характеристики действуют только в PvP:
+-10%% входящего урона
++80 силы
++60 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% получаемого опыта мира"
+"Stats only apply in WvW:
+-10%% Incoming Damage
++50 Power
++40 Ferocity
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Характеристики действуют только в PvP:
+-10%% входящего урона
++50 силы
++40 ярости
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% получаемого опыта мира"
+"33%% Chance to Steal Life
++45 to All Attributes
+-10%% Incoming Direct Damage","33%% шанс кражи здоровья
++45 ко всем характеристикам
+-10%% входящий прямой урон"
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт. Совершите рывок к указанной цели, сбрасывая по пути бомбы, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы пройдете, тем больше бомб будет сброшено. </c>
+В течение короткого времени после использования этого навыка вы продолжаете сбрасывать дополнительные бомбы в своей текущей локации. <br> 
+"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы[|м|]
+"
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии. <br>Традиционная песня олмаханцев. <c=@flavor>«Пусть солнце осветит все наши грядущие дни, когда эта буря утихнет...»</c>
+"
+Citizen,Житель
+Vigil,Страж
+Guard,Страж
+Leader,Лидер
+Guest,Гость
+Obsidian Sanctum Waypoint,Путь к обсидиановому святилищу
+Market,Рынок
+April,апрель
+Engineer,Инженер
+Warden,Страж
+Moran Memorial,Мемориал Морана
+Molten Weapons Facility,Объект по производству оружия из расплавленного металла
+Cathedral of Hidden Depths,Собор Скрытых Глубин
+Purification Waypoint,Путь очищения
+Ring of Fire,Кольцо огня
+Archive of the Resting,Архив покоящихся
+Votive Cathedral,Собор обетов
+Hall of Champions,Зал чемпионов
+Ossuary Crypts,Крипты-костницы
+Preparation Waypoint,Точка подготовки
+Overseer Waypoint,Наблюдательный пункт
+Golemetric Diagnostics Waypoint,Точка перехода: Големетрическая диагностика
+Arcanic Reactor Waypoint,Путь к арканному реактору
+Central Data Repository Waypoint,Путь к центральному хранилищу данных
+Eastern Chambers,Восточные палаты
+Foefire's Heart,Сердце Фофира
+Lair of the Patriarch,Логово Патриарха
+Hall of Murals,Зал фресок
+Hall of Stairs,Зал лестниц
+Flooded Temple,Затопленный храм
+Graveling Tunnels,Гравийные туннели
+Western Chambers,Западные палаты
+Minister's Cabinet Room,Кабинет министра
+Grand Salon,Гранд-салон
+Drawing Room,Гостиная
+Reading Room,Читальный зал
+Main Workshop,Главная мастерская
+Wine Cellar,Винный погреб
+Kitchen,Кухня
+Larder,Кладовая
+Main Dining Room,Главный обеденный зал
+Altar of Secrets,Алтарь тайн
+Formal Garden,Формальный сад
+The Nursery,Детская
+Faolain's Lair,Логово Фаолайн
+Lake of Fear,Озеро Страха
+Hall of Heart's Remorse,Зал Сердечной Скорби
+Depth of Despair,Глубина Отчаяния
+Chamber of Envy,Палата Зависти
+Mechanisms of Production,Механизмы производства
+The Irongorge,Иронгорж
+Citadel of Vostol,Цитадель Востол
+Utility Passage,Утилитарный проход
+Mechanism Depot,Механический склад
+Citizen's Co-operative,Гражданский кооператив
+Zalten Mines,Шахты Зальтена
+Redflicker Fissure,Разлом Красного Мерцания
+Inquest Base KD-4,База Инквизиции KD-4
+Volcanium Pit,Волканиевая яма
+Forgeman Chamber,Кузнечное святилище
+Lostwreck Passage,Проход Затонувших Врат
+Bynebrachen,Бинбрахен
+Cathedral of Eternal Radiance,Собор Вечного Сияния
+Templum Praesidium,Храм-крепость
+Neotheon Chamber,Неотеонская палата
+Ashen Chamber,Пепельная палата
+Eastern Transept,Восточный трансепт
+Molten Foundry,Раскалённая кузница
+Mausoleum of the Khan-Ur,Мавзолей хана-ура
+Daemon's Undercroft,Подземелье Демона
+Viscous Caves,Вязкие пещеры
+Western Transept,Западный трансепт
+Sanguine Vault,Багряный склеп
+Gaheron's Triumph,Триумф Гахерона
+Shrine of Sacrifice,Святилище жертв
+Gallery of Peace,Галерея мира
+Hall of Balance,Зал равновесия
+Palace of Gathering,Дворец собраний
+Court of Measures,Судебная палата
+Port Hold,Порт-Холд
+Gallery of Passage,Галерея Перехода
+Kedge Hold,Кеддж-Холд
+Midships,В средней части корабля
+Starboard Hold,Правый борт
+Geoffrey's Tubes,Трубы Джеффри
+Winch Hold,Удерживать лебедку
+Blessed Path,Благословенный путь
+Cathedral of Glorious Victory,Собор Сла́вной Побе́ды
+Shark's Teeth Archipelago,Архипелаг Акулий Пасти
+The Underbelly,Подбрюшье
+"Azabe Qabar, the Royal Tombs","Азабе Кабар, Королевские гробницы"
+Orbweaver Gallery,Галерея ткачей сфер
+Weta Alcove,Вэта-Алькоув
+Spinneret Creche,Гнездо ткачихи
+Peatrot Gallery,Галерея Питрот
+Pedipalp Roots,Корни педипальп
+Verdure Gallery,"Галерея ""Зелёный мир"""
+Boleshian Pit,Болешианская яма
+Hall of Memories,Зал воспоминаний
+Reception Court,Приёмный двор
+Vista Lawn,Виста-Лоун
+Western Tunnel,Западный туннель
+Hidden Workshop,Скрытая мастерская
+Jerrifer's Slough,Трясина Джеррифера
+Wildcreek Run,Уайлдкрик-Ран
+Bravost Escarpment,Бравост-Эскарпмент
+Durios Gulch,Ущелье Дуриоса
+Mendon's Gap,Ущелье Мендона
+Anzalias Pass,Перевал Анзалиас
+Applied Development Lab (Home),Прикладная лаборатория разработки (Главный офис)
+Advanced Metamystics Lab,Передовая лаборатория метамагических исследований
+Zraith's Beacon,Маяк Зрейта
+Merchant,Торговец
+Godslore,Божественная история
+Border Waypoint,Пограничный пункт
+Old Soldier,Старый солдат
+Godslore Quarry,Каменоломня Богов
+Raid—Bastion of the Penitent,Рейд — Бастион Искупленных
+Local,Местный
+Kid,Ребёнок
+Apple Vendor,Продавец яблок
+Bank Teller,Кассир
+BRGL-5000,БРГЛ-5000
+Lionguard Guide,Наставник Львиной Стражи
+Noble,Благородный
+Black Lion Trader,Черный торговец львом
+Child,Ребёнок
+Villager,Житель деревни
+Zeta Vault,Зета-хранилище
+Nu Vault,Ну-хранилище
+Hero,Герой
+Brokentooth Maw Waypoint,Путь к Сломанному Зубу
+Hall of Monuments,Зал Монументов
+Ghyrtratus Fiendmauler,Гиртратус Кровожадный
+Workshop,Мастерская
+Eona,Эона
+Bee Swarm,Рой пчёл
+Mini,Мини
+Bear's Jaws Shrine,"Святилище ""Медвежьи Челюсти"""
+Leopard's Snarl Shrine,Святилище Леопардовой Рыси
+Risen Corpse,Восставший труп
+Conservatory,Консерватория
+Illusionary Duelist,Иллюзорный дуэлянт
+Illusionary Swordsman,Иллюзорный мечник
+Harbinger,Предвестник
+Versoconjouring Array,Матрица версоконжуринга
+Palawa's Benevolence,Благодеяние Палавы
+Western Front,Западный фронт
+Kodonur Crossing,Переправа Кодонур
+Scholar Glenna,Учёный Гленна
+Acquisition Portal,Портал приобретений
+Ewyn's Retreat,Убежище Эвин
+Sanctuary Prow,Святилище Прова
+"Salvage of the ""Lady Livia""",Обломки «Леди Ливии»
+Durmand Priory Camp,Лагерь Дурмандского Приората
+Rockfall Chamber,Каменная пещера
+Catacomb Entrance,Вход в катакомбы
+The Lovers' Crypt,Крипта Любовников
+Dredge Square,Площадь Дредж
+Geothermal Access,Геотермальный доступ
+Old Summit Quarry,Старый карьер Саммита
+Security Checkpoint,Контрольно-пропускной пункт
+Stonemist Castle,Замок Стоунмист
+Quentin Lake,Озеро Квентин
+Langor Gulch,Унылая Лощина
+Umberglade Woods,Умберглейдские леса
+Danelon Passage,Проход Данелона
+Orgath Uplands,Высокогорье Оргат
+Darkrait Inlet,Вход Даркрайт
+Ogrewatch Cut,Огры и стражи
+Veloka Slope,Склон Велоки
+Speldan Clearcut,Спелдан Клиркат
+Pangloss Rise,Восхождение Панглосса
+Molevekian Delve,Молевекийский комплекс
+Klovan Gully,Клованская лощина
+Golanta Clearing,Поляна Голанта
+Rogue's Quarry,Каменоломня Разбойников
+Tower of Nightmares,Башня кошмаров
+Keep,Держите
+Fort Salma Waypoint,Путь к форту Сальма
+Overlord's Waypoint,Перевалочный пункт Оверлорда
+Halacon Waypoint,Путь Халакон
+Sojourner's Waypoint,Путь Странника
+Delanian Waypoint,Деланийский переход
+Blue Team Rally Point,Место сбора синей команды
+Ireko Tradecamp Waypoint,"Путевая точка ""Торговый лагерь Иреко"""
+Red Team Rally Point,Место сбора Красной команды
+Shadowheart Site Waypoint,Точка перехода «Место встречи с Шэдоухарт»
+Viathan Waypoint,Путь к Вайтану
+Darkwound Waypoint,Путь к Тёмной Ране
+Cereboth Waypoint,Перекрёсток Серебот
+Overlake Haven Waypoint,Путь к Оверлейк-Хейвену
+Kessex Haven Waypoint,Перекрёсток Кессекс-Хейвен
+Cavernhold Camp Waypoint,Путь к лагерю Кавернхолд
+Greyhoof Camp Waypoint,Путь к лагерю Грейхуф
+Black Haven,Чёрная гавань
+Gort's Pit,Яма Горта
+Jannaj's Bandits,Бандиты Джаннажа
+Quarryside,Каменоломка
+Goff's Bandits,Банда Гоффа
+Kenna's Bandits,Банда Кенны
+Auld Red Wharf,Старая Красная пристань
+Wallwatcher Camp,"Лагерь ""Страж Стен"""
+Mudbay Digs,Раскопки в Мадбее
+Togatl Grounds,Земли Тогатла
+Krait's Larder,Ларь Крайта
+Glorious Drill Collective #4,Славный буровой коллектив №4
+Gleaner's Archway,Арка Собирателя
+Lapatl Grounds,Земли Лапатл
+Aquanarium Hydropost,"Акванариум, гидропост"
+Stormbluff Beacon,Маяк Штормовой Скалы
+Deadend Cave,Тупиковая пещера
+Covington Keep,Ковингтонский форт
+Sullivan's Wake,Поминки Салливана
+Mudflat Camp,Иллюминаторный лагерь
+Broken Beacon,Сломанный маяк
+Challdar's Nest,Гнездо Чаллдара
+Rhiann's Respite,Приют Рианн
+Aquannian Research Group,Акванийская исследовательская группа
+Dr. Bleent's Encampment,Лагерь доктора Блинта
+Old Oola Lab,Старая лаборатория Оолы
+Parnna's Gate,Врата Парнны
+Conduit Tower Blig,Кондуитная башня Блиг
+Conduit Tower Nopp,Кондуитная башня Нопп
+Inner Inquest Complex,"Комплекс ""Внутреннее расследование"""
+Transfer Gate (Private),Передающая дверь (личная)
+Conduit Tower Scoln,Кондуитная башня Сколн
+Soren Draa Waypoint,Путь Сорена Драа
+Jeztar Falls Waypoint,Путь к водопадам Йестар
+Akk Wilds Waypoint,Путевая точка Аккских Пустошей
+Rana Landing Complex Waypoint,Путь к комплексу Рана Лэндинг
+Arterium Haven Waypoint,Путь к Артериум-Хейвену
+Hexane Regrade Waypoint,"Точка перехода ""Гексановый передел"""
+Survivor's Encampment Waypoint,Путь к лагерю выживших
+Muridian Waypoint,Путь Муридиана
+Desider Atum Waypoint,Путь к Десидер Атум
+Sorrow's Embrace Waypoint,Путь к объятиям скорби
+Ogotl Grounds,Земли Оготла
+Invariant Base,Инвариантная база
+Joy's End,Радостный конец
+Beldame's Rise,Восхождение Бельдамы
+Seraph Protectors,Защитники Серафим
+Willem's Bandits,Бандиты Виллема
+Scotta's Bandits,Банда Скотта
+Angelan's Bandits,Бандиты Ангелы
+Enrav Exploration Post,Пост для исследований Энрава
+Seanan's Bandits,Банда Синан
+Robbari's Bandits,Банда Роббари
+Thaumacore Inquiry Center,Центр изучения таумакоров
+Revered Terebinth,Почтенный Теребинт
+Watchful Source Waypoint,Путь к Бдительному Источнику
+Wendon Waypoint,Перекрёсток Вендона
+Tunnels Waypoint,Путь через туннели
+Hillstead Waypoint,Путь к Хиллстеду
+East End Waypoint,Путь к восточному концу
+Brilitine Waypoint,Путь Брилитина
+Seraph Observers Waypoint,"Путевая точка ""Наблюдательный пункт Серафимов"""
+Gallowfields Waypoint,Путь к Галлоуфилдсу
+Triforge Point Waypoint,Путь к Трифоржу
+Ulta Metamagicals Waypoint,Путь Ульты Метамагических Искусств
+Aethervolt Lab,Эфиропроводная лаборатория
+Golotl Grounds,Земли Голотла
+Bay Haven,Бухта Бэй-Хейвен
+Morgatl Grounds,Моргатские земли
+Naulshead Refuge,Укрытие Наулсхед
+Stormwreck Deeps,Глубоководье Штормовой Крушины
+Hemlock Coil,Катушка из гемелока
+Hanto Trading Post,Торговый пост Ханто
+Hazupl Grounds,Земли Хазупла
+Slaver's Deeps,Глубины работорговцев
+Banshee's Keen,Пронзительный вой Банши
+Dengatl Grounds,Денгатльские земли
+Mrot Boru Waypoint,Путь Мрот Бору
+Mirkrise Waypoint,Путь к Миркрайзу
+Melandru's Cenote,Ценот Меландру
+Amaranth Grotto,Амарантовая грота
+The Beastpool,Звериный водоём
+Stonefish Beach,Пляж Каменистой Рыбы
+Wiley's Cove,Бухта Уайли
+Vigil HQ,Штаб-квартира Vigil
+Molenheide,Моленхайде
+Almuten Mansion,Особняк Альмутен
+C.L.E.A.N. Station,Станция C.L.E.A.N.
+Svannijem Hold,Сванний Холд
+Tala Point,Тала-Пойнт
+Lashoosh,Лашуш
+Durgar's Homestead,Родовое поместье Дургар
+Restricted Zone XRB,Ограниченная зона XRB
+Forward Camp,Передовой лагерь
+Northpasture Camp,Северный Пастбищный Лагерь
+Southforge Camp,Южный форпост
+War King's Greatcamp,Великий лагерь Военного короля
+Kingsgate Camp,Лагерь Кингсгейт
+Watchlin Armory,Арсенал Стражей
+Shorebluff Camp,Лагерь Шорблюф
+Overwatch Camp,"Лагерь ""На страже"""
+Confinement Camp,Лагерь для заключённых
+Blackhold Mine Camp,Лагерь у шахты Блэкхолд
+Drakken's Den,Логово Драккена
+Mountainroot Lair,Логово Горного Корня
+Martyr's Tomb,Могила мучеников
+Owl Lodge,Совиный приют
+Blasted Haven,Опустошённая гавань
+Faun's Waypoint,Путь Фавна
+Shieldbluff Waypoint,Путь к Щитовой скале
+Seraph's Landing Waypoint,"Перекрёсток ""Пристанище Серафимов"""
+Wynchona Rally Point Waypoint,Точка сбора у Винчоны
+Grey Gritta's Waypoint,Путь Грей Гритты
+Nightguard Waypoint,Путь ночных стражей
+Demetra Waypoint,Перекрёсток Деметры
+Recovery Camp Waypoint,"Точка возрождения ""Лагерь восстановления"""
+Barricade Camp Waypoint,Путь к баррикадному лагерю
+Trebusha's Overlook Waypoint,Путь к смотровой площадке Требуша
+Bridgewatch Camp Waypoint,Путь к лагерю Бриджуоч
+Junction Camp Waypoint,Перекрёстная точка перехода
+Cloven Hoof Waypoint,Путь Кловен-Хуф
+Arca Waypoint,"Арка, Путь"
+Skradden Waypoint,Скрэдденский перекресток
+Lornar's Waypoint,Путь Лорнара
+Highpass Haven Waypoint,"Путевая точка ""Гавань Хайпасс"""
+Lost Child's Sorrow Waypoint,Путь к скорби потерянного ребёнка
+Scholar's Cleft Waypoint,"Путь Учёного, контрольная точка"
+Isenfall Waypoint,Путь к Айзенфоллу
+Seraph Outriders' Waypoint,Путь серафимских разведчиков
+Torstvedt Homestead Waypoint,Путевая точка у поместья Торстведт
+Exile Waypoint,Путь Изгнанника
+Njordstead Waypoint,Путь к Ньёрдстеду
+Soderhem Steading Waypoint,Путевая точка Содерхемская усадьба
+Snowhawk Landing Waypoint,Перекрёсток Снежного Ястреба
+Reaver's Waypoint,Путь Разбойника
+Owl Waypoint,Путь Совы
+Podaga Steading Waypoint,Путь к Подаге
+Arcallion Waypoint,Путь к Аркаллиону
+Desert Gate,Пустынная врата
+The Hawkgates,Ястребиные врата
+Postern Gate,Потайная дверь
+Spotter's Base,База наблюдателя
+Sapper's Delve,Подземные разработки сапёров
+Cymbel's Rescue,Спасение Симбеля
+Otyugh's Kraal,Отыугский Краал
+Wreckage of Doomspy's Watch,Обломки сторожевой башни Думсп
+Varimhold Outpost,Аванпост Варимхольд
+Rocket,Ракета
+Ebonhawke Delegation,Делегация Эбонхоука
+Summit Peak,Высочайшая вершина
+Gillscale Pond,Пруд Гиллскейл
+Delegation of the Legions,Делегат Легионов
+The Thunder Den,Громовой приют
+Foulbear Kraal,Грязный Краал
+Hawkgates Waypoint,Путь Хоукгейта
+Deathblade's Watch Waypoint,Путь к дозорной башне Смертоносного Клинка
+Summit Waypoint,Перевалочный пункт на вершине
+Tyler's Bivouac Waypoint,Путь к лагерю Тайлера
+Tenaebron Waypoint,Путь к Тенаеброну
+Rosko's Campsite Waypoint,Путь к лагерю Роско
+Charrgate Haven Waypoint,Путь к гавани Чарргейт
+Blasted Moors Waypoint,Путь к Выжженным Болотам
+Bloodsaw Mill Waypoint,Путь к Кровавому лесопильному заводу
+Font of Rhand Waypoint,Путь к Фонту Рханда
+Nageling Waypoint,Путь к Нагелингу
+Nolan Waypoint,Путь Нолана
+Traveler's Dale Waypoint,Путь к Долине Путешественника
+Stoneguard Gate Waypoint,Путь к вратам Стоунгарда
+Broadhollow Waypoint,Путь к Бродхоллоу
+Oogooth Waypoint,Путь к Ооготу
+Cornucopian Fields Waypoint,"Путевая точка ""Родные поля изобилия"""
+Provern Shore Waypoint,Путевая точка Проверн Шор
+Vanjir's Stead Waypoint,Путь к стойлу Ванжира
+Demon's Maw Waypoint,Путь к Пасти Демона
+Winterthaw Waypoint,"Перекрёсток ""Зимний оттепель"""
+False Lake Waypoint,Путь к Ложному Озеру
+Brute,Грубиян
+Black Lion Trading Company,Чёрная торговая компания
+Order of Whispers,Орден Шепчущих
+Salvador,Сальвадор
+Tanner,Таннер
+Guardian,Страж
+Ley-Line Confluence Waypoint,Точка перехода к месту схождения линий лей.
+Carver's Ascent,Восхождение Карвера
+Eastwatch Waypoint,Путь к Восточной страже
+Temple of Lost Prayers,Храм Забытых Молитв
+Ogre Camp Waypoint,Путь к лагерю огров
+Prismatic Postpile,Призматический стог
+Facet of Darkness,Мрачная грань
+Dragon's Domain,Владения Дракона
+Hidden Copse,Скрытая роща
+Archer,Лучник
+Northern Forward Camp Waypoint,Путь к Северному передовому лагерю
+Door Breaker,Взломщик дверей
+Dragon's Domain Southern Waypoint,Южная точка перехода в Область Дракона
+Dragon's Domain Northern Waypoint,Северная точка перехода в Области Дракона
+Bluevale Refuge,Укрытие Блювейл
+Southern Barbed Gate,Южные Колючие Ворота
+Chak Nest,Гнездо чаков
+Teku Nuhoch Waypoint,Путевая точка Теку-Нухоч
+Eternal Necropolis,Вечная некрополь
+Reception Hall,Приёмный зал
+Magimechanic Upgrade Depot,Склад для улучшения механизмов
+Illuminated Nave,Освещенный неф
+Lair of the Seawitch,Логово Морской Ведьмы
+Bandit's Supply Room,Кладовая бандитов
+Crucible Access Platform,Платформа доступа к Испытаниям
+Lionguard Haral,Львиная Стража Харал
+Travelen,Путешественник
+Logan Thackeray,Логан Такераи
+Monument to the Return of Palawa Joko,Памятник в честь возвращения Палавы Джоко
+Ring of Judgment,Кольцо Суда
+Wurmmarshal's Encampment,Лагерь Вурммаршала
+Jahai Keep,Крепость Джахаи
+Jahai Great Hall,Великий зал Джахаи
+Staging Platform,Стартовая платформа
+Sleepless Beacon,Бессонный маяк
+Siren's Reef Fractal,"Фрактал ""Сирений риф"""
+Battleground Ramparts,"Боевая арена ""Рампарты"""
+Archon's Retreat,Убежище Архонта
+Mirza's Rest,Мирзас-Рест
+Fidelma,Фидельма
+Refugee,Беженец
+"Captain ""Bonny"" Anne Reid","Капитанша ""Бонни"" Энн Рейд"
+Servant,Слуга
+Dig Site Gamma,Раскопки Гамма
+Sailor's Heart,Сердце моряка
+Malice Swordshadow,Меч-тень злобы
+Forecastle Rock,Скальный выступ Фо́ркасл
+Consecrated Piazza,Освящённая площадь
+Hidden Aquifer,Скрытый водоносный горизонт
+Winding Haven,Извилистая гавань
+Crimsonleaf Fountain,Багроволистный фонтан
+Choya Conclave,Союз Чоя
+Gilded Forum,Позолоченный форум
+Mia Kindleshot,Мия Кандлшот
+Gullet's Beginning,Начало Гуллета
+Littlewing Pond,Пруд Литлвинг
+Colosseum of the Faithful,Колизей Верных
+Iris,Ирис
+Griffon,Грифон
+Elon Riverbank,Элон Ривербанк
+Unending Ocean,Бесконечный океан
+Tyria (Surface),Тирия (поверхность)
+Refugee Camp Director,Директор лагеря беженцев
+Suspicious Heirloom Lost and Found,Подозрительная реликвия из отдела потерянных и найденных вещей
+Redwater Lowlands,Низменности Редвотера
+Redlake Tower,Красная башня
+Avatar of Balthazar,Аватар Балтазара
+Elon River,Река Илон
+Village of Wren,Деревня Врен
+Altar of Lies,Алтарь лжи
+Altar of Tempests,Алтарь Бурь
+Blazeridge Mountains,Хребет Блейзерридж
+Surly Local,Ворчливый местный житель
+Golem Assistant,Помощник-голем
+Cub,Куб
+Bramble Plateau,Плато Шиповник
+Tarnished Treetop,Испорченная верхушка дерева
+Overseer's Cave,Пещера надсмотрщика
+Vinetooth Den,Логово Винетоота
+Quetzal Scout,Разведчик Кетцаль
+Weeping Glade,Плачущая Роща
+Dust Mites,Пылевые клещи
+Experimental Lab Red,Экспериментальная лаборатория (красная)
+Experimental Lab Green,Экспериментальная лаборатория (зелёная)
+Highborn Kings Waypoint,Путь Высокородных королей
+Temple of Kormir Waypoint,Путь к храму Кормир
+Amnoon Harbor,Порт Амнун
+First Camp,Первый лагерь
+Temple of Kormir,Храм Кормира
+Free City of Amnoon,Свободный город Амнун
+Destiny's Gorge,Ущелье Судьбы
+Throne of Pellentia,Трон Пеллентии
+Scattered Remnants,Разбросанные останки
+The Deadhouse,Мёртвый дом
+Amnoon Southern Outskirts,Южная окраина Амнуна
+Amnoon Farms,Фермы Амнуна
+Giant's Rise,Подъём гигантов
+Elon Flow,Элон Флоу
+Inquest Engineer,Инженер-инквизитор
+Inquest Assassin,Убийца-разведчик
+Lunatic Court,Безумный двор
+Lyssa Waypoint,Путь к Лиссе
+Illusionary Mage,Иллюзорный маг
+Primordus,Примордус
+Xinrae's Wharf,Причал Ксинрэ
+Argo Crawler,Арго-ползун
+Residential District,Жилой район
+The Great Jade Wall,Великая Нефритовая Стена
+Harrower Veltan,Испепелитель Велтан
+Sanctuary of Ione,Святилище Ионы
+Kaolai Tower,Башня Каолай
+The Jade Expanse,Нефритовые просторы
+Hound of Balthazar,Пёс Бальтазара
+The Great Melt,Великое таяние
+Rhea's Landing,Рейя-Лендинг
+Bastion of the Natural,Бастион Природы
+Fish,рыба
+Eastern Front,Восточный фронт
+Bay of Gandara,Бухта Гандара
+Apizmic Grounds,Апизмические земли
+Elon Basin,Бассейн Илона
+Jofast's Camp,Лагерь Йофаста
+Boettiger's Hideaway,Укрытие Бёттигера
+Foghaven,Фогхейвен
+Smokescale,Дымочешуйка
+Tyrian Explorers Society,Тирийское общество исследователей
+Chitterogg Camp,Лагерь Читтероггов
+Neuskrittia Camp,Лагерь Неускриттии
+Stonetwist Paths,Каменные тропы
+Flame Legion Lava Shaman,Лавовый шаман Пылающего легиона
+Eboneigh Camp,Эбонейский лагерь
+Ice Shark,Ледяная акула
+Order of Whispers Headquarters,Штаб-квартира Ордена Шепчущихся
+Scholar,Учёный
+End of the Road Waypoint,Путь к концу
+Langmar Estate Waypoint,Путь к поместью Лангмар
+Illusionary Warden,Иллюзорный страж
+Guild Bluff Waypoint,Путь к Гильдейскому обрыву
+Statuary,Статуя
+Rancher Tolona Ironrustler,Ранчер Толона Айронрастлер
+Deverol Gardens,Сады Деверола
+The Vaults,Хранилища
+Captain Theo Ashford Memorial Bridge,Мемориальный мост капитана Тео Эшфорда
+Durmand Priory Research Site,Исследовательский объект Дурмандского приората
+The Free Market,Свободный рынок
+Butcher,Мясник
+Zopatl Grounds,Зопатльские земли
+Chak Hollow,Чако-Холлоу
+Thornwatch,Терновый дозор
+Eastgate,Восточные ворота
+Northwatch Priory Camp,Лагерь Северного дозора
+Legacy Pillars,Наследие столпов
+Giant Devourer,Гигантский пожиратель
+Flame Legion Recruiter,Наборщик в Огненный Легион
+Serpent's Folly,Заблуждение змеи
+Candescent Corridor,Раскалённый коридор
+Isgarren,Исгаррен
+Excavation Point 7-G,Раскоп 7-Г
+Heitor,Эйтор
+Lady Kasmeer Meade,Леди Касмир Мид
+Raptor Rental,Аренда рапторов
+Jade Brotherhood,Нефритовое братство
+Tae-Jin's Estate,Имение Тэйджина
+Technician,Техник
+Haunted Nolani Waypoint,Призрачный перекресток Нолани
+Thunder Hollow Waypoint,Путь к Громовой Пустоши
+Pact Base Camp Southern Waypoint,Южная точка телепорта у лагеря Пакт
+Hailstone Floe,Хрустающая льдина
+Black Ice Pass,Чёрный Ледяной Перевал
+Confessional,Исповедальня
+Grand Lyceum,Великий лицей
+The Grotto,Грот
+Deldrimor Ruins,Руины Делдримора
+The Hammer's Hoard,Сокровищница Молота
+Armadillo,броненосец
+Silent Falls,Тихие Водопады
+Refiner's Joy,Радость переработчика
+Path of the Exalted,Путь Возвышенного
+The Astralarium,Астраларий
+Chalon Docks,Доки Шалон
+Plains of Jarin,Равнины Джарин
+Sea of Istan,Море Истан
+Churrhir Cliffs,Скалы Чурхир
+Corsair Flotilla,Корсарская флотилия
+Pride of the Pact,Гордость Пакт
+Haunted Canyons,Зачарованные каньоны
+Depths of the Maw Waypoint,Путь к Глубинам Пасти
+Bloodstone Maw,Кровавая Пасть
+Whispering Grottos,Шепчущие гроты
+Misery,Страдание
+Zayan Gate,Заянские врата
+Combat Training Waypoint,Точка маршрута «Боевая тренировка»
+Bitumen Reserve,Запас битума
+Forged Sentry,Выкованный страж
+Champion's Monument,Памятник чемпиону
+Qinkai Waypoint,Путь Цинькай
+Aetherblade Refuge,Убежище Эфирных Клинков
+Sensali Shrine,Сенсалийский храм
+Shrine of Reverence,Святилище Благоговения
+Player Respawn,Восстановление игрока
+Tengu Alpine Camp,Альпийский лагерь Тэнгу
+Freebooters,Свободные стрелки
+Hiberus Mythseeker,"Хиберус, ищущий мифы"
+Broken Golem,Сломанный голем
+Wreck of the Thunderbreaker,"Обломки ""Громовержца"""
+Mist Portals,Туманные порталы
+Cavern Waypoint,Путь к пещере
+Toadstool Mire,Топкое Болото
+Shade,Тень
+Lord Azeem,Лорд Азим
+Fear,Страх
+Front Line,Передовая линия
+Arkjok Farmlands,Аркйокские фермерские угодья
+First Spear Hakima,Первый копьёносец Хакима
+Cave of the Sunspear Champion,Пещера чемпиона Солнечного Копья
+Bitterfly Bayou,Биттерфлай-Баю
+Kadir,Кадир
+Blistering Undercroft Waypoint,Путь к Палящей Подземке
+Kasmeer Meade,Касмир Мид
+Frostreach Safe Zone Waypoint,Точка перехода: безопасная зона Фрострейч
+Osprey's Palace Waypoint,Путь к дворцу Орла
+Canyon Dig Waypoint,Путь к Каньонным раскопкам
+Sandstone Coliseum Waypoint,Путь к песчаниковому колизею
+Labor Camp,Трудовой лагерь
+Chak Hollow Waypoint,Путь к Чаку Холлоу
+Mysterious Pylons,Таинственные пилоны
+River of Spirits,Река Духов
+Bandit's Rest,Приют бандитов
+Upper Plaza Waypoint,Перекрёсток Верхней площади
+Temple of Salvation,Храм Спасения
+Central Hollow Waypoint,Путь к Центральной Пустоши
+Prospector's Landing,Посадочная площадка старателей
+Park Mining Ops,Добыча полезных ископаемых в парке
+Bouncer,Вышибала
+Tarra,Тара
+Corsair Landing,Корсарская бухта
+Ouissal,Уиссал
+Necromancer,Некромант
+Forge,Кузница
+Elementalist,Элементалист
+Fahrar of Young Heroes,Фахрар юных героев
+Seraph,Сераф
+Djinn Enclave,Джинновое анклаве
+The Bone Wall,Костяная стена
+Stoneyard Rest,Отдых в Каменном дворе
+Eastern Mihan Hillsides,Восточные склоны холмов Михан
+Headmaster's Office,Кабинет директора
+Troopmarshal's Encampment,Военный лагерь военачальника
+The Mists,Туманы
+Glint's Lair,Логово Глинта
+Judgment,Суд
+Fangstorm's Farmhouse,Ферма Фангсторма
+Doomlore Ruins,Руины Думлора
+Flame Legion Camp,Лагерь Пламенного Легиона
+Ley-Infused Branded Forgotten Priest,"Забытый жрец, отмеченный печатью и пропитанный энергией линий"
+Hammer of Wisdom,Молот Мудрости
+Shield of the Avenger,Щит Мстителя
+Sword of Justice,Меч справедливости
+Eye of Zhaitan,Око Зайтана
+Dominion's Breach,Пролом Доминиона
+Lighthouse Point,Маяк Пойнт
+Wolf's Crossing,Волчий переход
+Petraj Overlook,Смотровая площадка Петрадж
+Sniper's Slope,Снайперский склон
+Veins of Jormag,Жилы Йормаг
+Iceblood Channel,Ледяной канал
+Stone Archways,Каменные арки
+Sentinel Bay,Сентинел-Бэй
+Legions' Alcove,Укрытие легионов
+Port Cascadia,Порт Каскадия
+Outlaws,Законники
+Luccia Wildeye,Луччия Уайлдсай
+Vloxen Mine,Шахта Влоксена
+Leadfoot Village,Деревня Лидфут
+The Hollow,Пустошь
+Howling Caves,Воющие пещеры
+Luxon Terminus Waypoint,Путь к Люксон Терминусу
+Park Mining Ops Waypoint,Путь к шахтам Парка
+Behemoth's Gap Waypoint,Путь к Ущелью Бегемота
+Jadepillar Point Waypoint,Путь к Изумрудной гусенице
+Base Camp,Базовый лагерь
+Tower Courtyard Waypoint,Путь к башне
+Bastion of the Natural Waypoint,Оплот Пути Природы
+Behemoth's Drop,Добыча из Бегемота
+Inner Sanctorium,Внутреннее святилище
+Shimmering Basin,Мерцающая Чаша
+Tranquil Glen,Безмятежная роща
+Kinfall,Кинфолл
+Enchanting Grottoes,Зачарованные гроты
+Hunter,Охотник
+Posternus Caverns,Пещеры Постернуса
+Rocklair,Скала-Логово
+Security Waypoint,Охранный портал
+The Glory of Tyria's Waypoint,"Слава Тирии, портал"
+Magicat Court Waypoint,Путь к Магическому двору
+Corpse,Труп
+Stone Spirit,Каменный дух
+Frost Spirit,Ледяной дух
+Lava,лава
+Bulsa the Elder,Бульса Старейшина
+Kasha Blackblood,Каша Блэкблад
+King Adelbern,Король Адельберн
+Vassar,Вассар
+Shadow,Тень
+Cave Troll,Пещерный тролль
+Prototype Golem,Прототип голема
+Brassburn Torch,Факел из Латунного Пламени
+Pact Rally Point,Точка сбора пакта
+Inspector Snik,Инспектор Сник
+Inquest Advanced Assault Golem,Улучшенный боевой голем Инквизиции
+Dragon's Passage,Проход Дракона
+Blistering Undercroft Emergency Waypoint A,"Аварийный путь ""Палящая Подземка"""
+Chak Den,Чак Ден
+Mossheart Walk,Мохсердечный проход
+Stoic Rampart Emergency Waypoint A,Аварийный путь Стоического бастиона А
+Northern Blighting Tower,Северная Башня Заражения
+Rata Novus Command Center,Центр управления Рата-Новус
+Northern Confluence Tunnel,Северный туннель слияния
+Second Central Checkpoint,Второй центральный контрольно-пропускной пункт
+Cascade Descent,Каскадный спуск
+Stonemist Castle Emergency Waypoint A,Аварийный путь к замку Стоунмист А
+Deeproot Sink,Глубокорений Ручей
+Pact Base Camp Waypoint,Путевая точка у лагеря Пакт
+Wyvern Nest,Гнездо виверны
+Mordremoth's Vantage,Смотровая площадка Мордремота
+Plunder Hold,Пландая крепость
+Woodland Cascades,Лесные водопады
+Altar,Алтарь
+Salmon,лосось
+Separatist Captain DeLana,Капитан-сепаратист ДеЛана
+Lilac,Сиреневый
+Olive,Олива
+Cinnamon,Корица
+Plains Wurm,Равни́нный червь
+Matriarch's Nest,Гнездо Матриарха
+N.K. Broadcast Terminal Beta,Бета-версия вещательного терминала N.K.
+Chak Hatchery,Чаковый питомник
+Akeem's Sacrifice,Жертва Акеема
+Reserve Arsenal,Запасной арсенал
+Sailor's Lament,Плач моряка
+The Light Crystal,Световой кристалл
+Fortune's Collapse,Крушение Фортуны
+Young Skyscale,Молодая скайскала
+Emerald Seiche,Изумрудный сеихе
+Talus Passage,Проход Талус
+Rama,Рама
+Deathmatch Courtyard,"Арена ""Смертельный поединок"""
+Mad King's Realm,Царство Безумного Короля
+Mad King's Raceway Waypoint,"Путевая точка ""Автогоночная трасса Безумного короля"""
+The Auditorium,Аудиториум
+Formal Garden Waypoint,Путь к формальному саду
+Pantry,Кладовая
+Redbriar Tower,Красная Башня
+Titanpaw Crossroads,Перекрёсток Титанпау
+"Perhaps—my—close—personal—friend, Captain—Magnus, can—clear—this—matter—up.","Возможно, мой близкий друг, капитан Магнус, сможет прояснить этот вопрос."
+"+10%% Outgoing Healing
++30 Healing Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исходящее лечение
++30 Сила лечения
++10%% Карма
++5%% Ко всему получаемому опыту
++20%% Шанс найти магические предметы
++20%% Шанс найти золото
++10%% Получаемый опыт за выполнение заданий"
+"-10%% Incoming Damage
++40 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++40 ко всем характеристикам
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс получить золото
++10%% опыта за прохождение"
+Slime Volley,Слизневый залп
+Shoot your foe from a distance.,Стреляйте по врагу с расстояния.
+Knock back your foe with a close shot.,Отбросьте врага точным выстрелом с близкого расстояния.
+Hold to block incoming attacks.,"Удерживайте кнопку, чтобы блокировать входящие атаки."
+Daze your foe with the butt of your rifle.,Ошеломите врага прикладом своей винтовки.
+Fire a barrage of shots at your foe.,Обрушьте на врага шквал выстрелов.
+Shoot your foe and inflict bleeding.,Выстрелите в противника и нанесите кровотечение.
+"Cast a fireball at foes, that explodes on impact.","Бросьте огненный шар во врагов, он взрывается при попадании."
+Incendiary Shell,Зажигательный снаряд
+Block three attacks. Explodes when it ends.,Блокирует три атаки. Взрывается по истечении времени действия.
+Allies gain a massive boost to vitality while in the presence of the commander.,"Союзники получают значительное увеличение показателя живучести, находясь рядом с командиром."
+Increases vitality to allies.,Увеличивает запас жизненных сил у союзников.
+Deploy your Arrow Cart,Разверните свою тележку со стрелами.
+Deploy your Ballista,Разверните свою баллисту.
+Ice Shot (Damage),Ледяной выстрел (урон)
+Fire the cannon (radius damage),Выстрелите из пушки (наносит урон по области).
+Ice Shot (Radius Damage),Ледяной выстрел (урон по области)
+Fire grapeshot to bleed foes. (Damage and Double Bleeds),"Выпустите огненный град, чтобы вызвать кровотечение у врагов. (Наносит урон и вызывает двойное кровотечение.)"
+Large Rending Gravel Shot,Мощный удар гравийной пушкой
+Hollowed Gravel Shot,Освящённый гравийный заряд
+"Sound the call to arms, granting protection and vigor to yourself and nearby allies. Launch attackers at end of call.","Подайте боевой клич, дарующий защиту и энергичность вам и находящимся рядом союзникам. В конце действия клича обрушьте атаку на противников."
+Red Team is tracking your movement.,Красная команда отслеживает ваши перемещения.
+"+600 Power
++300 Precision
++3,750 Vitality
++450 Toughness","+600 силы
++300 точности
++3 750 единиц живучести
++450 защиты"
+"+600 Power
++300 Precision","+600 силы
++300 точности"
+Surprise Attack,Внезапная атака
+Deploy your trap.,Установите свою ловушку.
+Gravel Shot,Гравийный залп
+Supply Explosion Trap,Ловушка взрывного снабжения
+Plant the banner in the ground with such force that you knock down enemies and grant stability and protection to allies.,"Водрузите знамя в землю с такой силой, чтобы отбросить врагов и даровать союзникам устойчивость и защиту."
+Fire grapeshot to bleed foes,"Выпустите огненный град, чтобы вызвать кровотечение у врагов."
+Deploy your shield generator.,Активируйте генератор щита.
+Summon a cascade in front of you consisting of bleeding arrows.,"Создайте перед собой каскад стрел, вызывающих кровотечение."
+Airship Bombardment,Бомбардировка с дирижабля
+Become a spirit of a centaur.,Стань духом кентавра.
+Cannot be killed.,Нельзя убить.
+"You transform into a centaur that knocks people out of your way. Applies bleeding, blindness, or crippled. Disables other skills for the duration.","Вы превращаетесь в кентавра, отбрасывающего врагов. Накладывает кровотечение, ослепление или хромоту. Отключает другие умения на время действия."
+Invulnerable Dolyak,Неуязвимый Доляк
+"Summon a spirit centaur at your position that charges forward, crippling enemies and granting stability to nearby allies.","Призывает духа кентавра в текущую позицию, который устремляется вперед, нанося врагам удар, вызывающий хромоту, и даруя устойчивость находящимся поблизости союзникам."
+Mortar Recharge,Перезарядка миномёта
+"+5 Max Supply
++10%% WvW Experience
++25%% Movement Speed
++25 Power
++25 Precision
++25 Toughness
++25 Vitality
++20%% Magic Find","+5 Макс. припасов  
++10%% опыта WvW  
++25%% скорости передвижения  
++25 Мощи  
++25 Точности  
++25 Прочности  
++25 Живучести  
++20%% Магического поиска"
+"+5 Max Supply
++10%% WvW Experience","+5 Максимальный запас
++10%% опыта в PvP"
+"+5 Max Supply
++10%% WvW Experience
++25%% Movement Speed
++25 Power
++25 Precision
++25 Toughness
++25 Vitality","+5 Максимальный запас
++10%% Опыт в PvP (Мировые против Мировых)
++25%% Скорость передвижения
++25 Сила
++25 Точность
++25 Выносливость
++25 Жизненная сила"
+"+5 Max Supply
++10%% WvW Experience
++25%% Movement Speed
++25 Power","+5 Максимальный запас
++10%% опыта в PvP
++25%% скорости передвижения
++25 силы"
+"+5 Max Supply
++10%% WvW Experience
++25%% Movement Speed
++25 Power
++25 Precision","+5 Максимальный запас
++10%% опыта в PvP (Завоевания и войны)
++25%% скорости передвижения
++25 силы
++25 точности"
+"+5 Max Supply
++10%% WvW Experience
++25%% Movement Speed
++25 Power
++25 Precision
++25 Toughness","+5 Максимальный запас
++10%% Опыт в PvP
++25%% Скорость передвижения
++25 Сила
++25 Точность
++25 Защита"
+"+5 Max Supply
++10%% WvW Experience
++25%% Movement Speed","+5 Максимальный запас
++10%% опыт в PvP
++25%% скорость передвижения"
+[lbracket][lbracket]908612[rbracket][rbracket],[lbracket][lbracket]908612[rbracket][rbracket]
+((934271)),((934271))
+"+10%% Outgoing Healing
++80 Concentration
++60 Healing Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10 %% Исцеление, наносимое союзникам
++80 Концентрация
++60 Сила исцеления
++10 %% Карма
++5 %% Весь получаемый опыт
++20 %% Шанс найти магические предметы
++20 %% Шанс получить больше золота
++10 %% Получаемый опыт WXP"
+"-10%% Incoming Damage
++80 Concentration
++60 Healing Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% Урон от входящих атак
++80 Концентрация
++60 Сила исцеления
++10%% Карма
++5%% К получаемому опыту
++20%% Шанс найти магические предметы
++20%% Шанс получить больше золота
++10%% К получаемому опыту мира"
+"+10%% Outgoing Healing
++20 Healing Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исходящее лечение
++20 Сила лечения
++10%% Карма
++5%% Ко всем получаемым очкам опыта
++20%% Шанс найти магические предметы
++20%% Шанс найти золото
++10%% Получаемый опыт за события"
+"Stats only apply in WvW:
+-10%% Incoming Damage
++30 to All Attributes
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Статы действуют только в PvP:
+-10%% входящего урона
++30 ко всем характеристикам
++10%% к карме
++5%% ко всему получаемому опыту
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% к получаемому количеству очков опыта мира"
+"Stats only apply in WvW:
+-10%% Incoming Damage
++20 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Характеристики действуют только в PvP:
+-10%% входящего урона
++20 силы
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% получаемого опыта мира"
+"Stats only apply in WvW:
++10%% Outgoing Healing
++80 Healing Power
++60 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","Характеристики действуют только в PvP-режиме «Завоевание территорий»:
++10%% к исцелению, наносимому в бою.
++80 к силе исцеления.
++60 к концентрации.
++10%% к получаемой карме.
++5%% ко всему получаемому опыту.
++20%% к шансу найти магические предметы.
++20%% к шансу найти золото.
++10%% к получаемому опыту мира."
+Incoming damage from siege weapons reduced by 66%%.,Урон от осадных орудий уменьшен на 66%%.
+Deploy your ballista.,Установите свою баллисту.
+"+500 Power
++500 Vitality
++500 Toughness
++500 Ferocity
++500 Precision
++500 Healing
++500 Concentration
++500 Expertise
++500 Condition Damage","+500 силы
++500 жизненной силы
++500 к живучести
++500 ярости
++500 точности
++500 исцеления
++500 концентрации
++500 мастерства
++500 урона от состояний"
+Tiger Cub,Тигрёнок
+Plays,играет
+((488246)),((488246))
+"Gain 3 Seconds of Quickness on Dismount <c=@reminder>(Cooldown: 60 Seconds)</c>
++10%% Experience from Kills","Получайте 3 секунды эффекта «Проворство» при спешивании <c=@reminder> (перезарядка: 60 секунд) </c>
++10 %% опыта за убийства"
+Deploy your Siege Suit,Активируйте свой боевой экзоскелет.
+Run to Greatsword,Бегите к двуручному мечу.
+Raise,Поднять
+Place metal,Поместите металл
+Cakilak'ka,Какилак'ка
+Aetheric Resonator,Эфирный резонатор
+"The alliance of the Durmand Priory and the Vigil has been constructive, though even together we are challenged. Caer Evermore is under constant attack by the Risen as the Priory scours the surrounding ruins for ancient secrets of the Elder Dragons.","Союз Приората Дурманда и Стражей оказался продуктивным, хотя даже вместе мы сталкиваемся с трудностями. Цитадель Эвермор постоянно подвергается атакам восставших, в то время как члены Приората исследуют окружающие руины в поисках древних секретов Старших драконов."
+"Student: Blish
+Student ID: 0438238655
+ 
+CYS 310 Cybernetic Systems II
+MTH 411 Multivariable Calculus
+TML 310 Thaumaturgical Materials Lab
+MPY 340 Magical Metaphysics Seminar
+TAS 300 Advanced Theory of Abstract Structures
+
+(You skim through the lengthy list of advanced coursework that Blish completed during his time at the college. It's as impressive as it is intimidating.)
+","Студент: Блиш
+Студенческий билет № 0438238655
+ 
+CYS 310 Кибернетические системы II
+Многомерное исчисление (курс MTH 411)
+Лаборатория таутургических материалов
+Семинар по магической метафизике MPY 340
+Продвинутая теория абстрактных структур (TAS 300)
+
+(Вы просматриваете длинный список курсов повышенного уровня, которые Блиш посещал во время учебы в колледже. Он впечатляет не меньше, чем пугает.)
+"
+"<c=@abilitytype>Offensive Artifact.</c> Dash to the targeted location while dropping bombs along your path that detonate after a short period of time, dealing damage and burning enemies. More bombs are dropped the farther you travel. <br>
+For a short time after using this skill, you continue to drop additional bombs at your location. 
+","<c=@abilitytype>Наступательный артефакт. Совершите рывок к указанной цели, сбрасывая по пути бомбы, которые взрываются через короткое время, нанося урон и поджигая врагов. Чем дальше вы пройдете, тем больше будет сброшено бомб. </c>
+В течение короткого времени после использования этого умения вы продолжаете сбрасывать дополнительные бомбы в своей текущей локации. <br> 
+"
+"Double-click to unlock the first collection in the journey to craft the Tigris, the precursor to the legendary short bow, Chuka and Champawat.
+","Дважды щелкните, чтобы открыть первую коллекцию и начать создание Тигриса — прототипа легендарного короткого лука Чука и Чампават.
+"
+"Double-click to unlock the first collection in the journey to craft the Raven Staff, the precursor to the legendary staff, Nevermore.
+","Дважды щелкните, чтобы открыть первую коллекцию в цепочке заданий по созданию Вороньего посоха — предшественника легендарного посоха Невермор.
+"
+"-10%% Incoming Damage
++60 Condition Damage
++50 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-10%% входящий урон
++60 урона от состояний
++50 мастерство
++10%% карма
++5%% ко всему получаемому опыту
++20%% шанс найти магические предметы
++20%% шанс найти золото
++10%% получаемый опыт за события"
+"Consortium Officer<br>• Collects Champion Marks<br>• Advances Bonus-Event Community Goals
+","Офицер консорциума<br>• Собирает знаки чемпионов<br>• Способствует достижению целей сообщества в рамках бонусного события.
+"
+"Twisted Watchwork[pl:""Twisted Watchworks""]
+","Искажённые часовые механизмы
+"
+"Consumed automatically when acquired. Grants a small amount of volatile magic.<br>Traditional Olmakhan song. <c=@flavor>""May the sun shine on all our tomorrows, once this storm passes...""</c>
+","Автоматически уничтожается при получении. Даёт небольшое количество нестабильной магии.<br>Традиционная песня олмаханцев. <c=@flavor>«Пусть солнце осветит все наши грядущие дни, когда эта буря утихнет...»</c>
+"
+"+10%% Outgoing Healing
++80 Concentration
++60 Power
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+10%% Исцеление, наносимое союзникам
++80 Концентрация
++60 Сила
++10%% Карма
++5%% Ко всему получаемому опыту
++20%% Шанс найти магические предметы
++20%% Шанс получить больше золота
++10%% Получаемый опыт за выполнение заданий"
+Scholar Loren,Учёный Лорен
+"Copies conditions from source.
+Steals boons from target.","Копирует состояния из источника.
+Крадет благословения у цели."
+"The Inquest make no sense to me. I don't know if they're oblivious to the destruction they cause, impartial to it, or actively trying to destroy Tyria.","Я не понимаю, что творится с Инквизицией. Не знаю, просто ли они не замечают разрушений, которые причиняют, равнодушны к ним или же намеренно пытаются уничтожить Тирию."
+"Regardless, those rotten scumbags are trouble and need to be shut down!","В любом случае, эти гниды – настоящая проблема, и с ними нужно покончить!"
+You really think they're trying to destroy Tyria?,"Ты действительно думаешь, что они пытаются уничтожить Тирию?"
+Not sure. See you around.,Не уверен(а). Увидимся.
+"I agree! They're reckless and dangerous. They obliterated a town in Metrica Province when a reactor they were working on exploded, and what do they do?","Согласен! Они безрассудны и опасны. Они стёрли с лица земли город в провинции Метрика, когда взорвался реактор, над которым они работали, и что они сделали потом?"
+"They come out here and start making an even bigger reactor, using dragon energy. Does that seem sane to you? Beneficial in any way? No, at this point I just have to view them as agents of evil.","Они приходят сюда и начинают строить еще более мощный реактор, используя энергию драконов. Вам не кажется, что это безумие? Что в этом может быть полезного? Нет, на данном этапе я могу рассматривать их только как агентов зла."
+It doesn't seem sane or beneficial. They're just trouble.,Это кажется неразумным и бессмысленным. Они только приносят проблемы.
+I'm armed and dangerous.,Я вооружён и опасен.
+Temperance,Умеренность
+((393808)),((393808))
+((475806)),((475806))
+((453220)),((453220))
+((402876)),((402876))
+((536060)),((536060))
+((402501)),((402501))
+((386018)),((386018))
+((502025)),((502025))
+((372340)),((372340))
+((506903)),((506903))
+Roo,Рык
+"-20%% Incoming Condition Duration
++50 Power
++40 Precision
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-20%% Длительность входящих эффектов
++50 Силы
++40 Точности
++10%% Кармы
++5%% ко всем получаемым очкам опыта
++20%% к шансу найти магические предметы
++20%% к шансу найти золото
++10%% ко всем получаемым очкам WXP"
+"66%% Chance to Steal Life on Critical Hit
++80 Expertise
++60 Condition Damage
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","66%% шанс украсть здоровье при критическом ударе
++80 к мастерству
++60 урона от состояний
++10%% кармы
++5%% ко всему получаемому опыту
++20%% к шансу нахождения магических предметов
++20%% к шансу найти золото
++10%% очков опыта"
+"-20%% Incoming Condition Duration
++30 Concentration
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","-20%% Длительность входящих эффектов
++30 Концентрация
++10%% Кармы
++5%% Получаемого опыта
++20%% Шанс найти магические предметы
++20%% Шанс получить золото
++10%% Получаемых очков опыта"
+"+150 Fishing Power
++30 Condition Damage
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+150 к силе рыбалки
++30 урона от состояний
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% опыта мира"
+I didn't oversleep and miss the Great Hunt. This is his fight.,Я не проспал и не пропустил Великую Охоту. Это его бой.
+((518367)),((518367))
+"+150 Fishing Power
++60 Condition Damage
++50 Expertise
++10%% Karma
++5%% All Experience Gained
++20%% Magic Find
++20%% Gold Find
++10%% WXP Gained","+150 к силе рыбалки
++60 урона от состояний
++50 мастерства
++10%% кармы
++5%% ко всему получаемому опыту
++20%% шанса найти магические предметы
++20%% шанса найти золото
++10%% получаемого опыта мира"
+Pulls Player • Summons Minions • AOE Knockback,Притягивает игрока • Призывает миньонов • Область действия с отбрасыванием
+Dragon Grawl Shaman,Драконий гроульский шаман
+Leopard Form,Форма леопарда
+"It was inevitable, Horace. Fated even. Our legend will grow here when we set up our shop.","Это было неизбежно, Гораций. Даже предначертано судьбой. Наша легенда будет расти здесь, когда мы откроем нашу лавку."
+"You want to play ""Quaggan Quaff""?",Хотите сыграть в «Квакканский кубок»?
+Shoot a foe with an overcharged blast that knocks it back.,"Выпустите в противника перегруженный луч, который отбросит его назад."
+"Daze a foe with the butt of your extinguisher, then roll back.","Оглушите врага рукояткой огнетушителя, а затем отступите назад."
+Covered in flamable tar.,Покрыт легковоспламеняющейся смолой.
+Embracing fire makes attacks more powerful.,Принятие огня делает атаки более мощными.
+Undead Illusion,Нежить-иллюзия
+Heal yourself and nearby allies. Removes a condition.,Восстановите себе и ближайшим союзникам здоровье. Снимите одно из негативных состояний.
+Near-Left Platform,Ближняя левая платформа
+Near-Right Platform,Платформа справа
+Far-Left Platform,Крайне левая платформа
+Far-Right Platform,Праворадикальная платформа
+"The Pact hold Vorgas Garrison and have driven the Flame Legion off, for the moment.",Союз удерживает форт Воргас и временно оттеснил Легион Пламени.
+"I don't know where she is now, but I can tell you where that camp was. Is that enough to get me off the hook?","Я не знаю, где она сейчас, но могу сказать, где был этот лагерь. Разве этого недостаточно, чтобы меня отпустили?"
+MONSTER ONLY Grawl Priest Staff,Жезл жреца гроула (только для монстров)
+This should do for now. Let's gather up what we can—,"На данный момент этого должно хватить. Давайте соберем всё, что сможем."
+Whoa! Is that massive beast a minotaur? We'll never get out of here while it's around.,"Ого! Это что, огромный минотавр? Мы никогда отсюда не выберемся, пока он здесь крутится."
+Don't just stand there—move! We've got to stop the Flame Legion and recover those weapons!,Не стой столбом — двигайся! Мы должны остановить Пламенную Легию и вернуть оружие!
+Wait...was that who I think it was? Did you bring in Destiny's Edge? I'm...having trouble understanding all this. I need to find the Flame camp...,"Подождите… неужели это был он? Вы привели ""Грань Судьбы""? Я… не совсем понимаю, что происходит. Мне нужно найти лагерь Пламени…"
+"What's wrong with me, Trahearne? What's wrong with you? Why are you trying to keep me from that camp?","Что с тобой не так, Трахарн? Что с тобой происходит? Почему ты пытаешься помешать мне добраться до этого лагеря?"
+This Pact soldier is dead.,Этот солдат Пакт мёртв.
+I sense the living.,Я чувствую живых существ.
+You there! You seem the type to rush headlong into danger. That fool Tewson could use your aid.,"Эй, ты! Похоже, ты из тех, кто без раздумий бросается в опасности. Тому болвану Тьюсону твоя помощь бы не помешала."
+I cannot divulge my sources to you.,Я не могу раскрывать свои источники информации.
+((267285)),((267285))
+I spoke with Syska in the field hospital. She seemed entirely normal.,Я поговорил с Сиской в полевом госпитале. Она казалась совершенно нормальной.
+Intro LC,Вступление к испытанию
+Pact Caravan Leader,Глава каравана Пакт
+Well of Lament,Колодец скорби
+"Throw a signalling grenade that calls down an artillery barrage, damaging foes.","Бросьте сигнальную гранату, чтобы вызвать артиллерийский обстрел, который нанесет урон врагам."
+Chill Radius,Радиус заморозки
+"Throw a grenade that explodes in an icy explosion, chilling foes.","Бросьте гранату, которая взрывается ледяным взрывом, замораживая врагов."
+Throw a signalling grenade to order a ballista strike that cripples foes.,"Бросьте сигнальную гранату, чтобы вызвать залп баллисты, который оглушит врагов."
+Inspect Troops,Осмотреть войска
+Inspect Troops—Target,Осмотреть войска — цель
+I hope so. We've seen a huge increase in undead activity while we've been establishing our defenses. I believe a major attack is imminent.,"Надеюсь, что так и будет. За время, пока мы укрепляли нашу оборону, активность нежити резко возросла. Я думаю, крупное нападение неизбежно."
+"We recovered a powerful magical orb from the depths, and explosives from our top demolitionist...but there have been some disturbing...glitches in communication. Fort Trinity is not yet secure.",Мы извлекли мощный магический шар из глубин и забрали взрывчатку у нашего лучшего специалиста по подрывам… но в последнее время наблюдаются некоторые тревожные сбои в связи. Форт Тринити ещё не безопасен.
+"Worst of all, our asura gates aren't functioning and nobody can tell me why. Magical or mechanical failure—saboteurs? It's all very disturbing.","Хуже всего то, что наши асурийские порталы не работают, и никто не может объяснить, почему. Магическая или механическая поломка — это диверсия? Всё это очень тревожно."
+Rise,Восстаньте
+Don't be a fool. Fort Trinity is in danger. Leave us and seal that gate!,Не будьте глупцом. Форт Тринити в опасности. Оставьте нас и запечатайте эти ворота!
+Command Troops,Отдать приказ войскам
+Command Troops—Target,Отдать приказ войскам — цель
+Pact Soldier—Following,Солдат Пакта — Следуя за ним
+I'm glad we've got the dragon's attention. I want Zhaitan to know the names and faces of those who will defeat it.,"Рад, что мы привлекли внимание дракона. Пусть Зайтан узнает имена и лица тех, кто его победит."
+Agreed. I'll wrap things up here and then meet you near the Signal Peak camp.,Договорились. Я закончу здесь и встречусь с тобой у лагеря возле Сигнальной вершины.
+Risen rotmouth[s],Восставший гнилорот[|ый|ые|ые]
+ It is good you have met me., Рад нашей встрече.
+Yes. We don't have long. Copters will be lifting them in here any time now.,"Да, у нас не так много времени. Вертолеты должны доставить их сюда в любой момент."
+The invasion has been pushed back. Forces are regrouping and awaiting reinforcements near the Royal Forum.,Вторжение отбито. Наши войска перегруппировываются и ждут подкрепления возле Королевского форума.
+Pact soldiers are attempting to hold off the Risen as they await reinforcements near the Royal Forum.,"Солдаты Пакт пытаются сдержать натиск восставших, ожидая подкрепления возле Королевского форума."
+Pilot Hauntsky,Пилот Хаунтски
+We can take them!,Мы можем их одолеть!
+Zhaitan's plans must be undone.,Планы Зайтана необходимо сорвать.
+Scuttle these creatures!,Уничтожьте этих тварей!
+Grenth take you all!,Да пребудет с вами Грент!
+Let's wreck Zhaitan's warship.,Давайте уничтожим военный корабль Зайтана.
+For the tribes! For Tyria!,За наши племена! За Тирию!
+The invasion has been pushed back. Forces are regrouping and awaiting reinforcements off the coast of Stentor Cannonade.,Вторжение отбито. Силы перегруппировываются и ждут подкрепления у берегов Стенторской Канонады.
+Pact soldiers are attempting to hold off the Risen as they await reinforcements off the coast of Stentor Cannonade.,"Солдаты Пакт пытаются сдержать натиск восставших, ожидая подкрепления у берегов Стенторской крепости."


### PR DESCRIPTION
Дополнение к [#2](https://github.com/K13or/crowdsource/pull/2). Играл с русификатором, прокси насобирал строк, которых в репозитории нет вообще — проверил по всем батчам.

## Что это

**1575 строк** из `discovered_strings.csv`, отсутствующих в проекте:

- описания черт и навыков (`Striking a chilled foe grants might and life force.<br><c=@reminder>…</c>`)
- элементы интерфейса и системные сообщения (`Unable to find server address…`)
- реплики наставников, тексты заданий
- служебные строки PvP и режимов

Всего прокси выучил 9208 непереведённых строк, но 7626 из них уже есть в ваших батчах — их не трогал, оставил только действительно новые.

## Качество

- **`validate.py`: 0 ошибок**, 8 предупреждений (неразрывные пробелы в юр-текстах, «ты/вы» в одной строке)
- переведено 1575 из 1575, пустых нет

Переводилось так же, как в #2: `translategemma:27b` на двух RTX 5090, для склонений и трудных случаев — Qwen3.6. Разметку защищал механически, а не инструкцией: краевые теги и `[M]/[F]` снимаются перед отправкой и приклеиваются обратно, внутренние (`<c=…>`, `<br>`, `[null]`, `%str1%`, `%%`) маскируются метками, и если после возврата набор не совпал — попытка бракуется. Без этого модель стабильно выбрасывала `<c=@reminder>` и схлопывала `%%` в `%`.

## Формат

Положил **одним файлом** `discovered/discovered_2026-08-05.csv` в формате батчей (`english,translate`). Не стал раскладывать по категориям — вам виднее, куда они относятся, тем более что у вас есть свой механизм для выученных прокси строк. Разложите или влейте как удобно.

Если такой формат неудобен — скажите, переоформлю как батчи по 500 строк.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcddpKjT9GNWSgG6ZF3CRK