### PR TITLE
Слой имён против правил проекта: 26 записей

### DIFF
--- a/pn/pn_achievements_001.csv
+++ b/pn/pn_achievements_001.csv
@@ -122,7 +122,7 @@ Incursive Investigation: Working Together,Вторженческое рассл�
 Into the Obscure,В неизвестность
 Knowing Is Half the Battle,Знание — половина битвы
 Kraitmare Averted,Кошмар крайтов предотвращен
-"""Champions"" Mastery","Мастерство ""Чемпионы"""
+"""Champions"" Mastery","Мастерство «Чемпионы»"
 (Annual) A Royal Tradition,(Ежегодное) Королевская традиция
 (Annual) Boss Blitz,(Ежегодное) Босс-блиц
 (Annual) Bundle Plunderer,(Ежегодное) Похититель связок
@@ -231,7 +231,7 @@ Janthir Wilds: Act 1 Mastery,Дикие земли Джантира: Масте�
 Janthir Wilds: Act 2 Mastery,Дикие земли Джантира: Мастерство акта 2
 Janthir Wilds: Godspawn Mastery,Дикие земли Джантира: Мастерство порождения бога
 Jormag's Madness,Безумие Jormag
-"""A Star to Guide Us"" Mastery","Мастерство ""Путеводная звезда"""
+"""A Star to Guide Us"" Mastery","Мастерство «Путеводная звезда»"
 (Weekly) Convergences,(Еженедельное) Конвергенции
 (Weekly) Convergences: Mount Balrior,(Еженедельное) Конвергенции: Гора Balrior
 ...Back Again,...Снова здесь

--- a/pn/pn_items_001.csv
+++ b/pn/pn_items_001.csv
@@ -23,7 +23,7 @@ Astral Acclaim,Астральное признание
 Baby Book,Детская книга
 Black Lion Glyph Selection Container,Контейнер выбора глифа Чёрного Льва
 Black Lion Statuette,Статуэтка Чёрного Льва
-"""/Readbook"" Emote Tome","Том эмоций ""/Readbook"""
+"""/Readbook"" Emote Tome","Том эмоций «/Readbook»"
 A Kralkatorrid Affair,Кралькаторричное дело
 Alkaline Solution,Щелочной раствор
 Amalgamated Draconic Lodestone,Амальгамированный драконий магнитный камень
@@ -216,10 +216,10 @@ Branded Shard,Клеймёный осколок
 Branded Skimmer,Клейменный скиммер
 Branded Springer,Клейменный спрингер
 Brandspark Jewel,Самоцвет искры Клейма
-"""/Channel"" Emote Tome","Том эмоций ""/Channel"""
-"""/Flex"" Emote Tome","Том эмоций ""/Flex"""
-"""/bless"" Emote Tome","Том эмоций ""/bless"""
-"""/drink"" Emote Tome","Том эмоций ""/drink"""
+"""/Channel"" Emote Tome","Том эмоций «/Channel»"
+"""/Flex"" Emote Tome","Том эмоций «/Flex»"
+"""/bless"" Emote Tome","Том эмоций «/bless»"
+"""/drink"" Emote Tome","Том эмоций «/drink»"
 """Dragon"" Protein",«Драконий» протеин
 """Laughter on the Wind""",«Смех на ветру»
 """The Storm That Consumes All""","«Буря, что поглощает всё»"

--- a/pn/pn_names_003.csv
+++ b/pn/pn_names_003.csv
@@ -74,7 +74,7 @@ Cap'n Justene,Капитан Джастин
 Caprice,Каприз
 Caprice Vonne,Каприз Вонн
 Captain,Капитан
-"Captain ""Bonny"" Anne Reid","Капитанша ""Бонни"" Энн Рейд"
+"Captain ""Bonny"" Anne Reid","Капитанша «Бонни» Энн Рейд"
 Captain Antje,Капитан Антье
 Captain Ashym,Капитан Ашим
 Captain Banya,Капитан Баня

--- a/pn/pn_names_006.csv
+++ b/pn/pn_names_006.csv
@@ -144,7 +144,7 @@ Exitare,Экситаре
 Exitus,Экситус
 Exo-Suit Mounts Pack,Набор ездовых животных «Экзо-костюм»
 Exordium,Эксордиум
