### PR TITLE
Слой не перевёл сам себя: 77 записей с готовым каноном рядом

### DIFF
--- a/pn/pn_achievements_001.csv
+++ b/pn/pn_achievements_001.csv
@@ -36,7 +36,7 @@ Dive Master,Мастер прыжков
 Escape from Lion's Arch,Побег из Львиной Арки
 Fawcett's Bounty,Награда Fawcett
 Kinfall Fractal,Фрактал Кинфолл
-Klobjarne Geirr: Raid or Convergence Victories,Klobjarne Geirr: победы в рейдах или конвергенциях
+Klobjarne Geirr: Raid or Convergence Victories,Клобьярне Гейрр: победы в рейдах или конвергенциях
 Bava Nisos Mastery,Мастерство Bava Nisos
 Convergences: Mount Balrior,Схождения: Гора Балриор
 Eir's Memorial in Hoelbrak,Мемориал Eir в Hoelbrak
@@ -45,7 +45,7 @@ Halloween Rituals,Ритуалы Хэллоуина
 Home Sweet Home,"Дом, милый дом"
 "I'm Brave, You Know","Я храбрый, ты же знаешь"
 Janthir Syntri Mastery,Мастерство Janthir Syntri
-Klobjarne Geirr: World Boss or Meta-Event Completions,Klobjarne Geirr: завершение мировых боссов или мета-событий
+Klobjarne Geirr: World Boss or Meta-Event Completions,Клобьярне Гейрр: завершение мировых боссов или мета-событий
 (Annual) Dragon Bash Feats,(Ежегодно) Подвиги Драконьего празднества
 (Annual) Four Winds Customs,(Ежегодное) Обычаи Четырех Ветров
 A Bold Strategy,Смелая стратегия
@@ -71,7 +71,7 @@ Janthir Wilds: Act 1,Дикие земли Джантира: Акт 1
 Janthir Wilds: Act 2,Дикие земли Джантира: Акт 2
 Jilai the Radiant,Jilai Сияющая
 Journey to Bitterfrost Frontier,Путешествие к Границе Горечи
-Klobjarne Geirr: Janthir Spear Kills,Klobjarne Geirr: убийства копьём Янтира
+Klobjarne Geirr: Janthir Spear Kills,Клобьярне Гейрр: убийства копьём Янтира
 A Legacy Damned,Проклятое наследие
 A Raw Deal,Нечестная сделка
 A Season for Work in Paradise,Сезон работы в раю
@@ -335,9 +335,9 @@ Commander of Fools,Коммандир дураков
 Competent Commander,Компетентный Коммандир
 Conservation of Resources,Сохранение ресурсов
 Convergence Challenge Mode: Master,Конвергенция: Режим испытания — Мастер
-Convergence Challenge Mode—Decima: Silver,Конвергенция: Режим испытания — Decima: Серебро
-Convergence Challenge Mode—Greer: Silver,Конвергенция: Режим испытания — Greer: Серебро
-Convergence Challenge Mode—Ura: Silver,Конвергенция: Режим испытания — Ura: Серебро
+Convergence Challenge Mode—Decima: Silver,Конвергенция: Режим испытания — Децима: Серебро
+Convergence Challenge Mode—Greer: Silver,Конвергенция: Режим испытания — Грир: Серебро
+Convergence Challenge Mode—Ura: Silver,Конвергенция: Режим испытания — Ура: Серебро
 Convergences: Outer Nayos,Схождения: Внешний Найос
 "Cornered, Caught, Collared (2013)","Загнанные, пойманные, в ошейниках (2013)"
 Cover the Castaway Crew,Прикрыть команду потерпевших кораблекрушение
@@ -473,7 +473,7 @@ Hold the Line,Держать строй
 Hunger Manifest,Проявление голода
 Hylek Historian,Историк Hylek
 I Brought Flowers,Я принес цветы
-"Iberu, We Hardly Knew You","Iberu, мы едва знали тебя"
+"Iberu, We Hardly Knew You","Иберу, мы едва знали тебя"
 Ice Breaker,Ледокол
 Illuminating Amnytas,Озарение Амнитаса
 Illuminating Inner Nayos,Озарение Внутреннего Найоса

--- a/pn/pn_achievements_002.csv
+++ b/pn/pn_achievements_002.csv
@@ -87,7 +87,7 @@ Sunken Treasure Hunter,Охотник за затонувшими сокрови
 The First City,Первый город
 The Ghost,Призрак
 Master Diver,Мастер-ныряльщик
