### PR TITLE
Канон глоссария: 25 ошибок линтера в слое pn до нуля, плюс дефисные лей-линии

### DIFF
--- a/items/items_069.csv
+++ b/items/items_069.csv
@@ -238,7 +238,7 @@ Mini Lavish Gold Llama,Мини-роскошная золотая лама
 Mini Lavish Llama,Мини-роскошная лама
 Mini Lavish Princess Llama,Мини-роскошная лама-принцесса
 Mini Lavish Silver Llama,Мини-роскошная серебряная лама
-Mini Ley-Line Scavenger,Мини-собиратель магических линий
+Mini Ley-Line Scavenger,Мини-собиратель лей-линий
 Mini Liadri the Concealing Dark,Мини-Лиадри Скрывающая Тьма
 Mini Light Blue and Purple Cuckoo Hatchling,Мини-светло-голубой с фиолетовым птенец кукушки
 Mini Lightning Hydra Head,Мини-голова молниеносной гидры

--- a/items/items_102.csv
+++ b/items/items_102.csv
@@ -163,9 +163,9 @@ Skewed Stairway (Right),Искривлённая лестница (правая)
 Skiff Supercharger 1,Ускоритель скифа 1
 Skiff Supercharger 2,Ускоритель скифа 2
 Skiff Supercharger 3,Ускоритель скифа 3
-Skimmer Ley-Line Adventure: Bronze,Приключение на скиммере по линиям магии: Бронза
-Skimmer Ley-Line Adventure: Gold,Приключение на скиммере по линиям магии: Золото
-Skimmer Ley-Line Adventure: Silver,Приключение на скиммере по линиям магии: Серебро
+Skimmer Ley-Line Adventure: Bronze,Приключение на скиммере по лей-линиям: Бронза
+Skimmer Ley-Line Adventure: Gold,Приключение на скиммере по лей-линиям: Золото
+Skimmer Ley-Line Adventure: Silver,Приключение на скиммере по лей-линиям: Серебро
 Skimmer Relic Scouring: Bronze,Очистка реликвий скиммером: Бронза
 Skimmer Relic Scouring: Gold,Очистка реликвий скиммером: Золото
 Skimmer Relic Scouring: Silver,Очистка реликвий скиммером: Серебро

