### PR TITLE
Боны и состояния: подписи интерфейса и параметры умений, 15 строк

### DIFF
--- a/ach/ach_024.csv
+++ b/ach/ach_024.csv
@@ -435,7 +435,7 @@ Remember the carrot and top hat.,Не забудьте морковку и ци�
 Remind Niles about the honored ritual of the Zephyrites.,Напомните Niles о священном ритуале Zephyrites.
 Remove  conditions from yourself or allies.,Снимите состояния с себя или союзников.
 Remove  instances of toxic pollen.,Удалите  слои токсичной пыльцы.
-"Remove bleeding, blinding, burning, chill, confusion, crippling, fear, immobilization, poison, vulnerability, or weakness from yourself or your allies.","Снимите кровотечение, ослепление, горение, замедление, замешательство, увечье, страх, обездвиживание, отравление, уязвимость или слабость с себя или своих союзников."
+"Remove bleeding, blinding, burning, chill, confusion, crippling, fear, immobilization, poison, vulnerability, or weakness from yourself or your allies.","Снимите кровотечение, слепоту, горение, заморозку, замешательство, хромоту, страх, неподвижность, отравление, уязвимость или слабость с себя или своих союзников."
 "Remove the remaining obstacles preventing a fully attended world summit, and represent the Pact at the summit.","Устраните оставшиеся препятствия, мешающие проведению всемирного саммита, и представьте Пакт на этом саммите."
 Renowned Adventurer: Crystal Oasis,Известный искатель приключений: Crystal Oasis
 Renowned Adventurer: Desert Highlands,Известный искатель приключений: Desert Highlands

--- a/discovered/discovered_2026-08-05.csv
+++ b/discovered/discovered_2026-08-05.csv
@@ -1870,7 +1870,7 @@ Build 30 stacks to gain increased magic find and bonus rewards, and a 60%% damag
 Накопите 30 стаков, чтобы получить повышенный шанс выпадения магических предметов и дополнительные награды, а также снижение урона от состояний на 60%% от врагов с сущностью доблести на 30 минут."
 "In Dragon's End, gain 10 seconds of might, fury, swiftness, regeneration, and protection when entering and exiting combat. 20%% increase to health and outgoing damage. 10%% increase to kill experience.
 
-Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи, ярости, быстроты, регенерации и защиты. Увеличение здоровья и исходящего урона на 20%%. Увеличение опыта за убийство на 10%%.
+Each stack of this effect will grant access to a bonus chest at the end of the Dragon's End's meta-event.","В локации «Конец Дракона» при входе и выходе из боя получайте 10 секунд мощи, ярости, быстроты, регенерации и протекции. Увеличение здоровья и исходящего урона на 20%%. Увеличение опыта за убийство на 10%%.
 
 Каждый стак этого эффекта позволит получить доступ к дополнительному сундуку в конце мета-события «Конец Дракона»."
 "Stats only apply in WvW:

--- a/items/items_051.csv
+++ b/items/items_051.csv
@@ -252,7 +252,7 @@ Grant might and fury to nearby allies after using a healing skill.,Даёт мо
 Grant protection and magnetic aura to allies after using an elite skill.,Даёт защиту и магнитную ауру союзникам после использования элитного умения.
 Grant superspeed to nearby allies after using an elite skill.,Наделите союзников вокруг себя сверхскоростью после применения умения элиты.
 "Grant superspeed, might, and fury to nearby allies after using an elite skill.","Даруйте сверхскорость, мощь и ярость союзникам поблизости после использования элитного умения."
-"Grant yourself aegis, quickness, swiftness, resistance, and might when striking an enemy with your mount's <c=@abilitytype>engage</c> skill.","Даруйте себе эгиду, проворство, скорость, сопротивляемость и мощь, когда поражаете врага умением <c=@abilitytype>атаки</c> вашего скакуна."
+"Grant yourself aegis, quickness, swiftness, resistance, and might when striking an enemy with your mount's <c=@abilitytype>engage</c> skill.","Даруйте себе эгиду, проворство, быстроту, сопротивляемость и мощь, когда поражаете врага умением <c=@abilitytype>атаки</c> вашего скакуна."
 Grant yourself and nearby allies superspeed when you enter or exit stealth.,"Даруйте себе и союзникам поблизости сверхскорость, когда вы входите или выходите из невидимости."
 Grants +50 fishing power for one hour. Persists across map changes.,Дарует +50 к силе рыбалки на один час. Сохраняется при смене карты.
 "Grants 1,000 karma and a wooden lure, and unlocks the Fishing Mastery track.