-Mount Balrior: Convergence Conqueror,Mount Balrior: Покоритель конвергенции
+Mount Balrior: Convergence Conqueror,Гора Балриор: Покоритель конвергенции
 "My Friends, the Smiths",Мои друзья — кузнецы
 Mystery of Drakkar's Lair,Тайна логова Drakkar
 Mystery of the Bjora Marches,Тайна Bjora Marches
@@ -349,7 +349,7 @@ Scouting for Scouts,Разведка для разведчиков
 Secret Agent,Секретный агент
 Secret of Southsun,Тайна Южного Солнца
 Secrets Obscured,Скрытые секреты
-Secrets of the Obscure: The Midnight King Mastery,Тайны Сокрытого: Мастерство «The Midnight King»
+Secrets of the Obscure: The Midnight King Mastery,Тайны Сокрытого: Мастерство «Король полуночи»
 Securing the Bastions,Обеспечение безопасности бастионов
 "See You Later, Alligator","До скорого, аллигатор"
 "Seed Generation, Under 3","Генерация семян, менее 3"

--- a/pn/pn_items_002.csv
+++ b/pn/pn_items_002.csv
@@ -133,7 +133,7 @@ Cantle of Sun,Лука седла солнца
 Captain's Airship Pass,Капитанский пропуск на дирижабль
 Captain's Airship Pass (2 weeks),Капитанский пропуск на дирижабль (2 недели)
 Captain's Council Commendation,Благодарность Совета капитанов
-Carcharias Experiment,Эксперимент «Carcharias»
+Carcharias Experiment,Эксперимент «Кархариас»
 Case of Corrupted Crystalline Phials,Ящик испорченных кристаллических фиалов
 Castoran Tentacled Skimmer,Касторанский щупальцевый скиммер
 Cattle Prod,Электропогонялка
@@ -145,7 +145,7 @@ Champion's Mad King,«Безумный король» чемпиона
 Champion's Moon,Чемпионская луна
 Champion's Sun,Чемпионское солнце
 Champion's Winter Crown,Чемпионская зимняя корона
-Chaos Gun Experiment,Эксперимент «Chaos Gun»
+Chaos Gun Experiment,Эксперимент «Пистолет хаоса»
 Charged Dwarven Spell Trap,Заряженная дварфийская ловушка заклинаний
 Charged Titan Ore,Заряженная титановая руда
 Charr Alarm Clock,Чаррский будильник

--- a/pn/pn_items_003.csv
+++ b/pn/pn_items_003.csv
@@ -90,16 +90,16 @@ Ghost Pepper,Призрачный перец
 Ghoul Backpack,Рюкзак гуля
 Gieve's Plate,Тарелка Гива
 Gift of Blades,Дар клинков
-Gift of Bolt,Дар «Bolt»
+Gift of Bolt,Дар «Болт»
 Gift of Competitive Prosperity,Дар соревновательного процветания
 Gift of Competitive Prowess,Дар соревновательной доблести
-Gift of Frenzy,Дар «Frenzy»
-Gift of Frostfang,Дар «Frostfang»
-Gift of Howler,Дар «Howler»
-Gift of Incinerator,Дар «Incinerator»
-Gift of Kraitkin,Дар «Kraitkin»
-Gift of Kudzu,Дар «Kudzu»
-Gift of Meteorlogicus,Дар «Meteorlogicus»
+Gift of Frenzy,Дар «Бешенство»
+Gift of Frostfang,Дар «Ледяной Клык»
+Gift of Howler,Дар «Завыватель»
+Gift of Incinerator,Дар «Инсинератор»
+Gift of Kraitkin,Дар «Крайткин»
+Gift of Kudzu,Дар «Кудзу»
+Gift of Meteorlogicus,Дар «Метеорлогикус»
 Gift of Nevermore,Дар «Nevermore»
 Enchanted Key,Зачарованный ключ
 Energized Soul Battery Fragment,Фрагмент заряженной батареи душ
@@ -262,9 +262,9 @@ Giant Chocolate Raspberry Cake,Гигантский шоколадно-мали�
 Giant Orange Coconut Cake,Гигантский апельсиново-кокосовый торт
 Gift from Scarlet,Подарок от Скарлет
 Gift of Amnytas,Дар Амнитаса
-Gift of Astralaria,Дар «Astralaria»
+Gift of Astralaria,Дар «Астралария»
 Gift of Aurene,Дар Аурены
-Gift of Bava Nisos,Дар «Bava Nisos»
+Gift of Bava Nisos,Дар «Бава Нисос»
 Gift of Blood,Дар крови
 Gift of Chuka and Champawat,Дар «Chuka and Champawat»
 Gift of Claws,Дар когтей