-Experimental Inquest Golem,Экспериментальный голем ИнКвеста
+Experimental Inquest Golem,Экспериментальный голем Инквеста
 Explorer,Исследователь
 Explorer Adri,Исследователь Адри
 Explorer Akkelyn,Исследователь Аккелин

--- a/pn/pn_names_008.csv
+++ b/pn/pn_names_008.csv
@@ -290,18 +290,18 @@ Inquest Mount Package,Набор скакунов Инквеста
 Inquest Overseer,Надзиратель Инквеста
 Inquest Phaser,Фазер Инквеста
 Inquest Prisoner Lamff,Пленник Инквеста Ламфф
-Inquest Recruiter,Вербовщик ИнКвеста
-Inquest Recruiter Takk,Вербовщик ИнКвеста Такк
-Inquest Sapper,Сапер ИнКвеста
-Inquest Sapper Kloddi,Сапер ИнКвеста Клодди
-Inquest Sharpshot,Стрелок ИнКвеста
-Inquest Specimen,Подопытный ИнКвеста
-Inquest Specimen Magiscientist,Подопытный ИнКвеста: Магический учёный
-Inquest Specimen Researcher,Подопытный ИнКвеста: Исследователь
-Inquest Tech,Техник ИнКвеста
-Inquest Technician Chibb,Техник ИнКвеста Чибб
-Inquest Technologist,Технолог ИнКвеста
-Inquest Time Golem,Временной голем ИнКвеста
+Inquest Recruiter,Вербовщик Инквеста
+Inquest Recruiter Takk,Вербовщик Инквеста Такк
+Inquest Sapper,Сапер Инквеста
+Inquest Sapper Kloddi,Сапер Инквеста Клодди
+Inquest Sharpshot,Стрелок Инквеста
+Inquest Specimen,Подопытный Инквеста
+Inquest Specimen Magiscientist,Подопытный Инквеста: Магический учёный
+Inquest Specimen Researcher,Подопытный Инквеста: Исследователь
+Inquest Tech,Техник Инквеста
+Inquest Technician Chibb,Техник Инквеста Чибб
+Inquest Technologist,Технолог Инквеста
+Inquest Time Golem,Временной голем Инквеста
 Inquisitive Djinn,Любопытный джинн
 Inquisitor Torbon,Инквизитор Торбон
 Insect Swarm,Рой насекомых

--- a/pn/pn_names_008.csv
+++ b/pn/pn_names_008.csv
@@ -292,8 +292,8 @@ Inquest Phaser,Фазер Инквеста
 Inquest Prisoner Lamff,Пленник Инквеста Ламфф
 Inquest Recruiter,Вербовщик Инквеста
 Inquest Recruiter Takk,Вербовщик Инквеста Такк
-Inquest Sapper,Сапер Инквеста
-Inquest Sapper Kloddi,Сапер Инквеста Клодди
+Inquest Sapper,Сапёр Инквеста
+Inquest Sapper Kloddi,Сапёр Инквеста Клодди
 Inquest Sharpshot,Стрелок Инквеста
 Inquest Specimen,Подопытный Инквеста
 Inquest Specimen Magiscientist,Подопытный Инквеста: Магический учёный

--- a/pn/pn_names_012.csv
+++ b/pn/pn_names_012.csv
@@ -490,7 +490,7 @@ Pixtor's Assistant,Помощник Пикстора
 PK 632z-M,ПК 632z-M
 Plagan Swordrend,Плаган Мечерез
 Plague Rot,Гниение чумы
-Plains Wurm,Равни́нный червь
+Plains Wurm,Равнинный червь
 Plains Wurm Hatchling,Детеныш степного червя
 Plains Wurm Queen,Королева степных червей
 Plasma,Плазма

--- a/pn/pn_names_014.csv
+++ b/pn/pn_names_014.csv
@@ -84,7 +84,7 @@ Riven Marl,Ривен Марл
 River Firefly,Речной светлячок
 Rivetclaw Burnfast,Риветклоу Скорожог
 Rixt,Рикст
-"RNR-336 ""Runner""","RNR-336 ""Бегунок"""
+"RNR-336 ""Runner""","RNR-336 «Бегунок»"
 Ro Venombite,Ро Ядовитый укус
 Roa,Роа
 Roaring Flames,Ревущее пламя