--- a/new/new_118.csv
+++ b/new/new_118.csv
@@ -459,7 +459,7 @@ Ilya,Илья
 Imer,Имер
 Immediate,Немедленное
 Immersive,Погружающий
-Immobilize,Обездвиживание
+Immobilize,Неподвижность
 Immobilizes,Обездвиживает
 Immobulus,Иммобулус
 Immolate,Сожжение

--- a/skills/skills_013.csv
+++ b/skills/skills_013.csv
@@ -184,7 +184,7 @@ Supercharged Damage Increase,Увеличение урона от суперза
 Superconducting Signet,Сверхпроводящая печать
 Supernova,Сверхновая
 Supersonic Arrow,Сверхзвуковая стрела
-Superspeed,Суперскорость
+Superspeed,Сверхскорость
 Supply Crate,Ящик с припасами
 Surge of Darkness,Всплеск тьмы
 Surge of the Mists,Всплеск Туманов

--- a/traits/traits_001.csv
+++ b/traits/traits_001.csv
@@ -172,7 +172,7 @@ All for One,Один за всех
 All's Well That Ends Well,"Все хорошо, что хорошо кончается"
 Allied Duration,Длительность для союзников
 Allies' Aid,Помощь союзникам
-Ally Superspeed Radius,Радиус суперскорости для союзников
+Ally Superspeed Radius,Радиус сверхскорости для союзников
 Alpha Focus,Альфа-фокус
 Altered Chord,Измененный аккорд
 Altruistic Aspect,Альтруистический аспект

--- a/ui/ui_050.csv
+++ b/ui/ui_050.csv
@@ -305,7 +305,7 @@ Damage nearby foes and chill them for 1 second when you swap to this weapon whil
 Damage nearby foes and chill them for 1.5 seconds when you swap to this weapon while in combat.<br><c=@reminder>(Cooldown: 9 Seconds)</c>,Наносит урон ближайшим врагам и замедляет их на 1.5 секунды при смене на это оружие в бою.<br><c=@reminder>(Перезарядка: 9 секунд)</c>
 Damage nearby foes and chill them for 2 seconds when you swap to this weapon while in combat.<br><c=@reminder>(Cooldown: 9 Seconds)</c>,Наносит урон ближайшим врагам и замедляет их на 2 секунды при смене на это оружие в бою.<br><c=@reminder>(Перезарядка: 9 секунд)</c>
 Damage On Skill Use,Урон при использовании навыка
-"Damage over time conditions. (Bleeding, Burning, Confusion, Poison, Torment.)","Состояния урона с течением времени. (Кровотечение, Горение, Замешательство, Отравление, Мучение.)"
+"Damage over time conditions. (Bleeding, Burning, Confusion, Poison, Torment.)","Состояния урона с течением времени. (Кровотечение, Горение, Замешательство, Отравление, Боль.)"
 Damage per Condition,Урон за состояние
 Damage Received,Полученный урон
 Damage Stationary,Урон в неподвижности

--- a/ui/ui_053.csv
+++ b/ui/ui_053.csv
@@ -36,7 +36,7 @@ Defensive Horn,Оборонительный рог
 Defensive Plays,Оборонительный
 Defensive Slam,Защитный удар
 Defensive Stance,Оборонительная стойка
-"Defensive. (Protection, Resolution, Resistance, Stability, Aegis.)","Защитный. (Защита, Решимость, Сопротивление, Непоколебимость, Эгида.)"
+"Defensive. (Protection, Resolution, Resistance, Stability, Aegis.)","Защитный. (Протекция, Решимость, Сопротивляемость, Устойчивость, Эгида.)"
 Defiance Bar,Шкала непокорности
 Defiance Bar: %str1%/%str2%,Шкала непокорности: %str1%/%str2%
 "Defiance bars are grayed out when locked, and they are blue when unlocked. Look for skills that have Defiance Break or apply control effects to deplete the defiance bar and make the target vulnerable for a short period of time.","Шкалы непокорности серые, когда заблокированы, и синие, когда разблокированы. Ищите навыки с эффектом «Прорыв непокорности» или накладывающие эффекты контроля, чтобы истощить шкалу непокорности и сделать цель уязвимой на короткое время."