@@ -276,12 +276,12 @@ Gift of Gliding,Дар планирования
 Gift of HOPE,Дар «HOPE»
 Gift of Infinity,Дар бесконечности
 Gift of Inner Nayos,Дар Внутреннего Найоса
-Gift of Kamohoali'i Kotaki,Дар «Kamohoali'i Kotaki»
+Gift of Kamohoali'i Kotaki,Дар «Камохоали'и Котаки»
 Gift of Maguuma Mastery,Дар мастерства Магуумы
 Gift of Mistburned Barrens,Дар Выжженных туманом пустошей
 Gift of New Kaineng City,Дар Нового Кайненга
 Gift of Persistence,Дар стойкости
-Gift of Quip,Дар «Quip»
+Gift of Quip,Дар «Шутка»
 Gift of Regrowth,Дар возрождения
 Empress Fish,Рыба-императрица
 Empty Alchemical Bottle,Пустая алхимическая склянка
@@ -494,8 +494,8 @@ Gift of Balthazar,Дар Бальтазара
 Gift of Divinity,Дар божественности
 Gift of Eternity's Garden Exploration,Дар исследования Сада Вечности
 Gift of Eureka,Дар «Eureka»
-Gift of Exordium,Дар «Exordium»
+Gift of Exordium,Дар «Эксордиум»
 Gift of Family,Дар семьи
 Gift of Ipos,Дар «Ipos»
 Gift of Knowledge,Дар знаний
-Gift of Pharus,Дар «Pharus»
+Gift of Pharus,Дар «Фарус»

--- a/pn/pn_items_004.csv
+++ b/pn/pn_items_004.csv
@@ -60,16 +60,16 @@ Jar of Distilled Glory,Банка перегнанной славы
 Kid Gloves,Перчатки из кожи козлёнка
 Koda's Gift,Дар Коды
 Kralkatite Ore,Руда кралкатита
-Gift of Rodgort,Дар «Rodgort»
+Gift of Rodgort,Дар «Родгорт»
 Gift of Runes,Дар рун
 Gift of Sigils,Дар сигилов
-Gift of Sunrise,Дар «Sunrise»
-Gift of The Dreamer,Дар «The Dreamer»
-Gift of The Juggernaut,Дар «The Juggernaut»
-Gift of The Minstrel,Дар «The Minstrel»
-Gift of The Moot,Дар «The Moot»
-Gift of The Predator,Дар «The Predator»
-Gift of Twilight,Дар «Twilight»
+Gift of Sunrise,Дар «Восход»
+Gift of The Dreamer,Дар «Мечтатель»
+Gift of The Juggernaut,Дар «Джаггернаут»
+Gift of The Minstrel,Дар «Менестрель»
+Gift of The Moot,Дар «Мут»
+Gift of The Predator,Дар «Хищник»
+Gift of Twilight,Дар «Сумерки»
 Gift of War Prowess,Дар воинской доблести
 Gift of the Dragon Empire,Дар Драконьей империи
 Gigantic Ice Elemental Core,Ядро гигантского ледяного элементаля
@@ -125,7 +125,7 @@ Gift of Skywatch Archipelago,Дар Архипелага Небесного До
 Gift of Souls,Дар душ
 Gift of Spiders,Дар пауков
 Gift of Tarir,Дар Тарира
-Gift of The Bifrost,Дар «The Bifrost»
+Gift of The Bifrost,Дар «Бифрост»
 Gift of Totems,Дар тотемов
 Gift of Venom,Дар яда
 Gift of the Astral Ward,Дар Астральной стражи
@@ -208,10 +208,10 @@ Kudu's Phasing Matrix,Фазовая матрица Куду
 Kudzu Experiment,Эксперимент с кудзу
 Large Ancient Haft,Большое древнее древко
 Lava Lounge Pass,Пропуск в лавовый лаунж
-Gift of Shooshadoo,Дар «Shooshadoo»
+Gift of Shooshadoo,Дар «Шушаду»
 Gift of Thorns,Дар терний
-Gift of Verdarach,Дар «Verdarach»
-Gift of Xiuquatl,Дар «Xiuquatl»
+Gift of Verdarach,Дар «Вердарах»
+Gift of Xiuquatl,Дар «Шиукуатль»
 Gift of Zhaitan,Дар Зайтана
 Gift of the Blade,Дар клинка
 Gift of the Forgeman,Дар кузнеца