--- a/items/items_125.csv
+++ b/items/items_125.csv
@@ -259,7 +259,7 @@ Traditional Olmakhan song. <c=@flavor>""""No song so sweet as a young cub''s lau
 "'""Double-click to gain one of 25 random colors commemorating Lion''s Arch of old. Includes six exclusive colors.'","'""Дважды щёлкните, чтобы получить один из 25 случайных цветов, посвященных Старому Львиному Архиву. Включает шесть эксклюзивных цветов.'"
 "'""Double-click to gain one of 25 random colors commemorating the rebirth of Lion''s Arch. Includes six exclusive colors.'","'""Дважды щёлкните, чтобы получить один из 25 случайных цветов в честь возрождения Львиной Арки. Включает шесть эксклюзивных цветов.""'"
 "'""Double-click to transform into a choya. Or don''t.'","«Дважды щёлкните, чтобы превратиться в чойю. Или нет»."
-"'""Double-click to view Priory and Consortium members researching ley-line energy in Lion''s Arch.'","'""Дважды щёлкните, чтобы просмотреть членов Приората и Консорциума, исследующих энергию линий магии в Львином Архиве.""'"
+"'""Double-click to view Priory and Consortium members researching ley-line energy in Lion''s Arch.'","'""Дважды щёлкните, чтобы просмотреть членов Приората и Консорциума, исследующих энергию лей-линий в Львиной Арке.""'"
 "'""Ela Makkay is researching similar objects in Lion''s Arch.'","'""Эла Маккай исследует подобные объекты в Львином Архиве.""'"
 "'""Found by defeating the Void in Dragon''s End.'","'""Найдено победой над Бездной в Драконьем Конце.""'"
 "'""Found in Decima''s Chest in the Mount Balrior raid.'",«Найдено в сундуке Децимы в рейде Балриор».

--- a/new/new_074.csv
+++ b/new/new_074.csv
@@ -93,7 +93,7 @@ Ley energy consumed from the islands,Поглощенная лей-энерги�
 Ley line samples collected: %num1%%%,Собрано образцов лей-линий: %num1%%%
 Ley-Energy Leak,Утечка лей-энергии
 "Ley-Energy Matter Converter, please.","Преобразователь леевой энергии, пожалуйста."
-Ley-Line Infused Jade,"Нефрит, пропитанный энергией линий Лей."
+Ley-Line Infused Jade,"Нефрит, пропитанный энергией лей-линий"
 Ley-Line Overcharge,Перегрузка лей-линий.
 Ley-Line Torrent,Лей-лайн поток
 Ley-Linien-Kartographie,Картография лей-линий.

--- a/pn/pn_names_005.csv
+++ b/pn/pn_names_005.csv
@@ -54,7 +54,7 @@ Disgruntled Vigil Crusader,Недовольный крестоносец Доз�
 Disguised Agent,Замаскированный агент
 Disheartened Refugee,Разочарованный беженец
 Dishwasher,Посудомойщик
-Disoriented Hylek,Дезориентированный хайлек
+Disoriented Hylek,Дезориентированный хилек
 Displaced Agent,Перемещенный агент
 Displaced Beetle,Перемещенный жук
 Displaced Boar,Перемещенный кабан
@@ -391,7 +391,7 @@ Elite Harathi Lancer,Элитный копейщик Харати
 Elite Harathi Trampler,Элитный топтун Харати
 Elite Haunted Aetherblade,Элитный призрачный эфирный клинок
 Elite Healing Coalescence,Элитная исцеляющая коалесценция
-Elite Hylek Tlamatini,Элитный хайлек-тламатини
+Elite Hylek Tlamatini,Элитный хилек-тламатини
 Elite Ice Drake,Элитный ледяной дрейк
 Elite Ice Wurm,Элитный ледяной червь
 Elite Immunized Blue Ooze,Элитная иммунизированная синяя слизь

--- a/pn/pn_names_008.csv
+++ b/pn/pn_names_008.csv
@@ -153,12 +153,12 @@ Hwaichin Thundersquawk,Хвайчин Громовой Крик
 Hydra,Гидра
 HYEOKSIN JADE,ХЁКСИН НЕФРИТ
 Hylek,Хилек
-Hylek Alchemist,Хайлек-алхимик
-Hylek Caster,Хайлек-заклинатель
-Hylek Conetl,Хайлек-конетль
-Hylek Guard,Хайлек-страж
-Hylek Nahualli,Хайлек-науалли
-Hylek Pilgrim,Хайлек-паломник
+Hylek Alchemist,Хилек-алхимик
+Hylek Caster,Хилек-заклинатель
+Hylek Conetl,Хилек-конетль
+Hylek Guard,Хилек-страж
+Hylek Nahualli,Хилек-науалли
+Hylek Pilgrim,Хилек-паломник
 Hypnotized Carnival Performer,Загипнотизированный артист карнавала
 Hypnotized Spectator,Загипнотизированный зритель
 Hywel,Хивел

--- a/pn/pn_names_009.csv
+++ b/pn/pn_names_009.csv
@@ -25,7 +25,7 @@ Jorg,Джорг
 Jormag,Йормаг
 Jormag Experiment,Эксперимент Йормага
 Jormag Rising,Восстание Йормага
-Jormag's World,Мир Джормага
+Jormag's World,Мир Йормага
 Jorn Kudebeh,Йорн Кудебе
 Jortag,Джортаг
 Jorund,Йорунд

--- a/pn/pn_names_010.csv
+++ b/pn/pn_names_010.csv
@@ -104,7 +104,7 @@ Ley-Infused Branded Forgotten Priest,"Забытый жрец, отмеченн�
 Ley-Infused Lodestone,Лей-инфузированный магнетит
 Ley-Infused Weapons,Напитанное магией оружие
 Ley-Line Anomaly,Аномалия Лей-линий
-Ley-Line Disruption Pod,Капсула искажения магических линий
+Ley-Line Disruption Pod,Капсула искажения лей-линий
 Leylak,Лейлак
 Liadri the Concealing Dark,Лиадри Скрывающая Тьму
 Liath,Лиат

--- a/pn/pn_names_011.csv
+++ b/pn/pn_names_011.csv
@@ -466,9 +466,9 @@ Mysterious Bartender,Таинственный бармен
 Mysterious Figure,Таинственная фигура
 Mysterious Skritt,Таинственный скритт
 Mystic Clovers,Мистические клеверы
-Mystic Forge,Мистическая кузня
-Mystic Forge Attendant,Служитель Мистической кузни
-Mystic Forge Skritt,Скритт Мистической кузни
+Mystic Forge,Мистическая кузница
+Mystic Forge Attendant,Служитель Мистической кузницы
+Mystic Forge Skritt,Скритт Мистической кузницы
 Mystic Forgery,Мистическая подделка
 Mystic Wave,Мистическая волна
 Myung-Soo,Мюн-Су

--- a/pn/pn_names_012.csv
+++ b/pn/pn_names_012.csv
@@ -173,8 +173,8 @@ Obsidian Destroyer Troll,Тролль-разрушитель обсидиана
 Obsidian Shards,Обсидиановые осколки
 Obsolete SCRAP 80-T,Устаревший СКРАП 80-Т
 Occam,Оккам
-Occuintl Hylek,Хайлек из Оккуинтля
-Occuintl Hylek Warrior,Воин хайлеков из Оккуинтля
+Occuintl Hylek,Хилек из Оккуинтля
+Occuintl Hylek Warrior,Воин хилеков из Оккуинтля
 Occuintl Leader,Лидер Оккуинтля
 Ocean,Океан
 Ocean Bloom,Океанский цветок

--- a/pn/pn_names_014.csv
+++ b/pn/pn_names_014.csv
@@ -50,7 +50,7 @@ Risen Farmer,Восставший фермер
 Risen Fisher,Восставший рыбак
 Risen Gorilla,Восставшая горилла
 Risen Human,Восставший человек
-Risen Hylek,Восставший Хайлек
+Risen Hylek,Восставший хилек
 Risen Knight,Восставший рыцарь
 Risen Krait Damoss,Восставший краит Дамосс
 Risen Krait Hypnoss,Восставший краит Гипносс

--- a/pn/pn_names_016.csv
+++ b/pn/pn_names_016.csv
@@ -204,7 +204,7 @@ Tlamatini,Тламатини
 Toad,Жаба
 Toby,Тоби
 Tochzotl,Точцотль
-Togatl Hylek,Тогатл-хайлек
+Togatl Hylek,Тогатл-хилек
 Togg,Тогг
 Togo,Того
 Togonn Windmane,Тогонн Ветрогрив

--- a/pn/pn_names_017.csv
+++ b/pn/pn_names_017.csv
@@ -39,7 +39,7 @@ Veteran Branded Djinn,Ветеран: клейменый джинн
 Veteran Branded Dredge Excavator,Ветеран: клейменый землекоп-дредж
 Veteran Branded Dredge Miner,Ветеран: клейменый шахтер-дредж
 Veteran Branded Earth Elemental,Ветеран: клейменый элементаль земли
-Veteran Branded Ley-Line Anomaly,Ветеран: клейменая аномалия магической линии
+Veteran Branded Ley-Line Anomaly,Ветеран: клейменая аномалия лей-линии
 Veteran Branded Ravager,Ветеран: клейменый опустошитель
 Veteran Bristleback,Ветеран: щетиноспин
 Veteran Brotherhood Scrapper,Ветеран: мусорщик Братства
@@ -236,7 +236,7 @@ Veteran Risen Corrupter,Ветеран: Восставший осквернит�
 Veteran Risen Drake,Ветеран: Восставший дрейк
 Veteran Risen Eagle,Ветеран: Восставший орел
 Veteran Risen Farmer,Ветеран: Восставший фермер
-Veteran Risen Hylek's Pet,Ветеран: Питомец восставшего хайлека
+Veteran Risen Hylek's Pet,Ветеран: Питомец восставшего хилека
 Veteran Risen Krait Slavemaster,Ветеран: Восставший рабовладелец краит
 Veteran Risen Noble,Ветеран: Восставший дворянин
 Veteran Risen Ravager,Ветеран: Восставший опустошитель

--- a/pn/pn_names_018.csv
+++ b/pn/pn_names_018.csv
@@ -204,7 +204,7 @@ Zenith Cesta,Цеста Зенита
 Zenith Harbinger,Предвестник Зенита
 Zenith Impaler,Копьё Зенита
 Zenith Kris,Крис Зенита
-Zenith Reaver,Разоритель Зенита
+Zenith Reaver,Жнец Зенита
 Zenith Scroll,Свиток Зенита
 Zenith Thunder,Гром Зенита
 Zenith Wake,Кильватер Зенита

--- a/pn/pn_terms_001.csv
+++ b/pn/pn_terms_001.csv
@@ -78,7 +78,7 @@ Head Slaver,Главный работорговец
 Holographic dragon minions,Голографические прислужники дракона
 Hullgardeners,Халлгарднеры
 hylek,хилек
-Hylek tribes,Племена хайлеков
+Hylek tribes,Племена хилеков
 Imperator,Император
 Inquest,Инквест
 Iron Legion,Железный легион

--- a/pn/pn_world_map_003.csv
+++ b/pn/pn_world_map_003.csv
@@ -362,7 +362,7 @@ Duran Brothers' Docks,Доки братьев Дюран
 Duress: Heitor's Territory,Принуждение: Территория Хейтора
 Duress: Nayos,Принуждение: Найос
 Duress: The Wizard's Tower,Принуждение: Башня Волшебника
-Durgar's Homestead,Родовое поместье Дургар
+Durgar's Homestead,Усадьба Дургара
 Durios Gulch,Ущелье Дуриоса
 Durios Gulch Emergency Waypoint,Аварийная путевая точка Дуриос
 Durios Post,Пост Дуриос

--- a/pn/pn_world_map_006.csv
+++ b/pn/pn_world_map_006.csv
@@ -105,15 +105,15 @@ Leopard's Tail Valley,Долина Леопардового хвоста
 Leopardshadow Shrine,Святилище Тени леопарда
 Leviathan's Gullet,Глотка Левиафана
 Ley Flow,Поток магии
-Ley Line Boneyard,Кладбище магических линий
-Ley Line Hub,Узел магических линий
-Ley Line Node,Точка магической линии
-Ley Line Overlook,Обзор магических линий
+Ley Line Boneyard,Кладбище лей-линий
+Ley Line Hub,Узел лей-линий
+Ley Line Node,Точка лей-линии
+Ley Line Overlook,Обзор лей-линий
 Ley-Drowned Quarry,Затопленный магией карьер
-Ley-Line Confluence,Слияние магических линий
-Ley-Line Confluence Waypoint,Точка перехода к месту схождения линий лей.
-Ley-Line Islet,Островок магических линий
-Ley-Line Nexus,Нексус магических линий
+Ley-Line Confluence,Слияние лей-линий
+Ley-Line Confluence Waypoint,Путевая точка Слияния лей-линий
+Ley-Line Islet,Островок лей-линий
+Ley-Line Nexus,Нексус лей-линий
 Leyfinder Research Facility,Исследовательский центр Лейфайндер
 Leylit Retreat,Убежище Лейлит
 Leystone Axis,Ось Лейстоун

--- a/pn/pn_world_map_011.csv
+++ b/pn/pn_world_map_011.csv
@@ -40,7 +40,7 @@ Toran Hollow Waypoint,Путевая точка Лощины Торана
 Torment's Watch,Дозор Мучений
 Torn from the Sky,Сорванные с небес
 Torpor Tavern,Таверна «Оцепенение»
-Torstvedt Homestead Waypoint,Путевая точка у поместья Торстведт
+Torstvedt Homestead Waypoint,Путевая точка у усадьбы Торстведт
 Tournament Battlegrounds,Турнирные поля боя
 Tower Courtyard Waypoint,Путь к башне
 Tower Down,Башня пала

--- a/pn_additions.csv
+++ b/pn_additions.csv
@@ -259,7 +259,7 @@ Mini Lavish Gold Llama,Мини-роскошная золотая лама,pn_na
 Mini Lavish Llama,Мини-роскошная лама,pn_names
 Mini Lavish Princess Llama,Мини-роскошная лама-принцесса,pn_names
 Mini Lavish Silver Llama,Мини-роскошная серебряная лама,pn_names
-Mini Ley-Line Scavenger,Мини-собиратель магических линий,pn_names
+Mini Ley-Line Scavenger,Мини-собиратель лей-линий,pn_names
 Mini Liadri the Concealing Dark,Мини-Лиадри Скрывающая Тьма,pn_names
 Mini Light Blue and Purple Cuckoo Hatchling,Мини-светло-голубой с фиолетовым птенец кукушки,pn_names
 Mini Lightning Hydra Head,Мини-голова молниеносной гидры,pn_names

--- a/ui/ui_089.csv
+++ b/ui/ui_089.csv
@@ -269,10 +269,10 @@ Ley-Line Energy Is Accumulating in Iron Marches,Энергия Лей-линий
 Ley-Line Energy Is Accumulating in Timberline Falls,Энергия Лей-линий накапливается в Тимберлайн-Фоллс
 Ley-Line Extractor Manual,Руководство по экстрактору лей-линий
 Ley-Line Focus Core[s],[Ядро|Ядра|Ядер] лей-линии фокуса
-Ley-Line Gliding,Парение на линиях магии
+Ley-Line Gliding,Парение на лей-линиях
 Ley-Line Greatsword Core[s],[Ядро|Ядра|Ядер] лей-линии большого меча
 Ley-Line Hammer Core[s],[Ядро|Ядра|Ядер] лей-линии молота
-Ley-line Imbued,Пропитанный магическими линиями
+Ley-line Imbued,Пропитанный лей-линиями
 Ley-Line Infused Tool[s],Инструмент[|а|ов] пропитанный магией линий
 Ley-Line Kick,Удар лей-линий
 Ley-Line Leap,Прыжок лей-линий

--- a/ui/ui_096.csv
+++ b/ui/ui_096.csv
@@ -1,5 +1,5 @@
 english,translate
-Mini Ley-Line Scavenger[s],[Мини-искатель|Мини-искателя|Мини-искателей] линий магии
+Mini Ley-Line Scavenger[s],[Мини-искатель|Мини-искателя|Мини-искателей] лей-линий
 Mini Ley-Line Spark,Мини-искра лей-линии
 Mini Light Blue and Purple Cuckoo Hatchling[s],[Мини-птенец|Мини-птенца|Мини-птенцов] кукушки светло-голубой и фиолетовый
 "Mini Light Thief[pl:""Thieves""]",Мини-вор[|а|ов] света

--- a/ui/ui_105.csv
+++ b/ui/ui_105.csv
@@ -131,7 +131,7 @@ Outreach 4: Connect with the wayward wisp atop the ruins in the Golden Lake.,С�
 Outrider Warclaw Skin[s],[Облик|Облика|Обликов] боевого когтя «Дозорный»
 Outrun a Centaur,Обогнать кентавра
 Outside the Lost Altar.,Снаружи Затерянного Алтаря.
-Outsmart the chak crown and disrupt the chak in the Ley-Line Confluence.,Перехитрите корону чак и нарушьте действия чак в Слиянии Линий Магии.
+Outsmart the chak crown and disrupt the chak in the Ley-Line Confluence.,Перехитрите корону чак и нарушьте действия чак в Слиянии лей-линий.
 Outstanding work,Отличная работа
 "Over by the southwest exit, we have Efo. He's looking for a volunteer to escort one of our novices, Woopa, around to various field sites.","У юго-западного выхода стоит Эфо. Он ищет добровольца, чтобы сопроводить одну из наших новичков, Вупу, по различным полевым точкам."
 Overall Fun,Общее удовольствие

--- a/ui/ui_112.csv
+++ b/ui/ui_112.csv
@@ -16,7 +16,7 @@ Purchase the Airship Essence from an Itzel vendor.,Купить Эссенцию
 Purchase the analytical charm from Lyhr in the Wizard's Tower.,Купите аналитический амулет у Лира в Башне Чародея.
 Purchase the associated Historical Weapon Diagram from Requisitions Specialists in Gyala Delve to unlock.,"Купите соответствующий исторический чертеж оружия у специалистов по заявкам в Ущелье Гиалы, чтобы разблокировать."
 Purchase the Aurillium Essence from an Exalted vendor.,Купить Эссенцию Ауриллиума у торговца Возвышенных.
-Purchase the Ley-Line Crystal Essence from a Nuhoch vendor.,Купить Эссенцию Кристалла Линий Магии у торговца нухок.
+Purchase the Ley-Line Crystal Essence from a Nuhoch vendor.,Купить Эссенцию кристалла лей-линий у торговца нухок.
 Purchase the Mission Slot: PvE unlock from the market.,Купите слот миссии: Разблокировка PvE на рынке.
 Purchase the Mission Slot: PvP unlock from the arena.,Купите слот для задания: PvP-разблокировка на арене.
 Purchase the Mission Slot: WvW unlock from the war room.,Купите слот для задания: WvW-разблокировка в военной комнате.

--- a/ui/ui_131.csv
+++ b/ui/ui_131.csv
@@ -87,7 +87,7 @@ Show Timestamps,Показать метки времени
 Show unbuilt upgrades.,Показывать непостроенные улучшения.
 Show unusable items,Показывать непригодные предметы
 Show usable object names as overhead text.,Показывать названия используемых объектов в виде текста над головой.
-Show your power by embodying energy and achieving a rank of silver or better in The Ley-Line Run adventure of Tangled Depths.,"Продемонстрируйте свою силу, воплощая энергию и достигнув серебряного ранга или выше в приключении «Бег по линиям магии» в Запутанных глубинах."
+Show your power by embodying energy and achieving a rank of silver or better in The Ley-Line Run adventure of Tangled Depths.,"Продемонстрируйте свою силу, воплощая энергию и достигнув серебряного ранга или выше в приключении «Забег по лей-линиям» в Запутанных глубинах."
 Show your power over spirits by defeating the Ascalonian soldiers of Duke Barradin's army in the Battle in the Vault under the Old Duke's Estate in Plains of Ashford.,"Покажите свою власть над духами, победив асклонских солдат армии герцога Баррадина в битве в Хранилище под поместьем Старого герцога на Равнинах Эшфорд."
 Show your power over spirits by drawing out and destroying the Demagogue's spirit at Aurora's Remains in Brisban Wildlands.,"Покажите свою власть над духами, выманив и уничтожив дух Демагога у Останков Авроры в Дебрях Брисбана."
 Show your power over spirits by killing Siegemaster Lormar in the ruins of Ascalon City in the Plains of Ashford.,"Покажите свою власть над духами, убив Осадного мастера Лормара в руинах города Аскалон на Равнинах Эшфорд."

--- a/validate.py
+++ b/validate.py
@@ -204,6 +204,12 @@ def ban_pattern(ban):
         parts.append(re.escape(word))
     return r'(?<![А-Яа-яЁё])' + r'\s+'.join(parts) + r'(?![А-Яа-яЁё])'
 
+# Пробел внутри составного EN-термина: в оригинале то же имя встречается и через
+# дефис — «Ley Line Nexus» и «Ley-Line Nexus» лежат в корпусе рядом. re.escape
+# пробел экранирует, поэтому правило видело только вариант с пробелом, а дефисные
+# оригиналы проходили мимо (по корпусу на 21.08.2026 так пряталось 15 строк).
+ESC_SPACE = re.escape(' ')
+
 def load_glossary_bans(path=None):
     path = path or os.path.join(os.path.dirname(os.path.abspath(__file__)), 'GLOSSARY.md')
     rules = []
@@ -224,7 +230,8 @@ def load_glossary_bans(path=None):
             # Апостроф в имени бывает и типографским: «Divinity's Reach» в одних
             # строках игры, «Divinity’s Reach» в других. Правило, собранное по
             # ASCII-апострофу, вторые молча пропускало.
-            en_re = re.compile('|'.join(r'\b' + re.escape(e).replace("'", "['’ʼ]") + r'\w{0,3}\b'
+            en_re = re.compile('|'.join(r'\b' + re.escape(e).replace("'", "['’ʼ]")
+                                                .replace(ESC_SPACE, '[ -]') + r'\w{0,3}\b'
                                         for e in ens), re.I)
             # Если «НЕ так» отличается от канона только регистром («Дозор Духов» /
             # «Дозор духов») — правило про регистр, ищем точно. Иначе регистр не важен.

--- a/zone/zone_036.csv
+++ b/zone/zone_036.csv
@@ -468,7 +468,7 @@ Examine it more closely.,Изучи его внимательнее.
 Examine it.,Изучить его.
 Examine more closely.,Присмотритесь повнимательнее.
 "Examine the ""Resources"" file.",Изучите файл «Ресурсы».
-Examine the Ley-Line Energies,Изучите потоки энергии линий Лей.
+Examine the Ley-Line Energies,Изучите потоки энергии лей-линий
 Examine the armor scrap.,Осмотреть обрывок брони.
 Examine the artifact.,Изучить артефакт.
 Examine the banner more closely.,Осмотреть знамя более внимательно.

--- a/zone/zone_097.csv
+++ b/zone/zone_097.csv
@@ -79,7 +79,7 @@ Levvi's figured out how to detect and handle the traps he's set for us. Take one
 "Ley energies have normalized. Not just here, but everywhere.","Энергии лей-линий нормализовались. Не только здесь, но и повсюду."
 "Ley energy powers this whole place, and this ley conduit is blown.","Магическая энергия питает все это место, и этот энергетический канал поврежден."
 "Ley energy seeps from the top of the device, as if the connection to Xera's bloodstones was severed.","Энергия лея просачивается из верхней части устройства, словно связь с кровяными камнями Ксеры была разорвана."
-"Ley-Line Core Status: Online<br>Ley-Line Core has been operational for seven years, eleven months, twenty-two days, nine hours, two minutes, fifty-three seconds.","Статус ядра линии Лей: в сети<br>Ядро линии Лей работает уже семь лет, одиннадцать месяцев, двадцать два дня, девять часов, две минуты и пятьдесят три секунды."
+"Ley-Line Core Status: Online<br>Ley-Line Core has been operational for seven years, eleven months, twenty-two days, nine hours, two minutes, fifty-three seconds.","Статус ядра лей-линии: в сети<br>Ядро лей-линии работает уже семь лет, одиннадцать месяцев, двадцать два дня, девять часов, две минуты и пятьдесят три секунды."
 "Ley-energy concentrations... Hmm. So this is a map? Ah, I see. This one is here, and that one is Tarir. What's this one?","Концентрации энергии линий... Хм. Значит, это карта? А, понятно. Эта здесь, а та — Tarir. А что это за точка?"
 Ley-infused sand?,"Песок, пропитанный энергией стихий?"
 Lhezza sent over her research notes to aid us.,Lhezza прислала свои исследовательские заметки нам в помощь.


### PR DESCRIPTION
Два коммита. Первый закрывает те 25 ошибок линтера, что оставались после PR #8,
второй чинит правило, из-за которого часть того же дефекта была линтеру не видна.

## 1. Слой pn — 31 строка

Все 25 ошибок сидели в слое имён. Правил батчи `pn/*.csv`, а не через `pnset`:
`cmd_frombatches` читает батчи слоя отдельным блоком и при расхождении пишет в bin
значение из батча, так что правка мимо батча живёт только до следующей сборки.

| класс | строк | канон |
|---|---|---|
| хайлеки | 14 | хилеки |
| лей-линии | 10 | лей-линия |
| Мистическая кузня | 3 | Мистическая кузница |
| поместье | 2 | усадьба |
| Джормаг | 1 | Йормаг |
| разоритель | 1 | Жнец |

Ничего не выдумывал — все шесть терминов канон уже держал рядом, в тех же файлах:
`pn_names_008` строкой выше стоит «Hylek → Хилек», `pn_terms_001` — «hylek → хилек»,
`pn_names_009` — «Эксперимент Йормага» и «Восстание Йормага», `pn_names_018` —
«Предвестник Зенита» и «Крис Зенита». По корпусу «хилек*» встречается 651 раз
против 15 «хайлек*», «Мистическая кузница» — 913 форм.

Две строки потребовали решения:

* `Durgar's Homestead` — было «Родовое поместье Дургар», стало «Усадьба Дургара»:
  имя в родительном, как у соседа по файлу `Durios Gulch` → «Ущелье Дуриоса»;
* `Torstvedt Homestead Waypoint` → «Путевая точка у усадьбы Торстведт» — ровно так
  эта строка уже переведена в `discovered_2026-08-05.csv:964`.

Заодно `Ley-Line Confluence Waypoint` приведён к шаблону путевых точек (669 из 870
в `pn_world_map` — «Путевая точка X») и лишён точки в конце названия.

## 2. Правило глоссария не видело дефис — 15 строк

`en_re` собирается из первой колонки GLOSSARY.md через `re.escape`, а он экранирует
пробел. Поэтому «ley line» искалось буквально с пробелом, и оригиналы через дефис —
`Ley-Line Nexus`, `Ley-Line Gliding`, `Mini Ley-Line Scavenger` — правило пропускало
молча. Теперь пробел внутри составного термина ищется как `[ -]`.

Дыра прятала 15 строк, все про лей-линии. Остальные 42 многословных термина
глоссария дефисных вариантов в корпусе не имеют — проверил по всем 477 374 строкам,
новых срабатываний правило не даёт.

Из поправленного стоит отметить:

* `Mini Ley-Line Scavenger` лежал сразу в трёх местах — `items_069`, `ui_096` и
  `pn_additions.csv`, откуда берёт `pnset`;
* «Бег по линиям магии» → «Забег по лей-линиям» (`ui_131`): так это приключение
  зовётся в `ach_029` и `ui_145`;
* «Эссенцию Кристалла Линий Магии» → «Эссенцию кристалла лей-линий» (`ui_112`),
  как в `items_062:285`;
* `items_125:208` — оригинал лежит в CSV-обёртке с удвоенным апострофом
  (`Lion''s Arch`), из-за чего правило про Lion's Arch на него не срабатывает, и
  «Львиный Архив» дожил до сегодня. Раз строка всё равно правилась — привёл к канону.

## Гейты

`python validate.py` по репозиторию: **0 ошибок** (было 25), 9415 предупреждений
против 9418 — минус три про заглавные в «Линий Магии». В bin не писал, `.dict_bak`
не трогал: правка целиком в батчах, применится следующей сборкой `frombatches`.

## Что осталось за кадром

Пока разбирался, насчитал **62 строки**, где оригинал про ley line, а в переводе
термина нет вовсе: «поток магии», «энергетические линии», «леевые линии», «линии
разлома», «лей-пушка», «леечные насосы». Линтер их не увидит и после этой правки —
в GLOSSARY.md в колонке «НЕ так» таких форм нет. Плюс 11 строк, где английское
`Ley-Line` оставлено латиницей прямо в переводе.

Если скажете — сделаю отдельным PR: пройду эти 62 строки и допишу в глоссарий
недостающие запретные формы, чтобы класс больше не отрастал. Ничего не трогаю до
вашего слова.

Ещё висит #9 по категории `site` — там от вас нужен выбор варианта, по нему тоже
ничего не делаю.