--- a/ui/ui_058.csv
+++ b/ui/ui_058.csv
@@ -407,7 +407,7 @@ Ebonmane's Apothecary Inscription[s],[Гравировка|Гравировки|
 Ebony Orb[s],[Эбеновая сфера|Эбеновые сферы|Эбеновых сфер]
 Ebuzzabeth's Beehive,Улей Эбуззабет
 "Ecaban was here, and he was incredibly handsome and brave, and he laughed right in Grenth's stupid face, right up until the end.","Экабан был здесь, и он был невероятно красив и храбр, и смеялся прямо в глупое лицо Гренту, до самого конца."
-Echo Immobilize,Эхо обездвиживания
+Echo Immobilize,Эхо неподвижности
 Echo of the Unclean,Эхо Нечистого
 Echo Resolution,Эхо решимости
 "Echo[pl:""Echoes""] of the Dragonvoid",Эхо Драконьего Пустоты

--- a/ui/ui_066.csv
+++ b/ui/ui_066.csv
@@ -14,7 +14,7 @@ First weapon found.,Первое оружие найдено.
 "First, in Drytop: Look out over a fallen people...","Первое, в Сухой Вершине: посмотри на павший народ..."
 "First, in Fields of Ruin: Go where the mightiest of the walled city rest.","Первое, на Полях Руин: отправляйся туда, где покоятся сильнейшие из укреплённого города."
 "First, you must train at sharing fire. Take a torch, and light every brazier you find. Return to a flamebearer when you are ready to undertake more advanced study.","Сначала ты должен научиться делиться огнём. Возьми факел и зажги все жаровни, которые найдёшь. Вернись к огненосцу, когда будешь готов к более продвинутому обучению."
-First-Hit Immobilize,Обездвиживание при первом ударе
+First-Hit Immobilize,Неподвижность при первом ударе
 First-Hit Might,Могущество при первом ударе
 First-Hit Weakness,Слабость первого удара
 First-Pulse Stability,Стабильность первого импульса

--- a/ui/ui_082.csv
+++ b/ui/ui_082.csv
@@ -408,7 +408,7 @@ Initial Burning,Начальное Горение
 Initial Cripple,Начальное Калечение
 Initial Fury,Начальная Ярость
 Initial Home World Select,Выбор начального домашнего мира
-Initial Immobilize,Начальное Обездвиживание
+Initial Immobilize,Начальная неподвижность
 Initial Kalla's Fervor,Начальное Рвение Каллы
 Initial Might,Начальная мощь
 Initial Quickness,Начальная Скорость

--- a/ui/ui_098.csv
+++ b/ui/ui_098.csv
@@ -34,7 +34,7 @@ Moa Racing,Гонки на моа
 MOA RACING!,ГОНКИ МОА!
 Moa Unarmed,Моа без оружия
 Mobile Spirits,Мобильные духи
-"Mobility-affecting conditions. (Chill, Cripple, Fear, Immobilize.)","Состояния, влияющие на подвижность. (Озноб, Увечье, Страх, Обездвиживание.)"
+"Mobility-affecting conditions. (Chill, Cripple, Fear, Immobilize.)","Состояния, влияющие на подвижность. (Заморозка, Хромота, Страх, Неподвижность.)"
 Mocha Dye[s],[Краска|Краски|Красок] «Мокко»
 Mocking Minstrel Treasure Finisher!,Финишер сокровищ «Насмешливый менестрель»!
 Mode Activation Guide,Руководство по активации режима

--- a/ui/ui_113.csv
+++ b/ui/ui_113.csv
@@ -1,7 +1,7 @@
 english,translate
 QA Health 8,Здоровье QA 8
 QA Health 9,Здоровье QA 9
-QA Immobilize,Обездвиживание QA
+QA Immobilize,Неподвижность QA
 QA Knockback,Отбрасывание QA
 QA Knockdown,Сбивание с ног QA
 QA Launch,Запуск QA

--- a/ui/ui_128.csv
+++ b/ui/ui_128.csv
@@ -463,7 +463,7 @@ Self Knockback Distance,Дальность отбрасывания себя
 Self Launch,Запуск себя
 Self Poison,Отравление себя
 Self Regeneration,Регенерация себя
-Self Superspeed,Собственная суперскорость
+Self Superspeed,Собственная сверхскорость
 Self-Assembling Axe Fragment[s],[Фрагмент|Фрагмента|Фрагментов] самособирающегося топора
 Self-Assembling Dagger Fragment[s],[Фрагмент|Фрагмента|Фрагментов] самособирающегося кинжала
 Self-Assembling Longbow Fragment[s],[Фрагмент|Фрагмента|Фрагментов] самособирающегося длинного лука