--- a/pn/pn_names_007.csv
+++ b/pn/pn_names_007.csv
@@ -144,11 +144,11 @@ Gift of Battle,Дар битвы
 Gift of Exploration,Дар исследования
 Gift of Fortune,Дар удачи
 Gift of Janthir Wilds,Дар Диких земель Джантира
-Gift of Klobjarne Geirr,Дар «Klobjarne Geirr»
+Gift of Klobjarne Geirr,Дар «Клобьярне Гейрр»
 Gift of Magic,Дар магии
 Gift of Mastery,Дар мастерства
 Gift of Might,Дар мощи
-Gift of The Flameseeker Prophecies,Дар «The Flameseeker Prophecies»
+Gift of The Flameseeker Prophecies,Дар «Пророчества Ищущего Пламя»
 Gift of the Homesteader,Дар поселенца
 Gigantic cat,Гигантский кот
 Giganticus Lupicus,Гигантикус Лупикус

--- a/pn/pn_names_022.csv
+++ b/pn/pn_names_022.csv
@@ -10,7 +10,7 @@ Tribune Steelgrip,Трибуна Стальная хватка
 Legendary Forged Demolisher,Легендарный Кованый разрушитель
 Moa Trainer Kappa,Дрессировщица моа Kappa
 Warmaster Kaylar,Магистр войны Кейлар
-Champion Molten Berserker,Чемпион Molten Berserker
+Champion Molten Berserker,Чемпион Берсерк Расплава
 Champion Risen Megalodon,Воскрешенный мегалодон-чемпион
 Scarlet's Twisted Marionette,Искривлённая марионетка Скарлет
 Shining Blade Kimber,Сияющий Клинок Kimber
@@ -19,19 +19,19 @@ Chief Officer Shashoo,Старший офицер Шашу
 Deputy Hamad,Заместитель Хамад
 Legendary Chak Gerent,Легендарный чак-герент
 Legendary Sand Giant,Легендарный песчаный гигант
-Legendary Zehlon Ossa,Легендарный Zehlon Ossa
+Legendary Zehlon Ossa,Легендарный Зельон Осса
 Sage Gorra,Мудрец Gorra
 Security Chief Ziff,Начальник охраны Ziff
 Champion Aetherblade Cannoneer,Чемпион Эфирный пушкарь
 Champion Boneskinner,Чемпион-Костедёр
-Champion Fallen Pineshade,Чемпион: Fallen Pineshade
+Champion Fallen Pineshade,Чемпион: Падшая Сосновая Шейда
 Champion Icebrood Quaggan,Чемпион ледяного выводка квагган
-Champion Mordrem Husk Copper,Чемпион Mordrem Husk Copper
+Champion Mordrem Husk Copper,"Чемпион Мордремская оболочка, медная"
 Champion Mordrem Thrasher Platinum,Платиновый чемпион Mordrem Thrasher
 Champion Mordrem Troll Iron,Чемпион Мордрем-тролль Железо
 Champion Mushroom Emperor,Чемпион Император грибов
 Champion Ram,Чемпион Ram
-Champion Risen Knight,Чемпион Risen рыцарь
+Champion Risen Knight,Чемпион Восставший рыцарь
 Champion Stonehead,Чемпион Каменноголовый
 Elite Aetherblades,Элитные эфирные клинки
 Elite Rot Strider,Элитный гнилостный шагатель
@@ -66,21 +66,21 @@ Champion Dredge Commissar,Чемпион-комиссар дрегов
 Champion First Mate Pekknik,Чемпион Первый помощник Pekknik
 Champion Forged Commander,Чемпион Кованый Коммандир
 Champion Forged Lieutenant,Чемпион Кованый лейтенант
-Champion Forged Marauder,Чемпион Forged Marauder
+Champion Forged Marauder,Чемпион Кованый мародёр
 Champion Forged Maverick,Чемпион Кованый Maverick
 Champion Forged Wolfhound,Чемпион: Кованый волкодав
 Champion Gladiator Waine,Чемпион-гладиатор Уэйн
 Champion Grawl Shaman,Граул-шаман чемпион
 Champion Icebrood Goliath,Чемпион ледяного голиафа
-Champion Ignis,Чемпион Ignis
+Champion Ignis,Чемпион Игнис
 Champion Jungle Troll,Чемпион: Тролль джунглей
 Champion Karka,Чемпион-карка
-Champion Kharkaris,Чемпион Kharkaris
+Champion Kharkaris,Чемпион Харкарис
 Champion Krait Witch,Чемпион Крайт Ведьма