--- a/pn/pn_names_027.csv
+++ b/pn/pn_names_027.csv
@@ -197,7 +197,7 @@ Inquest Alarm,Тревога Инквеста
 Inquest Amalgam Assassin,Амальгам-убийца Инквеста
 Inquest Apprentice Choona,Ученица Инквеста Чуна
 Inquest Assistant,Помощник Инквеста
-Inquest Attacker's Strength,Сила атакующего из ИнКвеста
+Inquest Attacker's Strength,Сила атакующего из Инквеста
 Inquest Audio Log Box,Коробка с аудиозаписями Инквеста
 Inquest Authorization Key,Ключ авторизации Инквест
 Inquest Barrier,Барьер Инквеста

--- a/pn/pn_world_map_002.csv
+++ b/pn/pn_world_map_002.csv
@@ -252,7 +252,7 @@ Cat Island,Кошачий остров
 Catacomb Entrance,Вход в катакомбы
 Cathedral of Eternal Radiance,Собор Вечного Сияния
 Cathedral of Flames Gate,Врата Собора Пламени
-Cathedral of Glorious Victory,Собор Сла́вной Побе́ды
+Cathedral of Glorious Victory,Собор Славной Победы
 Cathedral of Hidden Depths,Собор Скрытых Глубин
 Cathedral of Silence,Собор Молчания
 Cathedral of the Blessed,Собор Благословенных

--- a/pn/pn_world_map_004.csv
+++ b/pn/pn_world_map_004.csv
@@ -168,7 +168,7 @@ Forced Entry: Bava Nisos,Силовой прорыв: Бава Нисос
 Forced Entry: Bava Nisos Outskirts,Силовой прорыв: Окраины Бава Нисос
 Forced Hand: Nyedra,Силовой захват: Ниедра
 Forearmed Is Forewarned,Предупрежден — значит вооружен
-Forecastle Rock,Скальный выступ Фо́ркасл
+Forecastle Rock,Скальный выступ Форкасл
 Forest of a Thousand Voices,Лес тысячи голосов
 Forest of Niflhel,Лес Нифльхель
 Forever Tree,Древо Вечности


### PR DESCRIPTION
Продолжение [#86](https://github.com/K13or/crowdsource/pull/86). Тот заход показал, что слой не покрыт правилами, которым подчинён корпус — линтер проверяет его только на своё. Прогнал по слою остальные правила CLAUDE.md.

| нарушение | записей | пример |
|---|---:|---|
| прямые кавычки вместо ёлочек (§5) | 9 | `Мастерство "Чемпионы"` |
| знаки ударения (README §7) | 3 | `Равни́нный червь`, `Собор Сла́вной Побе́ды` |
| опечатка «ИнКвест» | 14 | `Вербовщик ИнКвеста` — против 239 «Инквест» |

Слой подставляется в игру **поверх** перевода, поэтому всё это игрок видит напрямую.

Заглавная в середине слова проверена отдельно: остальные такие слова законны — `DeLana`, `KayleeBear`, `MinSec`, `DiGiacomo`, `McBoops` в оригинале написаны так же.

## Грабля, которую поймал гейт

Первый прогон снимал ударение по **всему** диапазону комбинируемых знаков — и сломал «й»:

```
было : Равни́нный червь
стало: Равнинныи червь     ← «й» превратилась в «и»
```

NFD раскладывает «й» на «и» + кратку (U+0306), кратка попала под замену. Та же беда ждала «ё» с умляутом. Теперь снимается только акут и гравис, а гейт отдельно считает, не изменилось ли число «й» и «ё» в записи.

## Что не трогаю

61 запись вида `Aksim → Aksim`, где перевод повторяет оригинал. Они бессмысленны, но безвредны, и это решение владельца слоя, а не правка по правилу.

## Гейт

* по всем 26 записям — **0 дефектов**, ни одна «й» и «ё» не потеряна;
* классы находок `check_row` — 0 новых, 0 ушедших;
* контрольный замер: прямых кавычек **0**, ударений **0**, «ИнКвест» **0**.

## Что ещё проверил в слое и не нашёл

Слой согласован сам с собой: одно английское имя всюду переведено одинаково — расхождений **0** на 24 804 записи. Запретов глоссария он тоже не нарушает.