--- a/zone/zone_117.csv
+++ b/zone/zone_117.csv
@@ -193,7 +193,7 @@ Opening a gate now. I suggest you hurry—auto-destruct is imminent.,Откры�
 "Operating at one hundred percent efficiency, Crusader. Ignore the tinge of green around Elli's ears. I assure you asura never get seasick.","Работаю со стопроцентной эффективностью, Crusader. Не обращай внимания на зеленоватый оттенок ушей Elli. Уверяю, асура никогда не страдают морской болезнью."
 "Operation ""Sit On Our Furry Behinds"" is over. We're going in. Form up on the commander!",Операция «Сидим на своих пушистых задах» окончена. Мы входим. Собираемся вокруг Коммандир!
 Operational — parameters — complete,Оперативные — параметры — завершено
-"Operational. Power—levels—on—overload. Please—specify—energy—shunt: Might, Protection, Fury?","Функционирует. Уровни—энергии—перегружены. Пожалуйста—укажите—шунт—энергии: Мощь, Защита, Ярость?"
+"Operational. Power—levels—on—overload. Please—specify—energy—shunt: Might, Protection, Fury?","Функционирует. Уровни—энергии—перегружены. Пожалуйста—укажите—шунт—энергии: Мощь, Протекция, Ярость?"
 Operational—parameters—complete.,Операционные—параметры—полны.
 Operator-override-accepted.,Операторское переопределение принято.
 "Opinions will change. Any who wish to fight with us need only say the word. Farewell, Kalidris Sparrowhawk.","Мнения могут измениться. Любой, кто захочет сражаться вместе с нами, может просто сказать об этом. Прощай, Калидрис Спарохок."


### PR DESCRIPTION
Продолжение [#62](https://github.com/K13or/crowdsource/pull/62), но список другой: там эффекты контроля, здесь — благодати и
состояния из тех же таблиц GLOSSARY.md, сверенных с эталоном 11.08.

## Заход намеренно узкий

Замер по этим терминам в лоб даёт около **560 строк**, но почти всё — ложные
срабатывания, и правка по такому замеру сломала бы соседей:

| термин | что показал замер | почему нельзя править |
|---|---|---|
| Resistance | 154 строки «сопротивление» | 126 из них — `Agony Resistance`, отдельная строка глоссария, переведена верно |
| Stability | 23 строки «стабильность» | это устойчивость системы: «Rift Stability», «Bedrock Stability», «DDR-Stability», «Purpose. Stability.» |
| Vigor | 13 строк «бодрость» | сидит в названиях талантов — «Natural Vigor», «Hybrid Vigor», «Alchemic Vigor» |
| Protection / Might / Fury | 92 / 52 / 1 | в прозе значат ровно то, что значат |

Поэтому правятся только строки, где термин виден без сомнений.

## Подписи категорий в интерфейсе

Их видит каждый игрок, и три из них разъехались:

| было | стало |
|---|---|
| Защитный. (**Защита**, Решимость, **Сопротивление**, **Непоколебимость**, Эгида.) | (Протекция, Решимость, Сопротивляемость, Устойчивость, Эгида.) |
| Состояния, влияющие на подвижность. (**Озноб**, **Увечье**, Страх, **Обездвиживание**.) | (Заморозка, Хромота, Страх, Неподвижность.) |
| Состояния урона с течением времени. (…Отравление, **Мучение**.) | …Отравление, **Боль**. |

## Перечисления в описаниях

* `ach_024:438` — «Снимите кровотечение, **ослепление**, горение,
  **замедление**, замешательство, **увечье**, страх, **обездвиживание**…» —
  четыре позиции из одиннадцати;
* `discovered:501` и `zone_117:196` — protection → протекция;
* `items_051:253` — swiftness → быстрота («скорость» занята другим смыслом).

## Superspeed и Immobilize

`Superspeed` — канон «сверхскорость», в корпусе «суперскорость», три строки.

`Immobilize` параметром умения — канон «неподвижность», в корпусе
«обездвиживание»: «Эхо обездвиживания», «Обездвиживание при первом ударе»,
«Начальное Обездвиживание», «Обездвиживание QA», пять строк.

## Не тронуто

Глагольные формы: «Нельзя ослепить, охладить, покалечить, обездвижить»
(`new_132:43`) — там канон-существительное не подставить, нужен отдельный
разбор с образцом.

## Проверки

* `gate.py` — новых классов находок нет;
* полный прогон линтера до и после совпадает **побайтово**;
* `validate.py` по 15 файлам — 0 ошибок.

Разделы для DEFECTS.md идут отдельно, в ветку `docs` (PR #58).