-Champion Matriarch Shrilliss,Чемпион Matriarch Shrilliss
-Champion Matriarch Talonslayer,Чемпион Matriarch Talonslayer
-Champion Modniir High Sage,Чемпион Modniir High Sage
-Champion Mordrem Teragriff Gold,Чемпион Mordrem Teragriff Gold
+Champion Matriarch Shrilliss,Чемпион Матриарх Шриллис
+Champion Matriarch Talonslayer,Чемпион Матриарх Разрушительница Когтей
+Champion Modniir High Sage,Чемпион Верховный мудрец модниир
+Champion Mordrem Teragriff Gold,"Чемпион Мордремский терагриф, золотой"
 Champion Mordrem Teragriff Silver,Чемпион Mordrem Teragriff Silver
 Champion Svanir Brute,Чемпион Сванирский громила
 Champion Wayfarer,Чемпион Wayfarer
@@ -100,8 +100,8 @@ High Priestess Amala,Верховная жрица Амала
 Lab Manager Grex,Заведующий лабораторией Грекс
 Lead Explorer Parsa,Старший исследователь Парса
 Legendary Imbued Shaman,Легендарный напитанный шаман
-Legendary Ley-Line Anomaly,Легендарная Ley-Line Anomaly
-Legendary Triq Griz Grolak,Легендарный Triq Griz Grolak
+Legendary Ley-Line Anomaly,Легендарная Аномалия лей-линий
+Legendary Triq Griz Grolak,Легендарный Триг Гриз Гролак
 Legionnaire Virgrol Brashmar,Легионер Виргрол Брашмар
 Lionguard Engineer Dauphan,Инженер Lionguard Dauphan
 Lore Seeker Zolin,Искатель знаний Zolin

--- a/pn/pn_names_023.csv
+++ b/pn/pn_names_023.csv
@@ -7,15 +7,15 @@ Champion Arid Parasite Devourer,Чемпион Arid Parasite Devourer
 Champion Asphodel,Чемпион Асфодель
 Champion Awakened Defiler,Чемпион Пробужденный осквернитель
 Champion Awakened Devastator,Чемпион — пробуждённый опустошитель
-Champion Awakened Scavenger,Чемпион Awakened Scavenger
+Champion Awakened Scavenger,Чемпион Пробуждённый Мусорщик
 Champion Awakened Stray,Чемпион Пробуждённый бродяга
 Champion Bandit Foreman,Чемпион: Бандитский бригадир
 Champion Bat Matriarch,Матриарх летучих мышей-чемпион
 Champion Blossom Weaver,Чемпион: Ткач цветения
 Champion Branded Forgotten Priest,Клейменный чемпион — забытый жрец
 Champion Branded Hydra,Клейменный чемпион — гидра
-Champion Branded Josso Essher,Чемпион Branded Josso Essher
-Champion Branded Ley-Line Anomaly,Чемпион Branded Ley-Line Anomaly
+Champion Branded Josso Essher,Чемпион Клеймёный Джоссо Эшер
+Champion Branded Ley-Line Anomaly,Чемпион Клеймёная аномалия лей-линий
 Champion Branded Mender,Чемпион Брендированный целитель
 Champion Brotherhood Lieutenant,Чемпион лейтенант Братства
 Champion Buff,Усиление чемпиона
@@ -56,7 +56,7 @@ Champion Lord Hanif,Чемпион лорд Ханиф
 Champion Malfunctioning Golem,Чемпион — неисправный голем
 Champion Mistburned Kodan,Чемпион Mistburned Kodan
 Champion Modniir Chief,Чемпион Modniir Chief
-Champion Modniir Commander,Чемпион Modniir Commander
+Champion Modniir Commander,Чемпион Командир модниир
 Champion Modniir Leader,Чемпион лидер Моднииров
 Champion Modniir Overlord,Чемпион повелитель Моднииров
 Champion Monstrous Lava Elemental,Чемпион: Чудовищный элементаль лавы
@@ -64,7 +64,7 @@ Champion Mordrem Dark Wing,Чемпион Mordrem Тёмное Крыло
 Champion Mordrem Leeching Thrasher,Чемпион — мордремский молотильщик-пиявка
 Champion Mordrem Mangler,Чемпион Mordrem Mangler
 Champion Mordrem Vinetooth,Чемпион Mordrem Vinetooth
-Champion Mordrem Wolf,Чемпион Mordrem Wolf
+Champion Mordrem Wolf,Чемпион Мордрем-волк
 Champion Mushroom King,Чемпион Король грибов
 Champion Ogre Beastmaster,Чемпион Огр-повелитель зверей
 Champion Ogre Chieftain,Чемпион вождь огров
@@ -118,7 +118,7 @@ Elite Minion,Элитный прислужник
 Elite Purist Agitator,Элитный агитатор-пурист
 Elite Purist Instigator,Элитный подстрекатель пуристов
 Elite Speaker Saboteur,Элитный саботажник Спикеров
-Elite Spineshell Impaler,Элитный Spineshell Impaler
+Elite Spineshell Impaler,Элитный Колючепанцирный пронзатель
 Elite Sunspear Guard,Элитный страж Солнечных Копий
 Elite Unbound Spirit,Элитный свободный дух
 Elite Volatile Jade Spark,Элитная нестабильная нефритовая искра
@@ -150,7 +150,7 @@ Legendary Tunesmith,Легендарный мастер напевов
 Legendary Vinetooth Prime,Легендарный Vinetooth Prime
 Legendary Wyvern,Легендарная виверна
 Legendary Wyvern Matriarch,Легендарный матриарх виверн
-Legendary Wyvern Patriarch,Легендарный Wyvern Patriarch
+Legendary Wyvern Patriarch,Легендарный Патриарх виверн
 Legendary Wyverns,Легендарные виверны
 Master Nente,Мастер Ненте
 Pack Dolyak,Вьючный Dolyak
@@ -162,7 +162,7 @@ Technician Martijn,Техник Мартейн
 Technician Otto,Техник Отто
 Technician Tassa,Техник Тасса
 Valiant Gleranon,Доблестный Глеранон
-Veteran Acatl,Ветеран Acatl
+Veteran Acatl,Ветеран Акатль
 Veteran Adamant Team Lead,Ветеран: глава Адамантового отряда
 Veteran Arrowhead,Ветеран-наконечник
 Veteran Artillery Cannonade,Ветеран Артиллерийская пушка
@@ -189,7 +189,7 @@ Veteran Dredge Disaggregator,Ветеран-дезинтегратор дрег�
 Veteran Dredge Diving Suit,Ветеран-водолаз дреджей
 Veteran Dredge Resonator,Ветеран-резонатор из клана Дредж
 Veteran Dredge Siegemaster,Ветеран-осадный мастер дрегов
-Veteran Dust Mite Twister,Ветеран Dust Mite Twister
+Veteran Dust Mite Twister,Ветеран Вихрь пылевых клещей
 Veteran Dwarf,Ветеран-гном
 Veteran Ettin Leader,Ветеран-лидер эттинов
 Veteran Explosive Cannonade,Ветеран Взрывная пушка
@@ -205,7 +205,7 @@ Veteran Graveling Ghost Eater,Ветеран Graveling Ghost Eater
 Veteran Grawl Commander,Ветеран-командир граулов
 Veteran Grawl Shaman,Ветеран Граул Шаман
 Veteran Griffon,Ветеран-грифон
-Veteran Harathi Warleader,Ветеран Harathi Warleader
+Veteran Harathi Warleader,Ветеран Военачальник Харати
 Veteran Harpy Warrior,Ветерана-воительница гарпий
 Veteran Hunter Councillor,Ветеран-охотник советник
 Veteran Hylek Chieftain,Ветеран Хилек-вождь
@@ -213,11 +213,11 @@ Veteran Hylek Chieftan,Ветеран Hylek Chieftan
 Veteran Ice Imp,Ветеран Ледяной бес
 Veteran Ice Wurm,Ветеран: ледяной червь
 Veteran Icebrood Berserker,Ветеран-берсерк ледяных отродий
-Veteran Icebrood Goliath,Ветеран Icebrood Goliath
+Veteran Icebrood Goliath,Ветеран Голиаф ледяного выводка
 Veteran Icebrood Hunter,Ветеран-охотник ледяных отродий
 Veteran Icebrood Mauler,Ветеран-крушитель ледяного отродья
 Veteran Icebrood Seer,Ветеран-провидец ледяных отродий
-Veteran Icebrood Wolf,Ветеран ледяного выводка (Icebrood Wolf)
+Veteran Icebrood Wolf,Ветеран ледяного выводка (Волк ледяного отродья)
 Veteran Illusionary Beast,Ветеран Иллюзорный зверь
 Veteran Inquest Operative,Ветеран-оперативник Инквеста
 Veteran Jungle Boar,Ветеран джунглевого кабана
@@ -233,11 +233,11 @@ Veteran Marmox Packleader,Ветеран вожак стаи Marmox
 Veteran Mextli,Ветеран Mextli
 Veteran Minotaur,Ветеран-минотавр
 Veteran Molengrad Commissar,Ветеран: Комиссар Molengrad
-Veteran Mordant Crescent Arbiter,Ветеран Mordant Crescent Arbiter
-Veteran Mordrem Guard Cavalier,Ветеран Mordrem Guard Cavalier
-Veteran Mordrem Leeching Thrasher,Ветеран Mordrem Leeching Thrasher
-Veteran Mordrem Teragriff,Ветеран Mordrem Teragriff
-Veteran Mordrem Troll,Ветеран Mordrem Troll
+Veteran Mordant Crescent Arbiter,Ветеран Арбитр Мордантского полумесяца
+Veteran Mordrem Guard Cavalier,Ветеран Кавалерист мордремской стражи
+Veteran Mordrem Leeching Thrasher,Ветеран Мордремский высасывающий молотильщик
+Veteran Mordrem Teragriff,Ветеран Мордрем-терагриф
+Veteran Mordrem Troll,Ветеран Мордрем-тролль
 Veteran Mordrem Vile Thrasher,"Ветеран-мордрем, злобный бичеватель"
 Veteran Mordrem Vinetooth,Ветеран Mordrem Vinetooth
 Veteran Mossheart Caravan,Ветеран: Караван моховых сердец
@@ -251,10 +251,10 @@ Veteran Overseer Nasser,Ветеран-смотритель Nasser
 Veteran Potential Mate,Ветеран: Потенциальный партнер
 Veteran Purist Recruiter,Ветеран: Вербовщик пуристов
 Veteran Rampaging Golem,Ветеранский бушующий голем
-Veteran Risen Chicken,Ветеран Risen Chicken
+Veteran Risen Chicken,Ветеран Восставшая курица
 Veteran Risen Crusader,Ветеран: восставший крестоносец
 Veteran Risen Gorilla,Ветеран-горилла Risen
-Veteran Risen Hylek,Ветеран Risen Hylek
+Veteran Risen Hylek,Ветеран Восставший хилек
 Veteran Risen Spectral Juggernaut,Ветеран Восставший призрачный джаггернаут
 Veteran Risen Spider,Ветеран Risen spider
 Veteran Rotting Ancient Oakheart,Ветеран Гниющий Древний Дубосерд

--- a/pn/pn_names_024.csv
+++ b/pn/pn_names_024.csv
@@ -354,7 +354,7 @@ Awakened Artillery Mender,Пробуждённый артиллерийский 
 Awakened Asura,Пробуждённый асура
 Awakened Asura Supervisor,Пробуждённый асура-надзиратель
 Awakened Catapult,Катапульта Пробуждённых
-Awakened Champion,Чемпион Awakened
+Awakened Champion,Чемпион Пробуждённый
 Awakened Chest,Пробуждённый сундук
 Awakened Commander,Командир Пробуждённых
 Awakened Conduit,Проводник Пробуждённых
@@ -389,7 +389,7 @@ Awakened Raider,Пробуждённый налётчик
 Awakened Rations,Паёк Пробуждённых
 Awakened Ravager,Пробуждённый опустошитель
 Awakened Representative,Представитель Пробуждённых
-Awakened Saved,Awakened спасены
+Awakened Saved,Пробуждённые спасены
 Awakened Siege Shield,Осадный щит Пробуждённых
 Awakened Slam,Удар Пробуждённых
 Awakened Spy,Шпион Пробуждённых

--- a/pn/pn_names_025.csv
+++ b/pn/pn_names_025.csv
@@ -160,7 +160,7 @@ Branded Dredge Miner,Фирменный земснаряд-шахтер
 Branded Dredge Ratnik,Фирменный Дредж Ратник
 Branded Dredge Resonator,Клеймёный резонатор землероев
 Branded Earth,Клеймёная земля
-Branded Earth Elemental,Branded земляной элементаль
+Branded Earth Elemental,Клеймёный земляной элементаль
 Branded Elementalist Staff,Клеймёный посох элементалиста
 Branded Energy,Клеймёная энергия
 Branded Fireball,Клеймёный огненный шар

--- a/pn/pn_names_027.csv
+++ b/pn/pn_names_027.csv
@@ -405,7 +405,7 @@ Kodan Parent,Родитель кодан
 Kodan Planter Box,Коданская коробка для растений
 Kodan Preparation,Подготовка кодан
 Kodan Refugee,Беженец-кодан
-Kodan Relaxed,Kodan расслаблен
+Kodan Relaxed,Кодан расслаблен
 Kodan Rug,Коданский ковёр
 Kodan Rush,Коданий рывок
 Kodan Sacrifice,Жертва кодан

--- a/pn/pn_names_028.csv
+++ b/pn/pn_names_028.csv
@@ -201,7 +201,7 @@ Ministry Fishing Official,Официальный представитель Ми
 Ministry Guard Captain,Капитан Стражи Министерства
 Ministry Guard Pack Bull,Упаковка «Страж Министерства»
 Ministry Update,Обновление министерства
-Ministry Ward Eastern Gardens,Ministry Ward: Восточные сады
+Ministry Ward Eastern Gardens,Министерский квартал: Восточные сады
 Mist Champion Skins,Облики Чемпиона Тумана
 Mist Debris,Осколки Туманов
 Mist Energy,Энергия Туманов


### PR DESCRIPTION
Слой существует, чтобы подставлять русскую форму имени. Запись, у которой перевод наполовину английский, этой работы не делает: игрок с включённым слоем видит ту же латиницу, ради замены которой слой и включён.

```
Champion Forged Marauder     Чемпион Forged Marauder
Forged Marauder              Кованый мародёр          <- канон рядом
```

Таких записей в слое **439**. У 267 перевод уже лежит в самом слое — строкой выше или в соседнем файле. Правится 77 из них.

## Падеж брать неоткуда — и не нужно

Подставить канон механически можно не везде: «Мастерство Bava Nisos» требует родительного, а выдумывать склонение имён нельзя. Поэтому взяты только позиции, где именительный законен, и каждая проверена по прецеденту слоя:

| основание | записей | пример |
|---|---|---|
| имя в кавычках | 31 | `Дар «Rodgort»` → `Дар «Родгорт»` |
| имя после ранга | 32 | `Чемпион Forged Marauder` → `Чемпион Кованый мародёр` |
| имя открывает строку | 7 | `Iberu, мы едва знали тебя` → `Иберу, мы едва знали тебя` |
| имя за другим заголовком | 3 | `Конвергенция: Режим испытания — Decima: Серебро` → `… — Децима: Серебро` |
| собрано вручную | 4 | см. ниже |

Про ранг отдельно: слой пишет и «Чемпион: Кованый мародёр», и «Чемпион Кованый мародёр» (168 против 77). Обе формы ставят имя в именительный, поэтому конструкцию записи не трогаю вовсе — меняю только латиницу.

Четыре записи собраны вручную из канонов обеих частей имени. `Branded` и `Awakened` записаны в слое во множественном числе («Клейменные», «Пробужденные»), и перед существительным в единственном они давали «Клейменные земляной элементаль». Взято «Клеймёный земляной элементаль», «Чемпион Пробуждённый», «Чемпион Клеймёная аномалия лей-линий». В «Пробуждённые спасены» множественное как раз уместно — там речь о народе целиком.

## Что намеренно НЕ тронуто

* **181 запись, где именительный не подходит** — «Дневник Zojja», «Помогите Mabon», «Мастерство Bava Nisos». Прецедент слоя однозначен: `Mabon's Journal` переведено «Дневник Мабона», `Dragon's End Mastery` — «Мастерство Конца дракона», то есть родительный. Но склонение имён надо ставить руками — это отдельный заход;
* **20 записей, где канон покрывает не всё имя.** У `Mordrem Teragriff Gold` канон есть на всё имя, у `…Silver` — только на два слова, и подстановка дала бы соседние строки «Мордремский терагриф, золотой» и «Мордрем-терагриф Silver». Это не починка разнобоя, а новый разнобой;
* **172 записи без канона вовсе** — это пробел слоя, а не его разнобой.

## Проверки

* новых классов линтера **0**, дефектов разметки **0**;
* кавычки и плейсхолдеры сверены построчно;
* буквы й/ё: +38 — каноны с ё («мародёр», «Клеймёный», «Пробуждённый»);
* контрольный замер: полупереведённых записей осталось 362 вместо 439, с готовым каноном — 190 вместо 267.

## Попутно найдено (в этот PR не входит)

Слой расходится сам с собой и по другому признаку: производное имя не помнит канона своего корня. `Crystal Bloom` — «Хрустальный расцвет», а рядом «Кристальный Цвет», «Кристальное Цветение», «Кристальный Цветок» (22 записи). `Osprey's Palace` — «Дворец Оспрея», «Дворца скопы» и «дворцу Орла». `Mordant Crescent` — «Мордантский полумесяц» и «Иерарх Серпа Погибели». Всего 100 корней, 162 записи; разберу следующим заходом.