### PR TITLE
Мёртвые строки с живым двойником удалены: 174 из 263

### DIFF
--- a/items/items_125.csv
+++ b/items/items_125.csv
@@ -7,9 +7,6 @@ Double-click to gain 50 luck.","""После вашего захватывающ
 Double-click to gain 50 luck.","""Даже выступая в роли приманки для Двухлезвийного Пита, вы проявили большую храбрость. Серафимы...
 Дважды щёлкните, чтобы получить 50 единиц удачи."
 """Just Tillie"" ,""Просто Тилли""""","""Just Tillie"" ,""Просто Тилли"""""
-"""Let the loss of Ysvelta be a constant reminder of why we must stay strong against the Nightmare."",'«""Пусть потеря Исвельты будет постоянным напоминанием о том, почему мы должны оставаться сильными против Кошмара.""'
-Double-click to gain 50 luck.","""Пусть потеря Исвельты будет постоянным напоминанием о том, почему мы должны оставаться сильными против Кошмара"".
-Дважды щёлкните, чтобы получить 50 единиц удачи."
 """True greatness comes for those who have wisdom to do right, the courage to embark
 ""We Carry Her Loss Together""""""","«Истинное величие приходит к тем, у кого есть мудрость поступать правильно, смелость отправиться
 „Мы несём её утрату вместе“»"
@@ -444,8 +441,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 <c=@flavor>«Скритты соберут почти всё хотя бы раз». —Заметки Ордена о примитивных расах, стр. 422</c>"
 <c=@Warning>Warning!</c>,<c=@Warning>Внимание!</c>
 <c=@abilitytype>Costume Brawl Toy:</c> Double-click to equip a bundle which grants fun costume brawl skills. Brawl skills will only hit other players also using costume brawl.,"<c=@abilitytype>Игрушка для костюмированной потасовки:</c> Дважды щёлкните, чтобы экипировать набор, дающий забавные навыки потасовки. Навыки потасовки действуют только на других игроков, также использующих игрушки для потасовки."
-"<c=@abilitytype>Element: </c>Brilliance,<c=@abilitytype>Стихия: </c>Сияние","<c=@abilitytype>Стихия: </c>Сияние,<c=@abilitytype>Стихия: </c>Сияние"
-"<c=@abilitytype>Element: </c>Enhancement,<c=@abilitytype>Стихия: </c>Усиление","<c=@abilitytype>Стихия: </c>Усиление,<c=@abilitytype>Стихия: </c>Усиление"
 <c=@abilitytype>Tonic.</c> Transform into another shape.,<c=@abilitytype>Тоник.</c> Примите другой облик.
 <c=@abilitytype>Travel.</c> Double-click to equip a bundle that changes how you move around the world.,"<c=@abilitytype>Передвижение.</c> Дважды щёлкните, чтобы взять набор, меняющий то, как вы перемещаетесь по миру."
 "<c=@flavor>""""Aurene has been eyeing this—and drooling—ever since I put it in my pack.""""</c>""","<c=@flavor>""""Аурин слюнки пускает, глядя на это, с тех пор как я положил это в свой рюкзак"""".</c>"""
@@ -465,16 +460,12 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 <c=@flavor>""""A bear ate his pauldrons? Is this common? Do bears eat armor?""""</c>""","<c=@flavor>«Обычный посох, способный выполнять все ваши повседневные задачи. Я бы не стал вызывать эттина на дуэль на посохах с ним»
 <c=@flavor>«Медведь съел его наплечники? Это нормально? Медведи едят броню?»</c>«"
 "<c=@flavor>""A clean kill."",<c=@flavor>""""Чистое убийство.""""","<c=@flavor>""Чистое убийство"".,<c=@flavor>""""Чистое убийство""""."
-"<c=@flavor>""A good focus is essential for the accurate channeling of energy."",<c=@flavor>""""Хороший фокус необходим для точной передачи энергии.""""",<c=@flavor>«Хороший фокус необходим для точной передачи энергии».<c=@flavor>«Хороший фокус необходим для точной передачи энергии».
-"<c=@flavor>""A mini grawl might worship its mini likeness."",<c=@flavor>""""Маленький граул может поклоняться своему миниатюрному подобию.""""","<c=@flavor>""Маленький граул может поклоняться своему миниатюрному подобию"".,<c=@flavor>""""Маленький граул может поклоняться своему миниатюрному подобию""""."
 "<c=@flavor>""A top seller at First Haven, after our spoons
 —Ulva</c>","<c=@flavor>Хитовый товар в Первой Гавани, уступающий только нашим ложкам
 —Ульва</c>"
 "<c=@flavor>""Aha! I've been looking for those.""
 —Cin</c>","<c=@flavor>«Ага! А я их искал».
 —Син</c>"
-"<c=@flavor>""Aim true. But telling you that is like telling the sun to rise."",<c=@flavor>""Целься верно. Но сказать тебе это — всё равно что приказать солнцу взойти.""""","<c=@flavor>""Целься верно. Но сказать тебе это — всё равно что приказать солнцу взойти"".,<c=@flavor>""Целься верно. Но сказать тебе это — всё равно что приказать солнцу взойти""""."
-"<c=@flavor>""Are we mere reflections of the truth?"",<c=@flavor>""""Являемся ли мы всего лишь отражениями истины?""""","<c=@flavor>«Являемся ли мы всего лишь отражениями истины?»,<c=@flavor>«Являемся ли мы всего лишь отражениями истины?»"
 "<c=@flavor>""Armor up."",
 —Magister Pagga</c>","<c=@flavor>«Бронируйся».,
 —Магистр Пагга</c>"
@@ -482,7 +473,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 —Cin</c>","<c=@flavor>«Пока еда всё ещё хороша, знать больше не хочу».
 —Син</c>"
 "<c=@flavor>""As you look into her eyes, you know that this must be the mother of all catfish. The one that always got away.""</c>","<c=@flavor>«Глядя ей в глаза, вы понимаете, что это, должно быть, мать всех сомов. Та самая, что всегда ускользала».</c>"
-"<c=@flavor>""Balance in all things."",<c=@flavor>""""Равновесие во всём.""""","<c=@flavor>""Равновесие во всём"".,<c=@flavor>""""Равновесие во всём""""."
 "<c=@flavor>""Bandits hate fire."",
 —Waldo</c>","<c=@flavor>«Бандиты ненавидят огонь».,
 —Вальдо</c>"
@@ -520,16 +510,13 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""Drink deep,' and grant me your power!"" - Kodan''s Bane'
 <c=@flavor>""""Dye these black for the ultimate in tactical armor.""""","<c=@flavor>""Пей до дна,' и даруй мне свою силу!"" - Проклятие Кодана'
 <c=@flavor>""""Покрась их в чёрный для идеальной тактической брони."""""
-"<c=@flavor>""Excessive use has been linked to hearing loss in skritt."",<c=@flavor>""""Чрезмерное использование связано с потерей слуха у скриттов.""""","<c=@flavor>""Чрезмерное использование связано с потерей слуха у скриттов"".,<c=@flavor>""""Чрезмерное использование связано с потерей слуха у скриттов""""."
 "<c=@flavor>""Finally out of the fahrar, ready to battle our enemies
 <c=@flavor>""""Find balance or fall into discord.""""","<c=@flavor>«Наконец-то за пределами фара, готов сражаться с врагами
 <c=@flavor>»»«Обрети равновесие или погрязни в раздоре»»."
-"<c=@flavor>""For a hero. Your hardwork will not be forgotten."",<c=@flavor>""""Для героя. Ваш труд не будет забыт.""""","<c=@flavor>""Для героя. Ваш труд не будет забыт"".,<c=@flavor>""""Для героя. Ваш труд не будет забыт""""."
 "<c=@flavor>""Ghosts hate tresspassers, and the branded hate everything. Take some stones from one ruin
 <c=@flavor>""""Gift this speargun to your friend that hates water. Hilarious.""""","<c=@flavor>""Призраки ненавидят нарушителей, а меченые ненавидят всё. Возьмите несколько камней из одних руин.
 <c=@flavor>""""Подарите это гарпунное ружьё своему другу, который ненавидит воду. Уморительно""""."
 "<c=@flavor>""Glub.""</c>",<c=@flavor>«Бульк».</c>
-"<c=@flavor>""Good for herding dolyaks."",<c=@flavor>""""Хорошо подходит для пасьбы долиаков.""""","<c=@flavor>""Хорошо подходит для пастьбы дольяков"".,<c=@flavor>""""Хорошо подходит для пасьбы дольяков""""."
 "<c=@flavor>""Have you seen how drafty these buildings are?""
 —Cin</c>","<c=@flavor>«Видел, какие в этих зданиях сквозняки?»
 —Син</c>"
@@ -557,7 +544,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 —Cin</c>","<c=@flavor>«Я знаю алхимика, который часто про такое расспрашивает».
 —Син</c>"
 "<c=@flavor>""I now see my duty to be a good soldier,' and I''ll never waver again.""</c>'","<c=@flavor>""Теперь я вижу свой долг — быть хорошим солдатом,' и я больше никогда не поколеблюсь.""</c>'"
-"<c=@flavor>""I should have had these on for that ambush."",<c=@flavor>""""Мне следовало надеть это для той засады.""""","<c=@flavor>""Мне следовало надеть это для той засады"".,<c=@flavor>""""Мне следовало надеть это для той засады""""."
 "<c=@flavor>""I'll take all the stuff, so you'll never have to"" is inscribed on the object as a reminder to clean one's inventory once in a while.</c>","<c=@flavor>«Я возьму всё барахло, чтобы тебе никогда не пришлось» — выгравировано на предмете как напоминание чистить инвентарь время от времени.</c>"
 "<c=@flavor>""I've been in there for hours. Much...too long...""</c>",<c=@flavor>«Я был там часами. Слишком... долго...»</c>
 "<c=@flavor>""If I wanted an ice bath, I'd swim the Janthir Bay!""</c>","<c=@flavor>«Если бы я хотел ледяную ванну, я бы искупался в заливе Джантур!»</c>"
@@ -567,7 +553,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""It chops wood, meat
 —Hune</c>","<c=@flavor>""Оно рубит дрова, мясо
 —Хьюн</c>"
-"<c=@flavor>""It even has a compass in the stock."",<c=@flavor>""""В прикладе даже есть компас.""""","<c=@flavor>""В прикладе даже есть компас"".,<c=@flavor>""""В прикладе даже есть компас""""."
 "<c=@flavor>""It's not like the captain will be needing it soon.""
 —Cin</c>","<c=@flavor>«Не похоже, что капитану это скоро понадобится».
 —Син</c>"
@@ -580,14 +565,12 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""Looks like the bandits, Inquest
 —Mathair</c>","<c=@flavor>""Похоже, бандиты, Инквест
 —Матайр</c>"
-"<c=@flavor>""May the winds bless the flight of your bolts."",<c=@flavor>""""Пусть ветры благословят полет твоих стрел.""""","<c=@flavor>""Пусть ветры благословят полёт твоих стрел"".,<c=@flavor>""""Пусть ветры благословят полёт твоих стрел""""."
 "<c=@flavor>""Melted snow makes a great solvent for tonics,' so you''d think melted eternal ice would be better. But the stuff doesn''t melt! However'
 <c=@flavor>""""Mental note: test associates always ask for gloves when working with the prototype. This may just be a coincidence.""""
 —Kamma</c>""","<c=@flavor>«Тающий снег — отличный растворитель для тоников, так что, казалось бы, расплавленный вечный лёд должен быть ещё лучше. Но эта штука не плавится! Однако»
 <c=@flavor>«""Пометка на будущее: сотрудники тестовой группы всегда просят перчатки при работе с прототипом. Возможно, это просто совпадение.""»
 — Камма</c>"
 "<c=@flavor>""Need a hand? Sorry,' I don''t get out much.""—Kamma</c>'","<c=@flavor>""Нужна рука? Прости, я редко выхожу в свет.""—Камма</c>'"
-"<c=@flavor>""Never leave home without a good axe."",<c=@flavor>""""Никогда не выходи из дома без хорошего топора.""""","<c=@flavor>""Никогда не выходи из дома без хорошего топора"".,<c=@flavor>""""Никогда не выходи из дома без хорошего топора""""."
 "<c=@flavor>""OK,' so it''s not really Deldrimor steel'
 —Bink</c>","<c=@flavor>""Ладно, это не настоящая дельдриморская сталь""
 —Бинк</c>"
@@ -597,7 +580,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""Out here, you cant settle for the run of the mill. These have my own special little modifications.""
 —Waldo</c>'","<c=@flavor>«Здесь не стоит довольствоваться обычным. У этих есть мои собственные маленькие модификации».
 —Уолдо</c>'"
-"<c=@flavor>""Pick up a shield and get in there!"",<c=@flavor>""""Хватай щит и в бой!""""","<c=@flavor>""Хватай щит и вступай в бой!"",<c=@flavor>""""Хватай щит и в бой!"""""
 "<c=@flavor>""Pointy!"",
 —Lugung</c>","<c=@flavor>
 «Острый!»
@@ -606,14 +588,12 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 <c=@flavor>""""Poor rabbits. We will need more of this luck if we are to succeed.""""","<c=@flavor>""Усилия по очистке от загрязнений часто бывают утомительными и неблагодарными. В такие времена нужен друг. Так что
 <c=@flavor>""""Бедные кролики. Нам понадобится больше этой удачи, если мы хотим преуспеть""""."
 "<c=@flavor>""Praise Joko!""</c>",<c=@flavor>«Славьте Джоко!»</c>
-"<c=@flavor>""Real men wear skirts."",<c=@flavor>""""Настоящие мужчины носят юбки.""""","<c=@flavor>""Настоящие мужчины носят юбки"".,<c=@flavor>""""Настоящие мужчины носят юбки""""."
 "<c=@flavor>""Recover, reuse
 <c=@flavor>""""Remember that time we threw grenades at drakes?""""</c>""","<c=@flavor>""Восстановление, повторное использование
 <c=@flavor>""""Помнишь, как мы кидали гранаты в драков?""""</c>"""
 "<c=@flavor>""Remember to show your support."",
 —Evon Gnashblade</c>","<c=@flavor>«Не забудьте выразить свою поддержку».,
 —Эвон Гнэшблейд</c>"
-"<c=@flavor>""Reminds me of days gone by."",<c=@flavor>""""Напоминает мне о былых днях.""""","<c=@flavor>""Напоминает мне о былых днях"".,<c=@flavor>""""Напоминает мне о былых днях""""."
 "<c=@flavor>""Seek knowledge."",
 —Bink</c>","<c=@flavor>«Ищи знания».,
 —Бинк</c>"
@@ -623,11 +603,9 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""Shiny pieces of foil! Make something nice, maybe. You be friend
 '—Collector Terksli in Lion''s Arch</c>'","<c=@flavor>""Блестящие кусочки фольги! Может, сделаешь что-нибудь красивое. Ты друг
 '—Коллекционер Терксли во Львином Шпиле</c>'"""
-"<c=@flavor>""Shoots shinies."",<c=@flavor>""""Стреляет блестяшками.""""","<c=@flavor>""Стреляет блестяшками"".,<c=@flavor>""""Стреляет блестяшками""""."
 "<c=@flavor>""Siege machinery takes a lot of lumber, and that takes a lot of axes. Sharp
 <c=@flavor>""""Sign below to support removing Dr. Bleent from the Arcane Council.""""</c>""","<c=@flavor>""Осадные механизмы требуют много древесины, а для этого нужно много топоров. Острых
 <c=@flavor>""""Подпишитесь ниже, чтобы поддержать отстранение доктора Блинта от Арканного совета"""".</c>"""
-"<c=@flavor>""Skelk love the sound of this thing."",<c=@flavor>""""Скелкам нравится звук этой штуки.""""","<c=@flavor>""Скелкам нравится звук этой штуки"".,<c=@flavor>""""Скелкам нравится звук этой штуки""""."
 "<c=@flavor>""So many shiny things when they many blow up on landing."",
 —Explorer Grretergrret</c>","<c=@flavor>«Здесь столько блестящих штуковин, когда они при взрыве взлетают на воздух».
 — Исследователь Грертергрет</c>"
@@ -637,16 +615,9 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""Sometimes even the sewer rats have things that are worth a few coins.""
 —Cin</c>","<c=@flavor>«Иногда даже у канализационных крыс есть вещи, стоящие пары монет».
 —Син</c>"
-"<c=@flavor>""Sometimes skritt find the strangest things."",<c=@flavor>""""Иногда скритты находят самые странные вещи.""""","<c=@flavor>""Иногда скритты находят самые странные вещи"".,<c=@flavor>""""Иногда скритты находят самые странные вещи""""."
-"<c=@flavor>""Specially made for mining."",<c=@flavor>""""Специально сделано для добычи.""""","<c=@flavor>""Специально сделано для добычи"".,<c=@flavor>""""Специально сделано для добычи""""."
-"<c=@flavor>""Stride silently behind your prey."",<c=@flavor>""""Крадитесь бесшумно за своей добычей.""""","<c=@flavor>""Крадитесь бесшумно за своей добычей"".,<c=@flavor>""""Крадитесь бесшумно за своей добычей""""."
-"<c=@flavor>""Sure to quiet the loudest riot."",<c=@flavor>""""Точно утихомирит самый громкий бунт.""""","<c=@flavor>«Наверняка утихомирит самый громкий бунт».,<c=@flavor>«Точно утихомирит самый громкий бунт»."
-"<c=@flavor>""Tasty! Try it and see!"",<c=@flavor>""""Вкусно! Попробуй и убедись!""""","<c=@flavor>""Вкусно! Попробуй и убедись!"",<c=@flavor>""""Вкусно! Попробуй и убедись!"""""
-"<c=@flavor>""The Vigil recognizes your steadfastness in battle."",<c=@flavor>""""Дозор признает твою стойкость в бою.""""","<c=@flavor>""Дозор признает твою стойкость в бою"".,<c=@flavor>""""Дозор признает твою стойкость в бою""""."
 "<c=@flavor>""The caves around here are deep and very dark. We always keep torches to search for the moas."",
 —Cassie</c>","<c=@flavor>«Пещеры здесь глубокие и очень тёмные. Мы всегда держим факелы, чтобы искать моа».,
 —Касси</c>"
-"<c=@flavor>""The dredge are no match for our superior weapons and knowledge."",<c=@flavor>""""Дредги не ровня нашему превосходному оружию и знаниям.""""","<c=@flavor>""Дредги не чета нашему превосходному оружию и знаниям"".,<c=@flavor>""Дредги не ровня нашему превосходному оружию и знаниям""."
 "<c=@flavor>""The less you train with these, the more dangerous you are
 —Vigil Tactician Blazefur</c>","<c=@flavor>""Чем меньше тренируешься с ними, тем опаснее становишься
 — Тактик Дозора Пламяшерст</c>"
@@ -660,7 +631,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""These badges are amazing. There are so many interesting ranks, positions
 <c=@flavor>""""These boots are made for battle.""""","<c=@flavor>""Эти значки потрясающие. Здесь так много интересных званий, должностей
 <c=@flavor>""""Эти сапоги созданы для битвы""""."
-"<c=@flavor>""These can also hold ale."",<c=@flavor>""""Они также могут держать эль.""""","<c=@flavor>""Они также могут держать эль"".,<c=@flavor>""""Они также могут держать эль""""."
 "<c=@flavor>""These guns have so many gears,' I''m sure the one this is from wont be missing it.""'
 —Legionnaire Sleekfur</c>","<c=@flavor>""В этих пушках так много шестерёнок,' что та, из которой эта, наверняка не заметит её пропажи.""'
 —Legionnaire Sleekfur</c>"
@@ -668,7 +638,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""These should keep you safe until we can get more supplies."",
 —Magister Kathryn</c>","<c=@flavor>«Они защитят вас, пока мы не получим новые припасы».,
 —Magister Kathryn</c>"
-"<c=@flavor>""This can dispell the darkest of nights."",<c=@flavor>""«Это может развеять самую тёмную ночь.»","<c=@flavor>""Это может развеять самую тёмную ночь"".,<c=@flavor>""«Это может развеять самую тёмную ночь»""."
 "<c=@flavor>""This destroys just about anything: artifacts, grubs
 —Jezza</c>","<c=@flavor>«Это уничтожает почти всё: артефакты, личинки
 —Джезза</c>"
@@ -684,10 +653,6 @@ Can be exchanged for a non-soulbound version at merchants in Amnoon.","32 сло
 "<c=@flavor>""This may seem daunting, but remember
 —Magister Pagga</c>","<c=@flavor>«Это может показаться пугающим, но помните
 —Magister Pagga</c>»"
-"<c=@flavor>""This one lasted longer than the rest."",<c=@flavor>""""Этот продержался дольше остальных.""""","<c=@flavor>""Этот продержался дольше остальных"".,<c=@flavor>""""Этот продержался дольше остальных""""."
-"<c=@flavor>""This pin might be a little too tactical."",<c=@flavor>""""Эта булавка может быть чересчур тактической.""""","<c=@flavor>""Эта булавка может быть чересчур тактической"".,<c=@flavor>""""Эта булавка может быть чересчур тактической""""."
-"<c=@flavor>""This should help when fighting the icebrood."",<c=@flavor>""""Это должно помочь в бою с ледокровавицей.""""","<c=@flavor>«Это должно помочь в бою с ледокровавицей»,<c=@flavor>«""Это должно помочь в бою с ледокровавицей""»"
-"<c=@flavor>""This should help you in your adventures."",<c=@flavor>""""Это должно помочь вам в ваших приключениях.""""","<c=@flavor>""Это должно помочь вам в ваших приключениях"".,<c=@flavor>""""Это должно помочь вам в ваших приключениях""""."
 "<c=@flavor>""This was taken from a large jotun."",
 —Neida</c>","<c=@flavor>«Это было взято у большого ётуна».,
 —Нейда</c>"

--- a/items/items_126.csv
+++ b/items/items_126.csv
@@ -2,16 +2,12 @@ english,translate
 "<c=@flavor>""Used strictly for religious purposes, of course.""
 —Cin</c>","<c=@flavor>«Используется строго в религиозных целях, разумеется».
 —Син</c>"
-"<c=@flavor>""Was hoping to get weapons or food. Got this instead."",<c=@flavor>""""Надеялся получить оружие или еду. А получил вот это.""""","<c=@flavor>""Надеялся получить оружие или еду. А получил вот это"".,<c=@flavor>""""Надеялся получить оружие или еду. А получил вот это""""."
 "<c=@flavor>""We had to completely re-engineer the insides of these weapons to not get gummed up."",
 —Engineer Verutum</c>","<c=@flavor>«Нам пришлось полностью переработать внутренности этого оружия, чтобы оно не забивалось»,
 — инженер Верутум</c>"
 "<c=@flavor>""We had to modify these to free us up during scouting expeditions."",
 —Fahrtak </c>","<c=@flavor>«Нам пришлось их модифицировать, чтобы освободить руки во время разведывательных вылазок»,
 — Фартак </c>"
-"<c=@flavor>""We just have to be stronger and faster than the centaurs."",<c=@flavor>""""Мы просто должны быть сильнее и быстрее кентавров.""""","<c=@flavor>""Мы просто должны быть сильнее и быстрее кентавров"".,<c=@flavor>""""Мы просто должны быть сильнее и быстрее кентавров""""."
-"<c=@flavor>""We must each bring balance in our own ways."",<c=@flavor>""""Каждый из нас должен привносить равновесие по-своему.""""","<c=@flavor>""Каждый из нас должен привносить равновесие по-своему"".,<c=@flavor>""""Каждый из нас должен привносить равновесие по-своему""""."
-"<c=@flavor>""We wont be a secret here for long."",<c=@flavor>""""Мы здесь долго не останемся незамеченными.""""","<c=@flavor>""Мы здесь долго не останемся незамеченными"".,<c=@flavor>""""Мы здесь долго не останемся незамеченными""""."
 "<c=@flavor>""Well,' he wasn''t using it anymore."" —Rox</c>'","<c=@flavor>«Ну, он же всё равно не пользовался». — Рокс</c>"
 "<c=@flavor>""What they lack in common sense, they make up for in their ability to collect scraps. In this case
 <c=@flavor>""""What were these doing back there?""""","<c=@flavor>""Чего им не хватает в здравом смысле, они компенсируют умением собирать обрезки. В данном случае
@@ -20,25 +16,18 @@ english,translate
 —Sergeant Yarbrough</c>'","<c=@flavor>«Пока некоторые молятся Бальтазару, это напоминает мне, что покой солдата неизбежен».
 —Sergeant Yarbrough</c>"
 "<c=@flavor>""Who's a good little journeykit?""</c>",<c=@flavor>«Кто тут хороший маленький путешественник?»</c>
-"<c=@flavor>""Why did they come here? What were these used for? If only I could find the answers."",<c=@flavor>""""Зачем они пришли? Для чего это использовалось? Если бы я только мог найти ответы.""""","<c=@flavor>""Зачем они пришли? Для чего это использовалось? Если бы я только мог найти ответы"".,<c=@flavor>""""Зачем они пришли? Для чего это использовалось? Если бы я только мог найти ответы""""."
 "<c=@flavor>""With a hero like you around, the Flame Legion doesn't stand a chance.""
 —Corva Sharpclaw</c>","<c=@flavor>«С таким героем, как ты, рядом у Flame Legion нет шансов».
 —Corva Sharpclaw</c>"
-"<c=@flavor>""Wolf watches over you."",<c=@flavor>""""Волк присматривает за тобой.""""",<c=@flavor>«Волк присматривает за тобой».<c=@flavor>«Волк присматривает за тобой»
 "<c=@flavor>""Yes yes, it was a tragedy. But also an opportunity! Those dam pieces are historical artifacts!""
 —Cin</c>","<c=@flavor>«Да, да, это была трагедия. Но и возможность тоже! Эти куски дамбы — исторические артефакты!»
 —Син</c>"
-"<c=@flavor>""You can hear this from the highest peaks"",<c=@flavor>""""Ты можешь услышать это с высочайших вершин""""","<c=@flavor>""Это можно услышать с высочайших вершин"",<c=@flavor>""""Ты можешь услышать это с высочайших вершин"""""
-"<c=@flavor>""You can hit them even harder with my special gloves."",<c=@flavor>""""Мои особые перчатки помогут вам бить их ещё сильнее.""""","<c=@flavor>""Вы можете бить их ещё сильнее с моими особыми перчатками"".,<c=@flavor>""""Мои особые перчатки помогут вам бить их ещё сильнее""""."
 "<c=@flavor>""You can read between the lines. More harnesses than dolyaks."",
 —Warmaster Jofast</c>","<c=@flavor>«Вы умеете читать между строк. Больше упряжи, чем дольяков».
 —Warmaster Jofast</c>"
-"<c=@flavor>""You could sneak up on the Master of Whispers in these things."",<c=@flavor>""""В этом можно подкрасться к Мастеру Шепотов.""""","<c=@flavor>""В этом можно подкрасться к Мастеру Шепчущих"".,<c=@flavor>""""В этом можно подкрасться к Мастеру Шепчущих""""."
-"<c=@flavor>""You must outthink them."",<c=@flavor>""""Вы должны перехитрить их.""""","<c=@flavor>""Вы должны перехитрить их"".,<c=@flavor>""""Вы должны перехитрить их""""."
 "<c=@flavor>""You scratched my back,' and now I''ll scratch yours. Take a look at this crate of rifles we recovered from the wreck of the Argent Warrior. See any you like?"" 
 —Admiral Clarinda Demard</c>'","<c=@flavor>«Ты почесал мне спинку, и теперь я почешу твою. Взгляни на этот ящик с винтовками, которые мы извлекли из обломков «Аргент Уорриор». Видишь какие-нибудь, что тебе по душе?» 
 —Адмирал Кларинда Демард</c>"
-"<c=@flavor>""You see it; you can shoot it."",<c=@flavor>""""Видишь — стреляй.""""","<c=@flavor>""Видишь — стреляй"".,<c=@flavor>""""Видишь — стреляй""""."
 "<c=@flavor>""You'll need a shield when they start throwing bottles, gears, and the occasional bomb.""
 —Scholar Antal the Patient</c>","<c=@flavor>«Тебе понадобится щит, когда полетят бутылки, шестерни и случайная бомба».
 —Учёная Антал Терпеливая</c>"
@@ -49,7 +38,6 @@ english,translate
 'Найдено во Львиной Арке.'"
 "<c=@flavor>A gift from the treasuries of the King of All Cats.</c>""","<c=@flavor>Дар из сокровищниц Короля всех кошек.</c>"""
 "<c=@flavor>A lot of ways to get this chest, but the portal spikes are still a thorn in my side.</c>","<c=@flavor>Много способов получить этот сундук, но портальные шипы всё ещё заноза в моём боку.</c>"
-"<c=@flavor>A token of my eternal love.,<c=@flavor>Знак моей вечной любви.","<c=@flavor>Знак моей вечной любви.,<c=@flavor>Знак моей вечной любви."
 <c=@flavor>Amira asked you to be careful with these.</c>,<c=@flavor>Амира просила вас быть осторожными с ними.</c>
 "<c=@flavor>An attached note reads, ""Until the last enemy of Kryta falls
 Double-click to open.","<c=@flavor>Прилагаемая записка гласит: «Пока не падет последний враг Крайта
@@ -93,188 +81,26 @@ Double-click to open.","<c=@flavor>Прилагаемая записка гла�
 <c=@flavor>This stone crackles with an inner energy.</c>,<c=@flavor>Этот камень потрескивает от внутренней энергии.</c>
 "<c=@flavor>This was earned by prevailing at the highest levels of competition in the Mists.</c>""","<c=@flavor>Добыто за победу на высших уровнях состязаний в Туманных землях.</c>"""
 <c=@flavor>This weapon is used to craft the legendary axe Frostfang.,<c=@flavor>Это оружие используется для создания легендарного топора «Frostfang».
-"<c=@flavor>This weapon is used to craft the legendary axe Frostfang.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Frostfang,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного топора Ледяной Клык.,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар Ледяного Клыка,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary dagger Incinerator.,<c=@flavor>Это оружие используется для создания легендарного кинжала «Incinerator».
-"<c=@flavor>This weapon is used to craft the legendary dagger Incinerator.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Incinerator,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного кинжала «Инсинератор».,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар Инсинератора,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary focus The Minstrel.,<c=@flavor>Это оружие используется для создания легендарного фокуса «The Minstrel».
-"<c=@flavor>This weapon is used to craft the legendary focus The Minstrel.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Minstrel,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного фокуса «The Minstrel».,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар Менестреля,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary greatsword Sunrise.,<c=@flavor>Это оружие используется для создания легендарного двуручного меча «Sunrise».
-"<c=@flavor>This weapon is used to craft the legendary greatsword Sunrise.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Sunrise,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного двуручного меча «Восход».,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар Восхода,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary greatsword Twilight.,<c=@flavor>Это оружие используется для создания легендарного двуручного меча «Twilight».
-"<c=@flavor>This weapon is used to craft the legendary greatsword Twilight.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Twilight,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного двуручного меча «Сумерки».,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар Сумерек,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary hammer The Juggernaut.,<c=@flavor>Это оружие используется для создания легендарного молота «The Juggernaut».
-"<c=@flavor>This weapon is used to craft the legendary hammer The Juggernaut.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Juggernaut,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного молота «Колосс».,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар «Колосса»,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary harpoon gun Frenzy.,<c=@flavor>Это оружие используется для создания легендарного гарпунного ружья «Frenzy».
-"<c=@flavor>This weapon is used to craft the legendary harpoon gun Frenzy.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Frenzy,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного гарпуна «Бешенство».,
-Объедините это оружие в Мистической кузнице с:,
-• 1 Дар бешенства,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary longbow Kudzu.,<c=@flavor>Это оружие используется для создания легендарного длинного лука «Kudzu».
-"<c=@flavor>This weapon is used to craft the legendary longbow Kudzu.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Kudzu,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного длинного лука Кудзу.
-Соедините это оружие в Мистической кузнице с:
-• 1 Дар Кудзу,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary mace The Moot.,<c=@flavor>Это оружие используется для создания легендарной булавы «The Moot».
-"<c=@flavor>This weapon is used to craft the legendary mace The Moot.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Moot,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарной булавы «The Moot».,
-Соедините это оружие в Мистической кузнице с:
-• 1 Дар The Moot,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary pistol Quip.,<c=@flavor>Это оружие используется для создания легендарного пистолета «Quip».
 <c=@flavor>This weapon is used to craft the legendary rifle The Predator.,<c=@flavor>Это оружие используется для создания легендарной винтовки «The Predator».
-"<c=@flavor>This weapon is used to craft the legendary rifle The Predator.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Predator,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарной винтовки «Хищник».
-Соедините это оружие в Мистической кузнице с:
-• 1 Дар Хищника,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary scepter Meteorlogicus.,<c=@flavor>Это оружие используется для создания легендарного скипетра «Meteorlogicus».
-"<c=@flavor>This weapon is used to craft the legendary scepter Meteorlogicus.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Meteorlogicus,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного скипетра «Метеорлогикус».,
-Соедините это оружие в Мистической кузнице с:
-• 1 Дар Метеорлогикуса,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary shield The Flameseeker Prophecies.,<c=@flavor>Это оружие используется для создания легендарного щита «The Flameseeker Prophecies».
-"<c=@flavor>This weapon is used to craft the legendary shield The Flameseeker Prophecies.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Flameseeker Prophecies,• 1 [Дар|Дара|Даров] «Пророчества Ищущего Пламя»
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного щита «The Flameseeker Prophecies».,
-Объедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Flameseeker Prophecies,• 1 Gift of The Flameseeker Prophecies
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary short bow The Dreamer.,<c=@flavor>Это оружие используется для создания легендарного короткого лука «The Dreamer».
-"<c=@flavor>This weapon is used to craft the legendary short bow The Dreamer.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of The Dreamer,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного короткого лука «The Dreamer».,
-Соедините это оружие в Мистической кузнице с:
-• 1 Дар Мечтателя,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary spear Kamohoali'i Kotaki.,<c=@flavor>Это оружие используется для создания легендарного копья «Kamohoali'i Kotaki».
 <c=@flavor>This weapon is used to craft the legendary spear Klobjarne Geirr.,<c=@flavor>Это оружие используется для создания легендарного копья «Klobjarne Geirr».
-"<c=@flavor>This weapon is used to craft the legendary spear Klobjarne Geirr.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Janthir Wilds,• 1 Дар диких земель Джантира
-• 1 Gift of the Homesteader,
-• 1 Gift of Klobjarne Geirr</c>","<c=@flavor>Это оружие используется для создания легендарного копья Клобьярн Гейрр.,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Janthir Wilds,• 1 Gift of Janthir Wilds
-• 1 Gift of the Homesteader,
-• 1 Дар Клобьярн Гейрр</c>"
 <c=@flavor>This weapon is used to craft the legendary staff The Bifrost.,<c=@flavor>Это оружие используется для создания легендарного посоха «The Bifrost».
 <c=@flavor>This weapon is used to craft the legendary sword Bolt.,<c=@flavor>Это оружие используется для создания легендарного меча «Bolt».
-"<c=@flavor>This weapon is used to craft the legendary sword Bolt.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Bolt,• 1 Дар болта
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного меча «Болт».,
-Соедините это оружие в Мистической кузнице с:,Соедините это оружие в Мистической кузнице с:
-• 1 Дар болта,• 1 Дар болта
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary torch Rodgort.,<c=@flavor>Это оружие используется для создания легендарного факела «Rodgort».
-"<c=@flavor>This weapon is used to craft the legendary torch Rodgort.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Rodgort,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного факела Родгорта.
-Соедините это оружие в Мистической кузнице с:
-• 1 Дар Родгорта,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary trident Kraitkin.,<c=@flavor>Это оружие используется для создания легендарного трезубца «Kraitkin».
-"<c=@flavor>This weapon is used to craft the legendary trident Kraitkin.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Kraitkin,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного трезубца «Крайткин».,
-Соедините это оружие в Мистической кузнице с:,
-• 1 Дар Крайткина,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>"
 <c=@flavor>This weapon is used to craft the legendary warhorn Howler.,<c=@flavor>Это оружие используется для создания легендарного боевого рога «Howler».
-"<c=@flavor>This weapon is used to craft the legendary warhorn Howler.,
-Combine this weapon in the Mystic Forge with:,Соедините это оружие в Мистической кузнице с:
-• 1 Gift of Howler,
-• 1 Gift of Mastery,
-• 1 Gift of Fortune</c>","<c=@flavor>Это оружие используется для создания легендарного боевого рога «Ревун».
-Соедините это оружие в Мистической кузнице с:
-1 Даром Ревуна,
-1 Даром Мастерства,
-1 Даром Удачи</c>"
 <c=@flavor>Those blast gyros really do some damage. Maybe you should focus on them first?</c>,"<c=@flavor>Эти взрывные гироскопы действительно наносят урон. Может, стоит сначала сосредоточиться на них?</c>"
 "<c=@flavor>Time heals all wounds.</c>""","<c=@flavor>Время лечит все раны.</c>"""
 <c=@flavor>Unbridled joy is the domain of youth.</c>,<c=@flavor>Безудержная радость — удел юности.</c>
@@ -322,15 +148,10 @@ A book of homestead decoration recipes needed to craft objects from Amnytas.","�
 Книга рецептов украшений для усадьбы, необходимых для создания прочих предметов.,'Книга рецептов украшений для усадьбы, необходимых для создания прочих предметов.'
 Книга рецептов украшений для усадьбы, необходимых для создания предметов из Амнитаса."
 A box salvaged from the Aetherblades containing various items from Shing Jea Monastery. A monk nearby is probably looking for this.,"Коробка, снятый у Эфирных Клинков, с разными предметами из монастыря Шинг Джея. Наверняка его ищет кто-то из здешних монахов."
-"A box salvaged from the Aetherblades containing various items from Shing Jea Monastery. A monk nearby is probably looking for this.,'Коробка, извлечённая из Эфирных клинков, содержащая различные предметы из монастыря Шинг Джеа. Монах поблизости, вероятно, ищет её.'
-This item has no use outside of a collection.","Коробка, извлечённая из Эфирных клинков, содержащая различные предметы из монастыря Shing Jea. Монах поблизости, вероятно, ищет её.
-Этот предмет не имеет применения вне коллекции."
 "A collection of items recovered from the cave. Contains a personal bandit chest for your home instance, obsidian shards
 A collection of items to aid in the training of novice adventurers.","Коллекция предметов, найденных в пещере. Содержит личный сундук бандита для вашего домашнего экземпляра, осколки обсидиана.
 Коллекция предметов для помощи в обучении начинающих искателей приключений."
-"A collection of supplies for any passionate coffee brewer!,Набор припасов для любого страстного любителя кофе!",Набор припасов для любого страстного любителя кофе!
 A crystal from a Branded creature in Jahai.,Кристалл клеймёного существа из Джахай.
-"A crystal from a Branded creature in Jahai.,Кристалл из Проклятого существа в Джахаи.","Кристалл из Проклятого существа в Джахаи.,Кристалл из Проклятого существа в Джахаи."
 A device for stabilizing unstable magic rifts.,Устройство для стабилизации нестабильных магических разломов.
 "A device for stabilizing unstable magic rifts.,
 Double-click to equip.","Устройство для стабилизации нестабильных магических разрывов.
@@ -359,86 +180,23 @@ A gift of fortune used to create legendary weapons.,"Дар удачи, испо
 A gift of history used to create The Flameseeker Prophecies.,"Дар истории, используемый для создания «The Flameseeker Prophecies»."
 A gift of ice used to create Frostfang.,"Дар льда, используемый для создания «Frostfang»."
 A gift of light used to create Sunrise and Endless Summer.,"Дар света, используемый для создания «Sunrise» и «Endless Summer»."
-"A gift of light used to create Sunrise and Endless Summer.,'Дар света",используемый для создания «Рассвета» и «Бесконечного лета».'
 A gift of lightning used to create Bolt.,"Дар молнии, используемый для создания «Bolt»."
 A gift of metal used to create generation one and two legendary weapons and the legendary back item Ad Infinitum.,"Дар металла, используемый для создания легендарного оружия первого и второго поколений, а также легендарного наспинного предмета «Ad Infinitum»."
 A gift of music used to create The Minstrel.,"Дар музыки, используемый для создания «The Minstrel»."
-"A gift of music used to create The Minstrel.,'Дар музыки",используемый для создания «Менестреля».'
 A gift of nature used to create Kudzu.,"Дар природы, используемый для создания «Kudzu»."
 A gift of stealth used to create The Predator.,"Дар невидимости, используемый для создания «The Predator»."
 A gift of water used to craft Frenzy.,"Дар воды, используемый для создания «Frenzy»."
 A gift of weather used to create Meteorlogicus.,"Дар погоды, используемый для создания «Meteorlogicus»."
 A gift of wood used to create generation one and two legendary weapons and the legendary back item Ad Infinitum.,"Дар дерева, используемый для создания легендарного оружия первого и второго поколений, а также легендарного наспинного предмета «Ad Infinitum»."
 A gift used in legendary crafting.,"Дар, используемый в создании легендарок."
-"A gift used to create legendary weapons.,'Подарок, используемый для создания легендарного оружия.'
-Acquired from fully exploring all Central Tyrian maps.","Подарок, используемый для создания легендарного оружия.
-Получается при полном исследовании всех карт Центрального Тирии."
-"A gift used to create legendary weapons.,'Подарок, используемый для создания легендарного оружия.'
-Made by combining these items in the Mystic Forge:,
-• 1 Bloodstone Shard,
-• 250 Obsidian Shards,
-• 1 Gift of Exploration,
-• 1 Gift of Battle","Подарок, используемый для создания легендарного оружия.
-Создаётся путём комбинирования этих предметов в Мистической кузнице:
-• 1 Bloodstone Shard,
-• 250 Осколков обсидиана,
-• 1 Gift of Exploration,
-• 1 Gift of Battle"
-"A gift used to create legendary weapons.,'Подарок, используемый для создания легендарного оружия.'
-Made by combining these items in the Mystic Forge:,
-• 250 Vials of Powerful Blood,
-• 250 Powerful Venom Sacs,
-• 250 Elaborate Totems,• 250 Искусных тотемов
-• 250 Piles of Crystalline Dust","Подарок, используемый для создания легендарного оружия.
-Создаётся путём объединения этих предметов в Мистической кузнице:
-• 250 Флаконов мощной крови
-• 250 Мощных мешочков с ядом
-• 250 Искусных тотемов
-• 250 Куч кристаллической пыли"
-"A gift used to create legendary weapons.,'Подарок, используемый для создания легендарного оружия.'
-Made by combining these items in the Mystic Forge:,
-• 250 Vicious Fangs,
-• 250 Armored Scales,• 250 бронированных чешуй
-• 250 Vicious Claws,
-• 250 Ancient Bones","Подарок, используемый для создания легендарного оружия.,'Подарок, используемый для создания легендарного оружия.'
-Создается путем объединения этих предметов в Мистической кузнице:,
-• 250 Злобных клыков,
-• 250 Бронированных чешуй,• 250 бронированных чешуй
-• 250 Злобных когтей,
-• 250 Древних костей"
-"A gift used to create legendary weapons.,'Подарок, используемый для создания легендарного оружия.'
-Purchased from dungeon vendors for 500 Tales of Dungeon Delving.","Подарок, используемый для создания легендарного оружия.
-Приобретено у торговцев в подземельях за 500 Сказаний о подземельях."
 A gift used to create the legendary axe Frostfang.,"Дар, используемый для создания легендарного топора «Frostfang»."
 A gift used to create the legendary dagger Incinerator.,"Дар, используемый для создания легендарного кинжала «Incinerator»."
 A gift used to create the legendary focus The Minstrel.,"Дар, используемый для создания легендарного фокуса «The Minstrel»."
-"A gift used to create the legendary focus The Minstrel.,'«Дар, используемый для создания легендарного фокуса «Менестрель».'
-Made by combining these items in the Mystic Forge:,
-• 1 Gift of Energy,
-• 1 Gift of Music,
-• 100 Icy Runestones,
-• 1 Superior Sigil of Energy","Дар, используемый для создания легендарного фокуса «The Minstrel».,'«Дар, используемый для создания легендарного фокуса «The Minstrel».'
-Создается путем объединения этих предметов в Мистической кузнице:,
-• 1 Gift of Energy,
-• 1 Gift of Music,
-• 100 Ледяных рунных камней,
-• 1 Superior Sigil of Energy"
 A gift used to create the legendary greatsword Sunrise.,"Дар, используемый для создания легендарного двуручного меча «Sunrise»."
 A gift used to create the legendary greatsword Twilight.,"Дар, используемый для создания легендарного двуручного меча «Twilight»."
 A gift used to create the legendary hammer The Juggernaut.,"Дар, используемый для создания легендарного молота «The Juggernaut»."
 A gift used to create the legendary harpoon gun Frenzy.,"Дар, используемый для создания легендарного гарпунного ружья «Frenzy»."
 A gift used to create the legendary longbow Kudzu.,"Дар, используемый для создания легендарного длинного лука «Kudzu»."
-"A gift used to create the legendary longbow Kudzu.,'Подарок, используемый для создания легендарного длинного лука Кудзу.'
-Made by combining these items in the Mystic Forge:,
-• 1 Gift of Wood,
-• 1 Gift of Nature,
-• 100 Icy Runestones,
-• 1 Superior Sigil of Celerity","Дар, используемый для создания легендарного длинного лука Кудзу.,'Подарок, используемый для создания легендарного длинного лука Кудзу.'
-Создаётся путём объединения этих предметов в Мистической кузнице:,
-• 1 Gift of Wood,
-• 1 Gift of Nature,
-• 100 Ледяных рунических камней,
-• 1 Superior Sigil of Celerity"
 A gift used to create the legendary mace The Moot.,"Дар, используемый для создания легендарной булавы «The Moot»."
 A gift used to create the legendary pistol Quip.,"Дар, используемый для создания легендарного пистолета «Quip»."
 A gift used to create the legendary rifle The Predator.,"Дар, используемый для создания легендарной винтовки «The Predator»."
@@ -447,17 +205,6 @@ A gift used to create the legendary shield The Flameseeker Prophecies.,"Дар, 
 A gift used to create the legendary short bow The Dreamer.,"Дар, используемый для создания легендарного короткого лука «The Dreamer»."
 A gift used to create the legendary spear Kamohoali'i Kotaki.,"Дар, используемый для создания легендарного копья «Kamohoali'i Kotaki»."
 A gift used to create the legendary staff The Bifrost.,"Дар, используемый для создания легендарного посоха «The Bifrost»."
-"A gift used to create the legendary staff The Bifrost.,
-Made by combining these items in the Mystic Forge:,
-• 1 Gift of Energy,
-• 1 Gift of Color,• 1 Дар цвета
-• 100 Icy Runestones,
-• 1 Superior Sigil of Nullification","Дар, используемый для создания легендарного посоха «The Bifrost».,
-Создаётся путём объединения этих предметов в Мистической кузнице:,
-• 1 Gift of Energy,
-• 1 Gift of Color,• 1 Gift of Color,
-• 100 Ледяных рунных камней,
-• 1 высший сигил обнуления"
 A gift used to create the legendary sword Bolt.,"Дар, используемый для создания легендарного меча «Bolt»."
 A gift used to create the legendary torch Rodgort.,"Дар, используемый для создания легендарного факела «Rodgort»."
 A gift used to create the legendary trident Kraitkin.,"Дар, используемый для создания легендарного трезубца «Kraitkin»."
@@ -486,14 +233,10 @@ A nutritious and magic-imbued snack made specially for jackals! Double-click to 
 Питательный и магический перекус, приготовленный специально для шакалов! Дважды щёлкните, чтобы накормить им своего шакала."
 A nutritious and magic-imbued snack made specially for jackals! Double-click to feed this to your jackal.,"Питательное лакомство, напитанное магией и созданное специально для шакалов! Дважды щёлкните, чтобы угостить своего шакала."
 A parting gift from Glint. It hums with strange energy.,Прощальный дар Глинт. Он гудит от странной энергии.
-"A parting gift from Glint. It hums with strange energy.,Прощальный дар от Глинт. Он гудит странной энергией.",Прощальный дар от Глинт. Он гудит странной энергией.
 "A race against time, again and again...","Гонка со временем, снова и снова..."
 "A recollection of the life and deeds of Mad King Thorn,' as told by his loyal subjects and friends. Contains a complete account of King Oswald Thorn''s life'
 A record of your exploits as a hunter.","Воспоминания о жизни и деяниях Безумного короля Торна, рассказанные его верными подданными и друзьями. Содержит полный отчёт о жизни короля Освальда Торна.
 Запись о ваших подвигах как охотника."
-"A record of your exploits as a naturalist.,Запись ваших достижений как натуралиста.
-Double-click to read.","Запись ваших достижений как натуралиста.,
-Дважды щёлкните, чтобы прочитать."
 A relic from a time when heket were common throughout Kourna.,"Реликвия времен, когда хекеты были обычны в Курне."
 "A secret letter for Aisha Jedgok, who is undercover among the ghosts of the Lair of the Forgotten.
 Double-click to locate.","Секретное письмо для Айши Джедгок, которая скрывается среди призраков Логова Забытых.
@@ -512,9 +255,6 @@ Use 12 petals to crystalize a Teal Bloom.,
 "A special explosive that destroys steam creatures. Remember,' don''t use too much.'","Особая взрывчатка, уничтожающая паровых созданий. Помните, не используйте слишком много."
 "A sugary root grown in the choya village.""","Сладкий корень, выращенный в деревне чойя."""""
 "A tarnished silver locket containing an exquisite miniature family portrait. At least, it was exquisite before it was defaced.","Потускневший серебряный медальон с изысканным миниатюрным семейным портретом. По крайней мере, он был изысканным, пока его не испортили."
-"A treat that combines the flavors of common crustaceans and three types of fish. Double-click to feed this to your skimmer.,'«Угощение, сочетающее вкусы обычных ракообразных и трёх видов рыбы». Дважды щёлкните, чтобы скормить его скату.'
-Gives bonus Mastery experience once per day.","Угощение, сочетающее вкусы обычных ракообразных и трёх видов рыбы. Дважды щёлкните, чтобы скормить его скиммеру.,
-Даёт дополнительный опыт мастерства один раз в день."
 A unicorn statue used to create The Dreamer.,"Статуя единорога, используемая для создания «Мечтателя»."
 A vial of liquid flame used to create Incinerator and Rodgort.,"Флакон жидкого пламени, используемый для создания «Инсинератора» и «Родгорта»."
 A vial of pure quicksilver used to create The Juggernaut.,"Флакон чистой ртути, используемый для создания «Джаггернаута»."
@@ -580,7 +320,6 @@ This item is used to craft or purchase Slumbering Lightborne weapons, which she 
 Этот предмет используется для создания или покупки оружия «Дремлющий Светонос», для которого она продаёт рецепты или помощь."
 Acquired from fully exploring all Central Tyrian maps.,Получается за полное исследование всех карт Центральной Тирии.
 Acquired from the WvW Gift of Battle Item Reward Track.,Получается на пути наград «Gift of Battle» в WvW.
-"Acquired occasionally by earning a silver medal or better in Shipwreck Strand adventures.,Получается изредка за получение серебряной медали или лучше в приключениях «Кораблекрушение на берегу».","Выдаётся изредка за получение серебряной медали или лучше в приключениях «Кораблекрушение на берегу».,Выдаётся изредка за получение серебряной медали или лучше в приключениях «Кораблекрушение на берегу»."
 "Acquired occasionally by earning a silver medal or better in Starlit Weald adventures.,
 Trade to alliance field quartermasters in Castora for a pair of Extremis Leggings.","Иногда можно получить, заработав серебряную медаль или выше в приключениях Звёздной рощи.,
 Обменяйте у полевых интендантов альянса в Касторе на пару поножей «Экстремис»."
@@ -590,11 +329,9 @@ Trade to alliance field quartermasters in Castora for a pair of Extremis Gloves.
 "Acquired occasionally from jumping puzzles in Starlit Weald.,
 Trade to alliance field quartermasters in Castora for a pair of Extremis Boots.","Добывается иногда из прыжковых головоломок в Звёздной Роще.,
 Обменяйте у полевых интендантов союза в Касторе на пару сапог «Экстремис»"
-"Acquired occasionally from mystery mirrors in Shipwreck Strand.,Приобретается иногда из загадочных зеркал на Берегу кораблекрушений.",Приобретается иногда из загадочных зеркал на Берегу кораблекрушений.
 "Acquired occasionally from mystery mirrors in Starlit Weald.,
 Trade to alliance field quartermasters in Castora for an Extremis Mantle.","Изредка добывается из загадочных зеркал в Starlit Weald.,
 Обменяйте у полевых интендантов союза в Касторе на мантию «Экстремис»."
-"Acquired occasionally from obscured chests in Shipwreck Strand.,Иногда можно получить из спрятанных сундуков на Берегу кораблекрушений.""",Иногда можно получить из спрятанных сундуков на Берегу кораблекрушений.
 "Acquired occasionally from obscured chests in Starlit Weald.,
 Trade to alliance field quartermasters in Castora for an Extremis Hood.","Изредка добывается из скрытых сундуков в Звёздной роще.
 Обменяйте у полевых интендантов союза в Касторе на капюшон «Экстремис»."
@@ -605,7 +342,6 @@ Trade to alliance field quartermasters in Castora for an Extremis Hood.","Изр
 Trade to alliance field quartermasters in Castora for an Extremis Coat.","Иногда выпадает из мета-события «Тайны Пустоши» в Звёздной Пустоши.,
 Обменяйте полевым квартирмейстерам альянса в Касторе на куртка «Экстремис»."
 Activate a memory crystal while riding on your skyscale.,"Активировать кристалл памяти, находясь верхом на скайскейле."
-"Activate this to unlock the raptor mount. ,'Активируйте",чтобы разблокировать ездового ящера.'
 Add an extra Build Template tab to the character. Each character can unlock up to 6 additional Build Template tabs.,Добавьте дополнительную вкладку шаблонов сборок персонажу. Каждый персонаж может открыть до 6 дополнительных вкладок шаблонов сборок.
 Add an extra Equipment Template tab to the character. Each character can unlock up to 7 additional Equipment Template tabs.,Добавьте дополнительную вкладку шаблонов экипировки персонажу. Каждый персонаж может открыть до 7 дополнительных вкладок шаблонов экипировки.
 All those named here have probably died of old age.,"Все, кто здесь назван, вероятно, уже умерли от старости."
@@ -662,8 +398,6 @@ Become the Midnight King with this combat tonic.,Станьте Королём �
 "Bring the egg to Gorrik in Arborstone.""","Отнесите яйцо Горрику в Каменный сад."""""
 Build Template tabs allow a character to create and swap to an additional build.,Вкладки шаблонов сборок позволяют персонажу создавать и переключаться на дополнительную сборку.
 "By rebuilding the sanctuary,' you will be granted access to Kormir''s sanctum.'","Восстановив святилище,' вы получите доступ к святилищу Кормир.'"
-"Can be attained from the Shiverpeaks Pass raid encounter.,Можно получить в рейдовом столкновении «Перевал Дрожащих пиков».",Можно получить в рейдовом столкновении «Перевал Дрожащих пиков».
-"Can be consumed for Crystal Desert Mastery experience or traded at Grand Sahil Casino for other rewards.,Можно использовать для получения опыта мастерства Пустыни Кристалла или обменять в казино «Гранд Сахил» на другие награды.",Можно использовать для получения опыта мастерства Пустыни Кристалла или обменять в казино «Гранд Сахил» на другие награды.
 Can be exchanged for a non-soulbound version at merchants in Amnoon.,Можно обменять на версию без привязки к душе у торговцев в Амнуне.
 Can be exchanged for raid currency at specific vendors.,Можно обменять на рейдовую валюту у определенных торговцев.
 "Can be found at the same location as elegy mosaics.""","Можно найти там же, где и мозаики элегии."""""
@@ -671,66 +405,16 @@ Can be traded with Mordrem researchers across Tyria for valuable items.,Можн
 "Can be used in the Mystic Forge in place of Twilight to add the greatsword Eternity to your Legendary Armory.,
 <c=@warning>If you have two instances of Eternity unlocked in the armory, please contact Customer Support.</c>","Может быть использован в Mystic Forge вместо Сумерек, чтобы добавить двуручный меч Вечность в вашу Легендарную оружейную.,
 <c=@warning>Если у вас есть два экземпляра Вечности, открытых в оружейной, обратитесь в службу поддержки клиентов.</c>"
-"Can contain ancient or elder wood logs.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать бревна древней или старшей древесины.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Ищите торговые контракты в сундуках и потерянных припасах."
-"Can contain coarse or rugged leather squares. ,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать квадраты грубой или жёсткой кожи. ,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Находите торговые контракты в сундуках и потерянных припасах."
-"Can contain gossamer and silk scraps.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать обрывки паутины и шелка.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Ищите торговые контракты в сундуках и потерянных припасах."
-"Can contain green and soft wood logs.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать бревна из зелёной и мягкой древесины.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Ищите торговые контракты в сундуках и потерянных припасах."
-"Can contain hard and seasoned wood logs.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать бревна твердой и выдержанной древесины.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,
-Ищите торговые контракты в сундуках и потерянных припасах."
 "Can contain ingots of iron, darksteel
 Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
 Find trade contracts in chests and lost supplies.","Может содержать слитки железа, тёмной стали
 Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
 Находите торговые контракты в сундуках и потерянных припасах."
-"Can contain ingots of orichalcum or mithril.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать слитки орихалка или мифрила.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Найдите торговые контакты в сундуках и потерянных припасах."
 "Can contain ingots of steel, platinum
 Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
 Find trade contracts in chests and lost supplies.","Может содержать слитки стали или платины.
 Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
 Находите торговые контракты в сундуках и потерянных припасах."
-"Can contain jute and wool scraps.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать лоскуты джута и шерсти.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Находите торговые контракты в сундуках и припасах."
-"Can contain linen and cotton scraps.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать льняные и хлопковые лоскуты.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Ищите торговые контракты в сундуках и потерянных припасах."
-"Can contain rawhide or thin leather squares.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать кусочки сыромятной или тонкой кожи.,
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.,
-Находите торговые контракты в сундуках и потерянных припасах."
-"Can contain thick or hardened leather squares.,
-Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Find trade contracts in chests and lost supplies.","Может содержать квадраты толстой или закаленной кожи.
-Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
-Ищите торговые контракты в сундуках и потерянных припасах."
 "Can contain totems, dust
 Purchase from renown region karma merchants across the Crystal Desert with trade contracts.,Покупайте у торговцев кармы в регионах известности по всей Пустыне Хрусталя за торговые контракты.
 Find trade contracts in chests and lost supplies.","Может содержать тотемы, пыль
@@ -1246,15 +930,6 @@ Traditional Olmakhan song. <c=@flavor>""We sing her to rest,' in Nature''s arms.
 Consuming this will unlock one random armor skin in your wardrobe that you do not already have.,"При потреблении открывается один случайный образец брони в вашем гардеробе, которого у вас ещё нет."
 Consuming this will unlock one random dye color in your wardrobe that you do not already have.,"При потреблении открывается один случайный цвет краски в вашем гардеробе, которого у вас ещё нет."
 Consuming this will unlock one random weapon skin in your wardrobe that you do not already have.,"При потреблении открывается один случайный образец оружия в вашем гардеробе, которого у вас ещё нет."
-"Contains 1 of each of these miniatures:,
-• Mini Amber Great Jungle Wurm,
-• Mini Crimson Great Jungle Wurm,
-• Mini Cobalt Great Jungle Wurm,• Мини-кобальтовый великий джунглевый червь
-Each mini can be activated from your inventory to follow you around the world.","Содержит по 1 каждой из этих миниатюр:,
-• Мини-янтарный великий джунглевый червь,
-• Мини-малиновый великий джунглевый червь,
-• Мини-кобальтовый великий джунглевый червь,• Мини-кобальтовый великий джунглевый червь
-Каждую миниатюру можно активировать из инвентаря, чтобы она следовала за вами по миру."
 "Contains 1 of each of these minis:
 • Mini Toxic Warlock
 • Mini Molten Berserker
@@ -1291,11 +966,7 @@ Contains an Amalgamated Rift Essence and a Mystic Clover.,Содержит об�
 "Contains an Executioner Outfit, which is usable in combat
 Outfits are full sets of clothing that hide other armor. This will not change individual armor pieces, and you will still receive your current armor stats.","Содержит наряд палача, который можно использовать в бою
 Наряды — это полные комплекты одежды, скрывающие другую броню. Это не изменит отдельные части брони, и вы по-прежнему будете получать текущие характеристики брони."
-"Contains dragonite ore.,Содержит драконью руду.",Содержит драконью руду.
 Contains every Oracle Card collected.,Содержит все собранные карты Оракула.
-"Contains loot useful in exploring Auric Basin.,'«Содержит добычу, полезную при исследовании Золотой Чаши.'
-Double-click to open.","Содержит добычу, полезную при исследовании Золотой Чаши.
-Дважды щёлкните, чтобы открыть."
 Contains loot useful in exploring Verdant Brink.,"Содержит добычу, полезную для исследования Зелёного Уступа."
 "Contains obsidian shards.,
 Double-click to open.","Содержит осколки обсидиана.,
@@ -1308,12 +979,8 @@ Contains one random armor dye from a pool of 25 colors that includes nine exclus
 <c=#FFC957>Все краски имеют равные шансы выпадения.</c>"
 "Contains only one-handed weapons.""",Содержит только одноручное оружие.
 "Contains only two-handed weapons.""","Содержит только двуручное оружие."""""
-"Contains random loot.,Содержит случайную добычу.","Содержит случайную добычу.,Содержит случайную добычу."
 Contains various historical accounts from Shing Jea Island.,Содержит различные исторические записи с острова Шинг Джи.
 Contains various stories from Drizzlewood Coast.,Содержит различные истории с побережья Морось-Лес.
-"Contains your choice of an account-bound Skyscale weapon skin. Double-click to choose a reward.,'«Содержит на выбор один из связанных с учётной записью скинов оружия скайскилла. Дважды щёлкните, чтобы выбрать награду.'
-'<c=@flavor>""Now you don''t have to wait for that one skin you need. I love that for you.""</c>'","Содержит на выбор один из связанных с учётной записью обликов оружия скайскилла. Дважды щёлкните, чтобы выбрать награду.
-<c=@flavor>«Теперь вам не нужно ждать тот самый облик, который вам нужен. Мне это нравится».</c>"
 "Contains: ,
 • Mini Awakened Raptor,
 • Mini Awakened Skimmer,
@@ -1348,13 +1015,6 @@ Contains various stories from Drizzlewood Coast.,Содержит различн
 • Мини-шакал в экзокостюме,
 • Мини-грифон в экзокостюме"
 "Contains: ,
-• Mini Snow Owl,
-• Mini Hawk,• [Мини-ястреб|Мини-ястреба|Мини-ястребов]
-• Mini Raven","Содержит: ,
-• Мини-снежная сова,
-• Мини-ястреб,• Мини-ястреб
-• Мини-ворон"
-"Contains: ,
 • Mini Spooky Raptor,
 • Mini Spooky Skimmer,
 • Mini Spooky Springer,
@@ -1378,14 +1038,10 @@ Contains various stories from Drizzlewood Coast.,Содержит различн
 • Цыплёнок моа (мини)"
 Convergence Mastery,Convergence Mastery
 Craft six Dragonsblood weapons.,Создайте шесть оружия из драконьей крови.
-"Created by imbuing a Superior Rune of Scavenging at the Tamini Place of Power in Queensdale.,«Создано путём вливания высшей руны мародёрства в Месте силы Тамини в Квинсдейле.
-This item only has value as part of a collection.","Создано путём вливания высшей руны мародёрства в Месте силы Тамини в Квинсдейле.,«Создано путём вливания высшей руны мародёрства в Месте силы Тамини в Квинсдейле.
-Этот предмет имеет ценность только как часть коллекции."
 "Created by imbuing a pair of dragonfly-wing earrings, purchased from Cook Huelic in Metrica Province
 This item only has value as part of a collection.","Создано путём инкрустации пары серёжек из крыльев стрекозы, купленных у повара Хуэлика в Метрике.
 Этот предмет ценен только как часть коллекции."
 Created in the Mystic Forge by combining:,Создано в Mystic Forge путём соединения:
-"Created in the Mystic Forge by combining:,Создано в Таинственной кузнице путем объединения:",Создано в Мистической кузнице путём объединения:
 "Crystalline formations of dragon magic, veined with blue.
 Emissaries in the Eye of the North have interest in these.,
 Obtained from Priority Strikes or by combining shards.","Кристаллические образования драконьей магии, пронизанные голубым.
@@ -1406,25 +1062,8 @@ Double-click from inventory to read.,"Дважды щёлкните, чтобы 
 "Double-click from inventory to read.""","Дважды щёлкните в инвентаре, чтобы прочитать."""""
 "Double-click to access your tiger den.""","Дважды щёлкните, чтобы войти в своё логово тигра."""""
 Double-click to acquire the account-bound forms of Ancora.,"Дважды щёлкните, чтобы получить привязанные к учётной записи формы Анкоры."
-"Double-click to activate a single-use firework.,
-Cannot be used in WvW.,Нельзя использовать в WvW.
-Grants 2 stacks of a small bonus to experience from all sources when activated.","Дважды щёлкните, чтобы активировать одноразовый фейерверк.,
-Нельзя использовать в WvW.,Нельзя использовать в WvW.
-При активации даёт 2 стака небольшого бонуса к опыту из всех источников."
 Double-click to add an extra Fashion Template tab to this account. Each account can unlock up to 7 additional Fashion Template tabs.,"Дважды щёлкните, чтобы добавить дополнительную вкладку шаблонов моды на эту учётную запись. Каждая учётная запись может открыть до 7 дополнительных вкладок шаблонов моды."
 Double-click to add to wardrobe. (This item is account bound and cannot be sold.),"Дважды щёлкните, чтобы добавить в гардероб. (Этот предмет привязан к учётной записи и не может быть продан.)"
-"Double-click to apply this look to any other axe. This will also unlock this skin for your wardrobe.,'«Дважды щелкните, чтобы применить этот вид к другому топору. Это также откроет этот скин в вашем гардеробе.»'
-<c=@flavor>Legend says that only the most dedicated smith could withstand the elements for the decade it took to craft this axe and its rival.</c>","Дважды щёлкните, чтобы применить этот облик к другому топору. Это также откроет этот облик в вашем гардеробе.
-<c=@flavor>Легенда гласит, что только самый преданный кузнец мог выдержать стихии на протяжении десятилетия, потребовавшегося для ковки этого топора и его соперника.</c>"
-"Double-click to apply this look to any other axe. This will also unlock this skin for your wardrobe.,'«Дважды щелкните, чтобы применить этот вид к другому топору. Это также откроет этот скин в вашем гардеробе.»'
-<c=@flavor>Long ago, heroes would bring proof of their exploits to the Battle Isles in hopes of claiming one of these weapons.</c>","Дважды щёлкните, чтобы применить этот вид к другому топору. Это также откроет этот облик в вашем гардеробе.,'«Дважды щёлкните, чтобы применить этот вид к другому топору. Это также откроет этот облик в вашем гардеробе».'
-<c=@flavor>Давным-давно герои приносили доказательства своих подвигов на Боевые острова в надежде получить одно из этого оружия.</c>"
-"Double-click to apply this look to any other focus. This skin will be unlocked in your wardrobe for future use.,'«Дважды щелкните, чтобы применить этот облик к другому фокусу. Этот облик будет разблокирован в вашем гардеробе для последующего использования.»'
-<c=@flavor>The goddess teaches that the appearance of power has a power all its own.</c>","Дважды щёлкните, чтобы применить этот облик к другому фокусу. Этот облик будет разблокирован в вашем гардеробе для последующего использования.,'«Дважды щёлкните, чтобы применить этот облик к другому фокусу. Этот облик будет разблокирован в вашем гардеробе для последующего использования».'
-<c=@flavor>Богиня учит, что видимость силы обладает собственной силой.</c>"
-"Double-click to apply this look to any other focus. This skin will be unlocked in your wardrobe for future use.,'«Дважды щелкните, чтобы применить этот облик к другому фокусу. Этот облик будет разблокирован в вашем гардеробе для последующего использования.»'
-<c=@flavor>This artifact was recovered from deep within the Zaishen vaults in the Battle Isles.</c>","Дважды щёлкните, чтобы применить этот облик к другому фокусу. Этот облик будет разблокирован в вашем гардеробе для последующего использования.,'«Дважды щёлкните, чтобы применить этот облик к другому фокусу. Этот облик будет разблокирован в вашем гардеробе для последующего использования».'
-<c=@flavor>Этот артефакт был извлечен из глубин хранилищ Зайшена на Боевых островах.</c>"
 "Double-click to apply this look to any other hammer.,
 <c=@flavor>""Normal choya are vicious, but give these guys an extra three feet of height and reach
 Double-click to apply this look to any other hammer. Additional copies of this item are available from the achievements panel.,'Дважды щёлкните, чтобы применить этот облик к другому молоту. Дополнительные копии этого предмета доступны на панели достижений.'
@@ -1470,9 +1109,6 @@ Double-click to apply this look to any other helmet. This skin will be unlocked 
 Дважды щёлкните, чтобы применить этот вид к любому другому шлему.,'Дважды щёлкните, чтобы применить этот вид к любому другому шлему.'
 Дважды щёлкните, чтобы применить этот вид к любому другому шлему. Этот облик будет разблокирован в вашем гардеробе для дальнейшего использования.,'Дважды щёлкните, чтобы применить этот вид к любому другому шлему. Этот облик будет разблокирован в вашем гардеробе для дальнейшего использования.'
 Дважды щёлкните, чтобы применить этот облик к любому другому шлему. Этот облик будет разблокирован в вашем гардеробе для дальнейшего использования."
-"Double-click to apply this look to any other staff. This will also unlock this skin for your wardrobe.,'«Дважды щёлкните, чтобы применить этот облик к любому другому посоху. Это также разблокирует этот скин в вашем гардеробе.'
-<c=@flavor>It is said that this staff was carried by Heleyne, one of the Envoys that served as shepherds of souls into the Mists.</c>","Дважды щёлкните, чтобы применить этот облик к любому другому посоху. Это также разблокирует этот облик в вашем гардеробе.
-<c=@flavor>Говорят, что этот посох носила Хелейн, одна из Посланников, служивших пастырями душ в Туман.</c>"
 "Double-click to apply to a piece of armor.""","Дважды щёлкните, чтобы применить к элементу брони."""""
 "Double-click to apply to a weapon.""","Дважды щёлкните, чтобы применить к оружию."""""
 "Double-click to apply to an accessory, amulet
@@ -1533,7 +1169,6 @@ Rewards bonus Volatile Magic while gathering, in addition to the gathering resul
 Rewards bonus karma while gathering, in addition to the gathering results.","Дважды щёлкните, чтобы привязать этот глиф к учётной записи.,
 Награждает бонусной кармой при сборе ресурсов в дополнение к результатам сбора."
 "Double-click to change your skill bar, allowing you to play music for all those nearby.","Дважды щёлкните, чтобы изменить панель навыков и играть музыку для всех поблизости."
-"Double-click to choose an ascended weapon.,'Дважды щелкните",чтобы выбрать вознесенное оружие.'
 "Double-click to combine 50 components to assemble a power core.,
 <c=@flavor>This component was salvaged from an Energy Probe.</c>","Дважды щёлкните, чтобы объединить 50 компонентов и собрать силовое ядро.,
 <c=@flavor>Этот компонент был извлечён из энергетического зонда.</c>"
@@ -1591,8 +1226,6 @@ Double-click to gain a Charrzooka.","Дважды щёлкните, чтобы �
 Дважды щёлкните, чтобы получить предмет связки «Шахта чаров».
 Дважды щёлкните, чтобы получить «Чарр-зуку»
 Дважды щёлкните, чтобы получить «Чарр-зуку»."
-"Double-click to gain a Drake Egg,'Дважды щелкните",чтобы получить яйцо дракона'
-"Double-click to gain a Smoke Bomb.,'Дважды щелкните",чтобы получить дымовую бомбу.'
 "Double-click to gain a Stormcaller Weapon Box, Dragonite Ore
 Double-click to gain a Sylvari Seed Pod.","Дважды щёлкните, чтобы получить коробку с оружием Штормового зова, руду драконита
 Дважды щёлкните, чтобы получить стручок семян сильвари."
@@ -1606,7 +1239,6 @@ Double-click to gain a Sylvari Seed Pod.","Дважды щёлкните, что
 —Jezza</c>","Дважды щёлкните, чтобы получить бомбу Бдительных.,
 <c=@flavor>«Нам нужны большие взрывы, чтобы сдерживать нежить. Этого заряда должно хватить».
 — Джезза</c>"
-"Double-click to gain a cannonball,'Дважды щелкните",чтобы получить пушечное ядро'
 "Double-click to gain a choice of High Legion weapons, plus Dragonite Ore
 Double-click to gain a depleted power crystal,'Дважды щелкните, чтобы получить истощенный кристалл силы'
 Double-click to gain a drake egg.,'Дважды щелкните, чтобы получить яйцо дракона.'
@@ -1614,7 +1246,6 @@ Double-click to gain a drake egg.","Дважды щёлкните, чтобы п
 Дважды щёлкните, чтобы получить истощенный кристалл силы,'Дважды щёлкните, чтобы получить истощенный кристалл силы'
 Дважды щёлкните, чтобы получить яйцо дракона.,'Дважды щёлкните, чтобы получить яйцо дракона.'
 Дважды щёлкните, чтобы получить яйцо дракона."
-"Double-click to gain a flamethrower.,'Дважды щелкните",чтобы получить огнемет.'
 "Double-click to gain a hero  point. .,
 The sparkling vial brims with power.","Дважды щёлкните, чтобы получить очко  героя. .,
 Сверкающий флакон переполнен силой."
@@ -1682,11 +1313,6 @@ Double-click to open. Choose an account-bound weight class of the Visage of Nour
 "Double-click to open. Contains various plants, a Resonating Sliver
 Double-click to open. Contains:","Дважды щёлкните, чтобы открыть. Содержит различные растения.
 Дважды щёлкните, чтобы открыть. Содержит:"
-"Double-click to open. Contains:,
-• Revive Orb,• Сфера возрождения
-• Instant Repair Canister","Дважды щёлкните, чтобы открыть. Содержит:,
-• Сфера возрождения,• Сфера возрождения
-• Мгновенный ремонтный баллон"
 "Double-click to open. Grants a choice of Bear Ceremonial Hood, Sandals
 <c=@warn>Contents will be account bound!</c>","Дважды щёлкните, чтобы открыть. Даёт выбор: Медвежий церемониальный капюшон, Сандалии
 <c=@warn>Содержимое станет привязанным к учётной записи!</c>"

--- a/items/items_127.csv
+++ b/items/items_127.csv
@@ -67,11 +67,6 @@ Double-click to open.","Дважды щёлкните, чтобы открыть
 Содержит 100 разнообразных тотемов, чешуй
 Дважды щёлкните, чтобы открыть."
 "Double-click to open.,
-Contains 100 assorted vials of blood.,Содержит 100 различных склянок с кровью.
-<c=@flavor>""I suppose it makes sense. They are the Blood Legion.""</c>","Дважды щёлкните, чтобы открыть.,
-Содержит 100 различных склянок с кровью.,Содержит 100 различных склянок с кровью.
-<c=@flavor>""Полагаю, это имеет смысл. Они — Blood Legion"".</c>"
-"Double-click to open.,
 Contains 25 assorted molten materials.,
 '<c=@flavor>Fire. It''s a box of fire. Because the Flame Legion loves fire.</c>'","Дважды щёлкните, чтобы открыть.,
 Содержит 25 различных расплавленных материалов.,
@@ -127,11 +122,6 @@ Double-click to open.","Дважды щёлкните, чтобы открыть
 Содержит выбор рецептов оружия Зовущего бурю (фокус, скипетр
 Дважды щёлкните, чтобы открыть."
 "Double-click to open.,
-Contains loot from creatures.,Содержит трофеи с существ.
-<c=@reminder>Affected by magic-find bonuses.</c>","Дважды щёлкните, чтобы открыть.,
-Содержит трофеи с существ.,Содержит трофеи с существ.
-<c=@reminder>Подвержено влиянию бонусов к поиску магии.</c>"
-"Double-click to open.,
 Contains materials from Amnytas.","Дважды щёлкните, чтобы открыть.
 Содержит материалы из Амнитаса."
 "Double-click to open.,
@@ -152,9 +142,6 @@ Purchase these recipes from renown merchants in Elona after learning the base re
 "Double-click to pick a recipe for Spearmarshal Shoulder Pieces. Can be learned by armorsmiths, leatherworkers
 Purchase these recipes from renown merchants in Elona after learning the base recipes from the story.","Дважды щёлкните, чтобы выбрать рецепт наплечников маршала копья. Могут изучить броненосцы и кожевники.
 Купите эти рецепты у известных торговцев в Элоне после изучения базовых рецептов из сюжета."
-"Double-click to pick your choice of rewards.,'Дважды щёлкните, чтобы выбрать награду.'
-<c=@flavor>""Can we skip to the good part?""</c>","Дважды щёлкните, чтобы выбрать награду.,'Дважды щёлкните, чтобы выбрать награду.'
-<c=@flavor>""Можно перейти сразу к хорошей части?""</c>"
 "Double-click to plant a Cultivated Seed in this pot.,
 <c=@flavor>A pot so infused with energy,' it''s sure to germinate a more powerful seedling.</c>'","Дважды щёлкните, чтобы посадить возделанное семя в этот горшок.,
 <c=@flavor>Горшок, настолько пропитанный энергией, что обязательно прорастит более сильный саженец.</c>'"
@@ -167,7 +154,6 @@ Purchase these recipes from renown merchants in Elona after learning the base re
 Double-click to read a card.,"Дважды щёлкните, чтобы прочитать карту."
 Double-click to read. Can be safely discarded after acquiring.,"Дважды щёлкните, чтобы прочитать. Можно безопасно выбросить после получения."
 "Double-click to read.""","Дважды щёлкните, чтобы прочитать."
-"Double-click to read.,'Дважды щелкните",чтобы прочитать.'
 "Double-click to shine on a Cultivated Shoot.,
 <c=@flavor>With a hefty helping of luck, this lamp should get the most stubborn of plants to grow toward its light.</c>","Дважды щёлкните, чтобы осветить возделанный росток.,
 <c=@flavor>С изрядной долей везения эта лампа заставит даже самые упрямые растения тянуться к её свету.</c>"
@@ -176,7 +162,6 @@ Double-click to read. Can be safely discarded after acquiring.,"Дважды щ�
 <c=@flavor>Обладая светом, сиявшим в темноте, этот фонарь очень мощный.</c>"
 "Double-click to show.""","Дважды щёлкните, чтобы показать."""""
 "Double-click to start the party!""","Дважды щёлкните, чтобы начать вечеринку!"
-"Double-click to summon a pet Jade Armor for 5 minutes. This can only be used once every 30 minutes.,'Дважды щёлкните",чтобы призвать питомца-нефритового стража на 5 минут. Можно использовать не чаще одного раза в 30 минут.'
 "Double-click to summon this mini to follow you around. Only one mini may be in use at a time.,
 <c=@flavor>Potato-shaped friend, it is
 Double-click to summon this mini to follow you around. Only one mini may be in use at a time.","Дважды щёлкните, чтобы призвать этого мини-питомца, который будет следовать за вами. Одновременно может использоваться только один мини-питомец.,
@@ -205,9 +190,6 @@ Double-click to transform into a Janthiri floppy fish.,"Дважды щёлкн�
 "Double-click to transform into a hermit crab.,
 <c=@flavor>""When you live in a shell,' you''re always home!""</c>'","Дважды щёлкните, чтобы превратиться в рака-отшельника.,
 <c=@flavor>""Когда живешь в раковине,' ты всегда дома!""</c>'"
-"Double-click to transform into a thundershrimp.,'Дважды щелкните, чтобы превратиться в громокреветку.'
-<c=@flavor>""Still pretty big for a shrimp, if you ask me!""</c>","Дважды щёлкните, чтобы превратиться в громокреветку.
-<c=@flavor>""Все равно креветка, пусть и громовая!""</c>"
 Double-click to transform into a tropical crab.,"Дважды щёлкните, чтобы превратиться в тропического краба."
 "Double-click to unpack and bind this item to your account.""","Дважды щёлкните, чтобы распаковать и привязать этот предмет к вашей учётной записи."""""
 "Double-click to unpack.""","Дважды щёлкните, чтобы распаковать."""""
@@ -219,19 +201,11 @@ This item contains the Ghoul Backpack and Mini Ghoul Legs.","Дважды щёл
 '<c=@flavor>Special care should be taken with this hot stone if you don''t want to get burned.</c>'","Дважды щёлкните, чтобы согреть ваше растение-питомца.,
 '<c=@flavor>С этим горячим камнем следует обращаться осторожно, если вы не хотите обжечься.</c>'"
 Double-click to wear this outfit.,"Дважды щёлкните, чтобы надеть этот наряд."
-"Double-click to wear this outfit.,
-Seize the Awkward! Reach out to your friends in need.,«Перехвати неловкость!» Протяни руку помощи своим друзьям в беде.
-Outfits are full sets of clothing that hide other armor. This will not change individual armor pieces, and you will still receive your current armor stats.","Дважды щёлкните, чтобы надеть этот наряд.,
-Перехвати неловкость! Протяни руку помощи своим друзьям в беде.,«Перехвати неловкость!» Протяни руку помощи своим друзьям в беде.
-Наряды — это полные комплекты одежды, скрывающие другую броню. Это не изменит отдельные элементы брони, и вы по-прежнему будете получать характеристики вашей текущей брони."
 "Double-click while underwater to transform into a koi.,
 '<c=@flavor>""Don''t be coy', be a koi!""</c>","Дважды щёлкните под водой, чтобы превратиться в кои.,
 '<c=@flavor>""Не будь застенчив', будь кои!""</c>"
 Drinking a second time will transform you back to yourself.,"Если выпить второй раз, вы снова станете собой."
 Dropped by Mossman in the Swampland Fractal.,Сброшено Моссменом во Фрактале Болот.
-"Drops from Choya in the Crystal Desert.,«Выпадает с чойя в Пустыне Хрусталя.
-<c=@Flavor>Used in cooking and medicine, once sterilized and cleaned up a bit.</c>","Выпадает с чойя в Пустыне Хрусталя.,«Выпадает с чойя в Пустыне Хрусталя.
-<c=@Flavor>Используется в кулинарии и медицине после стерилизации и очистки.</c>"
 Dyes can be unlocked for unlimited use to color armor on all characters. Dye bottles can also be recycled in the Mystic Forge.,"Краски можно разблокировать для неограниченного использования, чтобы окрашивать броню на всех персонажах. Флаконы с краской также можно перерабатывать в Mystic Forge."
 Dyes can be unlocked for unlimited uses to color armor on all characters.,Краски можно разблокировать для неограниченного использования для окраски брони всех персонажей.
 "Each chest contains up to five personalized Wintersday gifts, plus an additional themed item. This includes tonics
@@ -301,9 +275,6 @@ Equipment Template tabs allow a character to swap to an additional set of equipm
 "Event Item""","Предмет события"""
 Fashion Template tabs allow accounts to swap and store an additional set of cosmetics for all your characters.,Вкладки шаблонов моды позволяют учётным записям менять и хранить дополнительный набор косметики для всех ваших персонажей.
 Filled with all the nutrients a growing raptor needs! Double-click to feed this to your raptor.,"Содержит все питательные вещества, необходимые растущему раптору! Дважды щёлкните, чтобы накормить этим вашего раптора."
-"Filled with all the nutrients a growing springer needs! Double-click to feed this to your springer.,'«Содержит все питательные вещества, необходимые растущему прыгуну! Дважды щёлкните, чтобы накормить своего прыгуна.»'
-Gives bonus Mastery experience once per day.","Содержит все питательные вещества, необходимые растущему спрингеру! Дважды щёлкните, чтобы скормить это вашему спрингеру.,
-Даёт дополнительный опыт мастерства один раз в день."
 Filled with all the nutrients a growing warclaw needs! Double-click to feed this to your warclaw.,"Содержит все питательные вещества, необходимые растущему боевому когтю! Дважды щёлкните, чтобы накормить этим вашего боевого когтя."
 First Drop:,Первая капля:
 Found by completing the meta-event finale in Gyala Delve.,Найдено при завершении финала мета-события в Ущелье Гьялы.
@@ -329,12 +300,6 @@ Natural","Гидеон Хоторн II,
 Натуральный"
 Gives bonus Mastery experience once per day.,Раз в день даёт дополнительный опыт мастерства.
 "Gives bonus Mastery experience once per day.""","Даёт дополнительный опыт мастерства один раз в день."""""
-"Gives one standalone homestead decoration of Orrax Contained.,Даёт одно отдельное украшение жилища «Орракс заточён».
-This homestead decoration cannot be crafted.","Даёт одно отдельное украшение усадьбы «Орракс заточён».
-Это украшение усадьбы нельзя создать."
-"Grants 10 agony resistance. ,«Даёт 10 сопротивления агонии.
-<c=@reminder>With Fractal Attunement Mastery, this item grants an additional 5 agony resistance.</c>","Даёт 10 сопротивления агонии. ,«Даёт 10 сопротивления агонии.
-<c=@reminder>С умением «Фрактальная гармония» этот предмет даёт дополнительные 5 сопротивления агонии.</c>"
 Grants a chance to receive a bonus crafting material on each swing in addition to your gathering results.,Даёт шанс получить дополнительный материал для крафта при каждом взмахе в дополнение к результатам сбора.
 Grants a chance to receive a bonus watchwork sprocket after gathering in addition to your harvesting results.,Даёт шанс получить дополнительную часовую шестерёнку после сбора в дополнение к результатам сбора урожая.
 Grants a chance to receive a bonus watchwork sprocket on each swing in addition to gathering results.,Даёт шанс получить дополнительную часовую шестерёнку при каждом взмахе в дополнение к результатам сбора.
@@ -377,74 +342,7 @@ Grants a large amount of kodan experience.","Даёт большой опыт м
 "Grants a moderate amount of karma.,
 <c=@Flavor>The bangle is both large and said to be excellent at distracting the giants that roam the Highlands. </c>","Даёт умеренное количество кармы.,
 <c=@Flavor>Браслет большой и, как говорят, отлично отвлекает великанов, бродящих по Нагорьям. </c>"
-"Grants a small amount of karma.,«Дает небольшое количество кармы.»
-'<c=@Flavor>This collection of Joko''s teachings seems of dubious value.</c>'","Даёт небольшое количество кармы.,«Даёт небольшое количество кармы».
-'<c=@Flavor>Эта коллекция учений Джоко кажется сомнительной ценности.</c>'"
-"Grants a small amount of karma.,«Дает небольшое количество кармы.»
-<c=@Flavor>The choya seemed very excited to present you with this clump of glistening earth.</c>","Даёт небольшое количество кармы.,«Даёт небольшое количество кармы».
-<c=@Flavor>Чойя, казалось, был очень рад подарить вам этот комок блестящей земли.</c>"
-"Grants a small amount of karma.,«Дает небольшое количество кармы.»
-<c=@Flavor>These are much crunchier than the non-golden version, and decidedly less delicious.</c>","Даёт небольшое количество кармы.,«Даёт небольшое количество кармы».
-<c=@Flavor>Они намного более хрустящие, чем незолотая версия, и определённо менее вкусные.</c>"
-"Grants a small amount of karma.,«Дает небольшое количество кармы.»
-<c=@Flavor>These things never work,' but that hasn''t stopped people from trying.</c>'","Даёт небольшое количество кармы.
-<c=@Flavor>«Эти штуки никогда не работают», но это не останавливает людей.</c>'"
 Grants a small chance to receive a bonus crafting material after gathering in addition to your gathering results.,Даёт небольшой шанс получить дополнительный материал для крафта после сбора в дополнение к результатам сбора.
-"Grants a tiny amount of karma.,Дарует крошечное количество кармы.
-'<c=@Flavor>The community of Zephyr''s Trace have begun to discover many secrets left behind by their intrepid predecessors.</c>'","Даёт крошечное количество кармы.,
-Дарует крошечное количество кармы.
-'<c=@Flavor>Сообщество Тропы Зефира начало открывать множество секретов, оставленных их бесстрашными предшественниками.</c>'"
-"Grants a tiny amount of karma.,Дарует крошечное количество кармы.
-<c=@Flavor>Difficult to catch, but edible. And better in a pot than under your foot.</c>","Дарует крошечное количество кармы.,
-<c=@Flavor>Трудно поймать, но съедобно. И лучше в горшке, чем под ногой.</c>"
-"Grants a tiny amount of karma.,Дарует крошечное количество кармы.
-<c=@Flavor>Ingenious construction causes this basket to provide the fishing village with a steady supply of delicious food for themselves and their raptors.</c>","Дарует крошечное количество кармы.
-<c=@Flavor>Гениальная конструкция позволяет этой корзине снабжать рыбацкую деревню постоянным запасом вкусной еды для них и их ящеров.</c>"
-"Grants a tiny amount of karma.,Дарует крошечное количество кармы.
-<c=@Flavor>These were unseen for a generation, but lately the warrior-monks of Balthazar have been placing these to signify their return.</c>","Дарует крошечное количество кармы.
-<c=@Flavor>Их не видели целое поколение, но в последнее время воины-монахи Бальтазара размещают их, чтобы обозначить свое возвращение.</c>"
-"Grants both Experience Booster and Item Booster benefits for 2 hours, including:
-• +50%% Experience in All Game Types,• +50%% опыта во всех типах игры
-• +50%% Reward Track Gain in PvP and WvW,
-• Up to 100%% Bonus Experience for Kill Streaks,
-• +50%% Magic Find,
-• +50%% Chance of Critical Crafting Experience Gain,
-• +33%% Chance of Extra Gathering Strike,
-• 10 Seconds of Swiftness after Gathering ,
-• Summons a Black Lion Merchant If Your Inventory Is Full after Gathering (20-Minute Cooldown)","Дарует эффекты усилителя опыта и усилителя предметов на 2 часа, в том числе:
-• +50%% опыта во всех типах игры
-• +50%% опыта во всех типах игры
-• +50%% к получению очков наград в PvP и WvW
-• до 100%% бонусного опыта за серии убийств
-• +50%% к поиску магии
-• +50%% шанса критического получения опыта в ремёслах
-• +33%% шанса дополнительного удара при сборе
-• 10 секунд скорости после сбора
-• призыв торговца «Black Lion», если инвентарь переполнен после сбора (перезарядка 20 мин.)"
-"Grants both Experience Booster and Item Booster benefits for 30 minutes:,Даёт преимущества Опытного усилителя и Усилителя предметов на 30 минут:",Даёт преимущества Опытного усилителя и Усилителя предметов на 30 минут:
-"Grants the following benefits for 2 hours:,
-• +50%% Experience in All Game Types,• +50%% опыта во всех типах игры
-• +50%% Reward Track Gain in PvP and WvW,
-• Up to 100%% Bonus Experience for Kill Streaks","Даёт следующие преимущества на 2 часа:,
-• +50%% опыта во всех типах игры,• +50%% опыта во всех типах игры
-• +50%% прироста линии наград в PvP и WvW,
-• До 100%% бонусного опыта за серии убийств"
-"Grants the following benefits for 30 minutes:,
-• +50%% Experience from Kills,
-• +75%% Gold from Kills,
-• +25%% Reward-Track Gain in PvP and WvW,• +25%% к скорости получения наград в PvP и WvW
-• +100%% Magic Find","Дарует следующие преимущества на 30 минут:,
-• +50%% опыта за убийства,
-• +75%% золота за убийства,
-• +25%% к скорости получения наград в PvP и WvW,• +25%% к скорости получения наград в PvP и WvW
-• +100%% удачи при поиске трофеев"
-"Grants the following benefits for 30 minutes:,
-• +50%% Experience in All Game Types,• +50%% опыта во всех типах игры
-• +50%% Reward Track Gain in PvP and WvW,
-• Up to 100%% Bonus Experience for Kill Streaks","Даёт следующие преимущества на 30 минут:,
-• +50%% опыта во всех типах игры,• +50%% опыта во всех типах игры
-• +50%% прироста наградной шкалы в PvP и WvW,
-• До 100%% бонусного опыта за серии убийств"
 "Griffon hatchlings are extremely energetic and precocious.
 Combine a white, yellow
 Griffoncrack,Трещина Грифона
@@ -593,26 +491,8 @@ Herald of Aurene Outfit,Herald of Aurene Outfit
 "Holding this empty bottle, you feel slightly uncomfortable
 <c=@flavor>Abandoned long ago, but only recently realized.</c>","Держа эту пустую бутылку, вы чувствуете лёгкий дискомфорт
 <c=@flavor>Покинута давно, но осознана только недавно.</c>"
-"Immediately adds 1 Café Transporter to your stock of homestead decorations.,«Немедленно добавляет 1 кафе-транспортёр в ваш запас украшений жилища.»
-<c=@flavor>Café customers will enter and exit your homestead from this decoration if it is placed instead of from the waypoint.</c>","Немедленно добавляет 1 кафе-транспортёр в ваш запас украшений усадьбы.,«Немедленно добавляет 1 кафе-транспортёр в ваш запас украшений усадьбы».
-<c=@flavor>Если установлено это украшение, посетители кафе будут входить и выходить из вашего усадьбы через него, а не через точку перемещения.</c>"
 Immediately receive 150 research notes.,Немедленно получите 150 исследовательских заметок.
 "In Echovald Wilds,' deactivate the haywire Gods'' Vengeance.'",В дебрях Эховалда отключите разбушевавшуюся «Месть богов».
-"In honor of those who cleared the way.,
-Double-click to open.,'Дважды щелкните, чтобы открыть.'
-Contains bonus Airship Parts.","В честь тех, кто расчистил путь.,
-Дважды щёлкните, чтобы открыть.,
-Содержит бонусные детали дирижабля."
-"In honor of those who cleared the way.,
-Double-click to open.,'Дважды щелкните, чтобы открыть.'
-Contains bonus Lumps of Aurillium.","В честь тех, кто расчистил путь.,
-Дважды щёлкните, чтобы открыть.,'Дважды щёлкните, чтобы открыть.'
-Содержит бонусные глыбы Ауриллиума."
-"In honor of those who cleared the way.,
-Double-click to open.,'Дважды щелкните, чтобы открыть.'
-Contains bonus ley-line crystals.","В честь тех, кто расчистил путь.,
-Дважды щёлкните, чтобы открыть.,'Дважды щёлкните, чтобы открыть.'
-Содержит бонусные кристаллы лей-линии."
 "In which His Royal Madness ascends to the Krytan throne and wields his first decree.,
 '<c=@flavor>—Search the dead streets and forgotten thoroughfares of another Lion''s Arch. (Site #2)',
 '—Say more now and look more where Kryta''s descendants are buried. (Site #3)</c>'","В котором Его Королевское Безумие восходит на крайтанский трон и издаёт свой первый указ.,
@@ -641,15 +521,9 @@ Contains bonus ley-line crystals.","В честь тех, кто расчист�
 —Find Provernic,' where the first king''s bones rot in the hills. (Site #5)</c>'","В котором Ос неуклюже и с неловкими паузами ухаживает за леди Лирикой.,
 <c=@flavor>—Отправляйтесь в холмы и укорените чёрные корни в стоячих водах. (Участок №4),
 —Найдите Проверника, где гниют кости первого короля в холмах. (Участок №5)</c>'"
-"In which a friend joins young Oswald Thorn for the adventure of a lifetime.,
-'<c=@flavor>—Say more now and look more where Kryta''s descendants are buried. (Site #3)','<c=@flavor>—Говори больше сейчас и смотри больше туда, где покоятся потомки Криты. (Участок №3)'
-—Go into the hills and set down black roots in stagnant waters. (Site #4)</c>","В которой друг присоединяется к юному Освальду Торну в приключении всей жизни.,
-'<c=@flavor>—Говори больше сейчас и смотри больше туда, где покоятся потомки Крайты. (Участок №3)','<c=@flavor>—Говори больше сейчас и смотри больше туда, где покоятся потомки Крайты. (Участок №3)'
-—Иди в холмы и укорени чёрные корни в стоячих водах. (Участок №4)</c>"
 "In which a rebellious village goes up in flames.,
 '<c=@flavor>—Walk in cadence with King Thorn''s shattered subjects. They keep their hatred deep within. (Site #10)</c>'","В коей мятежная деревня обращается в пламя.
 <c=@flavor>—Идите в ногу с разбитыми подданными короля Терна. Они глубоко хранят свою ненависть. (Место №10)</c>"""
-"In which the king makes an example of ungrateful peasants.,В которой король наказывает неблагодарных крестьян в назидание.","В которой король наказывает неблагодарных крестьян в назидание.,В которой король наказывает неблагодарных крестьян в назидание."
 "Information on the patrols around the mine and the dredge defensive capabilities. Grimarr Molesmasher, outside of Molensk
 Infused Aurora Chestguard Skin,
 Infused Aurora Gloves Skin,
@@ -695,16 +569,6 @@ Infused Tiger Milk,
 Устройство извлечения инфузии,
 Ингредиент,
 Ингредиент"
-"Ingredient,
-A rare potato found hidden in potato patches.,'Редкая картофелина, спрятанная на картофельных грядках.'
-<c=@flavor>A rare and wonderfully complex potato.<c>","Ингредиент,
-Редкая картофелина, спрятанная на картофельных грядках.,'Редкая картофелина, спрятанная на картофельных грядках.'
-<c=@flavor>Редкая и удивительно сложная картофелина.<c>"
-"Ingredient,
-Dropped by risen Orrians.,Выпадает с восставших оррианцев.
-<c=@flavor>Caution: Sometimes found attached to risen Orrians.<c>","Ингредиент,
-Выпадает с восставших оррианцев.,
-<c=@flavor>Внимание: Иногда встречается на восставших оррианцах.<c>"
 "Intellect, willpower
 Intelligence Report: Palawa Joko I,Разведывательное донесение: Палава Джоко I
 Intelligence Report: Palawa Joko I Page 01,'Разведдонесение: Палава Джоко I, стр. 01'
@@ -930,7 +794,6 @@ Balance","Иван Саберлин,
 • Mystic Forge,
 • Торговцы,
 • И многое другое! Всё в пределах лёгкой досягаемости для тех, кто ценит максимальное удобство."
-"Located in Ember Bay.,Находится в бухте Эмбер.",Находится в Бухте Углей.
 "Located in the Crystal Oasis.,
 • Crafting Stations,
 • Bank and Guild-Bank Access,
@@ -1159,7 +1022,6 @@ Made by combining these items in the Mystic Forge:,Создаётся путём
 • 250 Globs of Ectoplasm
 • 1 Gift of Might
 • 1 Gift of Magic"
-"Made by combining these items in the Mystic Forge:,Создается путем объединения этих предметов в Таинственной кузнице:","Создаётся путём объединения этих предметов в Мистической кузнице:,Создается путем объединения этих предметов в Мистической кузнице:"
 "May Contain: ,«Может содержать: 
 • Tomes of Mentorship,
 • Tomes of Knowledge,
@@ -1180,7 +1042,6 @@ Mist-Hardened Lockboxes can be found in weekly reward chests or dropped by keep 
 Musical Verdarach,Musical Verdarach
 "Neither moa nor griffon, these strange feathers are completely unfamiliar.","Ни моа, ни грифон — эти странные перья совершенно незнакомы."
 "Obscure""","Неясный"""
-"Obtain the Gigantic Ice Elemental Core from the remains of the giant ice elemental in Wayfarer Foothills. Bring it to the heart of the volcano core inside the Fractals of the Mists and imbue it in the lava. ,Добудьте гигантское ядро ледяного элементаля из останков гигантского ледяного элементаля в Предгорьях Путника. Отнесите его в жерло вулканического ядра в Осколках тумана и пропитайте его лавой.",Добудьте гигантское ядро ледяного элементаля из останков гигантского ледяного элементаля в Предгорьях Странника. Отнесите его в жерло вулканического ядра в Осколках тумана и пропитайте его лавой.
 "Olava Skumasdottir,
 403 Bloom XXX0,
 Obscure","Олава Скумасдоттир,
@@ -1201,13 +1062,6 @@ Only effective during April Fools.,Действует только в День �
 <c=@Flavor>Подарок от незнакомого друга из-за морей, в надежде, что вы станете полезным союзником.</c>"
 "Outfits are full sets of clothing that hide other armor. This will not change individual armor pieces, and you will still receive your current armor stats.","Наряды — это полные комплекты одежды, которые скрывают другую броню. Это не изменит отдельные элементы брони, и вы по-прежнему будете получать характеристики вашей текущей брони."
 "Piece of a timeworn dwarven door,' perfect for Gerrvid''s collection.'","Часть ветхой дворфской двери, идеально подходящая для коллекции Геррвида."
-"Purchase Limit: 5,Лимит покупки: 5
-Price increases when purchase limit is reached.,
-This item grants an Anguished Tear of Alba, which can be consumed to grant 10 agony resistance for 1 hour.
-With Fractal Attunement Mastery, grants an additional 5 agony resistance.","Лимит покупки: 5
-Цена увеличивается при достижении лимита покупки.
-Этот предмет даёт «Скорбную слезу Альбы», которую можно употребить для получения 10 единиц сопротивления агонии на 1 час.
-С мастерством «Сосредоточение на фракталах» даёт дополнительные 5 единиц сопротивления агонии."
 Purchase the recipe for this item from any Mystic Forge vendor and reach a chef rating of 400 to craft.,Рецепт этого предмета покупается у любого торговца Mystic Forge; для изготовления нужен уровень повара 400.
 Purchase the recipe for this item from any Mystic Forge vendor and reach a huntsman rating of 400 to craft.,Рецепт этого предмета покупается у любого торговца Mystic Forge; для изготовления нужен уровень охотника 400.
 Purchase the recipe for this item from any Mystic Forge vendor and reach a jeweler rating of 400 to craft.,Рецепт этого предмета покупается у любого торговца Mystic Forge; для изготовления нужен уровень ювелира 400.
@@ -1226,7 +1080,6 @@ Purchased from Tyrian Alliance Representative Sharpwhisker in Glimmering Arches 
 "Purchased from Visions of Eternity renown heart vendors.""","Куплено у продавцов заданий сердца «Visions of Eternity»."""""
 Purchased from dungeon vendors for 500 Tales of Dungeon Delving.,Покупается у торговцев подземелий за 500 Tales of Dungeon Delving.
 Rare or uncommon dye chances:,Шансы на редкие или необычные краски:
-"Really enjoys facing north for some reason.,Почему-то очень любит смотреть на север.",Почему-то очень любит смотреть на север.
 Relic of Dwayna,Relic of Dwayna
 "Renown Item""","Знаменитый предмет"""
 "Renown Item,
@@ -1234,31 +1087,6 @@ Deposit into food baskets to help the Makali community of the Desert Highlands.,
 <c=@Flavor>Despite the hardscrabble nature of nomadic life, the generosity on display is immense.</c>","Предмет известности,
 Положите в корзины с едой, чтобы помочь общине макали в Пустынных нагорьях.,
 <c=@Flavor>Несмотря на суровость кочевой жизни, щедрость здесь огромна.</c>"
-"Repackages boosts in your inventory to take up less space and allows you to change boosts to another similar type.,
-Each powder will grant one Enchanted Boost in exchange for the following boosts in the quantity listed in the parentheses:,
-• Karma Booster (2),
-• Experience Booster (1),• Усилитель опыта (1)
-• Gathering Booster (1),
-• Crafting Booster (1),
-• Magic Find Booster (1),
-• Killstreak Experience Booster (1),
-• Armor Booster (1),• Усилитель брони (1)
-• Strength Booster (1),
-• Speed Booster (1),
-• Rejuvenation Booster (1),• Усилитель восстановления (1)
-Double-click to activate.","Переупаковывает усиления в вашем инвентаре, чтобы они занимали меньше места, и позволяет изменить усиления на другой похожий тип.,
-Каждый порошок даёт одно зачарованное усиление в обмен на следующие усиления в количестве, указанном в скобках:,
-• Усилитель кармы (2),
-• Усилитель опыта (1),
-• Усилитель сбора (1),
-• Усилитель ремесла (1),
-• Усилитель поиска магии (1),
-• Усилитель опыта за серию убийств (1),
-• Усилитель брони (1),
-• Усилитель силы (1),
-• Усилитель скорости (1),
-• Усилитель восстановления (1),
-Дважды щёлкните, чтобы активировать."
 "Requires """"A Crack in the Ice.""""""",Требуется «Трещина во льду».
 "Requires The Head of the Snake.""","Требуется «Голова змеи»."""""
 Rewarded for finishing first in the World Tournament Series!,Награда за первое место в мировом турнире!
@@ -1529,7 +1357,6 @@ The Punisher Близнецов
 The Ugly Stick
 Очень голодный дольяк
 Припасы «War Eternal»"
-"The backpack of a Vigil leader.,Рюкзак лидера Дозора.",Рюкзак лидера Дозора.
 "The bat wing is well preserved.,
 <c=@flavor>The wing smells a little funky and tingles with a feeling that reminds you of the Mystic Forge.</c>","Крыло летучей мыши хорошо сохранилось.,
 <c=@flavor>Крыло пахнет странновато и покалывает ощущением, напоминающим Mystic Forge.</c>"
@@ -1544,35 +1371,6 @@ Double-click to open.","Открытый сундук содержит эссе�
 Дважды щёлкните, чтобы открыть."
 "There might be someone in Yatendi village looking for this.""","Возможно, кто-то в деревне Ятенди ищет это."""""
 Third Drop:,Третья капля:
-"This adds a Black Lion Expedition Board to your home instance, which can be used to collect exotic resources from across Tyria and the Mists. 
-Expedition options include the following:,
-• Skywatch Archipelago,• Архипелаг Небокрай
-• Amyntas,
-• Inner Nayos,
-• Rifts","Это добавляет доску экспедиций «Чёрного льва» в ваше домашнее убежище, которую можно использовать для сбора экзотических ресурсов по всей Тирии и Туманным землям. 
-Варианты экспедиций включают следующее:,
-• Архипелаг Небокрай,• Архипелаг Небокрай
-• Аминтас,
-• Внутренний Найос,
-• Разломы"
-"This adds a Black Lion Expedition Board to your home instance, which can be used to collect exotic resources from across Tyria. 
-Expedition locations include the following:,
-• Dry Top and the Silverwastes,
-• Bloodstone Fen,
-• Ember Bay,• Бухта Янтаря
-• Bitterfrost Frontier,
-• Lake Doric,
-• Draconis Mons,
-'• Siren''s Landing'","Это добавляет доску экспедиций Чёрного Льва в ваше домашнее убежище, которую можно использовать для сбора экзотических ресурсов по всей Тирии.
-Места экспедиций включают следующее:,
-• Сухая вершина и Серебряные пустоши,
-• Кровавый камень,
-• Залив Искр,
-• Бухта Янтаря,
-• Горький морозный рубеж,
-• Озеро Дорик,
-• Драконий Монс,
-• Земля Сирены"
 "This adds a Black Lion Hunters Board to your home instance, which can be used to collect fine crafting materials.
 Collectible materials include:,
 • Bones,
@@ -1654,36 +1452,6 @@ This miniature inherits the appearance of whichever jade bot skin you have equip
 This package contains cooking and artificing recipes that require ingredients from plants that can only be grown in your home garden.","Этот набор содержит облик топора, облик кинжала
 Этот набор содержит рецепты кулинарии и изготовления артефактов, требующие ингредиенты из растений, которые можно вырастить только в вашем домашнем саду."
 This page is part of the Frode's Journal achievement.,Эта страница является частью достижения «Дневник Фроде».
-"This pass provides permanent access to the Thousand Seas Pavilion, a beautiful isle adrift in the Mists.
-• Quick Travel to All Cities and a Variety of Fishing Locations,
-• Scenic and Convenient Fishing and Boating Opportunities,• Живописные и удобные возможности для рыбалки и катания на лодках
-• Crafting Stations,
-• Bank and Guild Bank Access,
-• Mystic Forge,
-• Merchants,
-• And more! All within easy reach, for those who enjoy the ultimate convenience.","Этот пропуск предоставляет постоянный доступ к Павильону тысячи морей, прекрасному острову, дрейфующему в Бездне.
-• Быстрое путешествие во все города и разнообразные места для рыбалки,
-• Живописные и удобные возможности для рыбалки и катания на лодках,
-• Столы для крафта,
-• Доступ к банку и гильдейскому банку,
-• Mystic Forge,
-• Торговцы,
-• И многое другое! Всё в пределах лёгкой досягаемости для тех, кто ценит максимальное удобство."
-"This pass provides temporary access to the Thousand Seas Pavilion, a beautiful isle adrift in the Mists.
-• Quick Travel to All Cities and a Variety of Fishing Locations,
-• Scenic and Convenient Fishing and Boating Opportunities,• Живописные и удобные возможности для рыбалки и катания на лодках
-• Crafting Stations,
-• Bank and Guild Bank Access,
-• Mystic Forge,
-• Merchants,
-• And more! All within easy reach, for those who enjoy the ultimate convenience.","Этот пропуск даёт временный доступ в Thousand Seas Pavilion — прекрасный остров, парящий в Бездне.
-• Быстрое путешествие во все города и множество мест для рыбалки,
-• Живописные и удобные возможности для рыбалки и катания на лодках,
-• Ремесленные станции,
-• Банк и доступ к банку гильдии,
-• Таинственная кузница,
-• Торговцы,
-• И многое другое! Всё в лёгкой досягаемости для тех, кто ценит максимальное удобство."
 "This regional weapon box contains unique skins, dragonite ore
 'This relic appears to be in better shape than most others you''ve found.',
 This residue lies dormant. It could be imbued at a strong phantasmal energy source.","Эта региональная коробка с оружием содержит уникальные облики, руду драконита
@@ -1735,33 +1503,7 @@ Account bound on use.","Превращает вас в случайное соз
 "Turn in to a Shadows handler in the Crystal Desert.,
 Event Item","Сдайте агенту Теней в Пустыне Кристалла.,
 Предмет события"
-"Unlocks the following recipes:,
-• Shimmering Dagger,• Мерцающий кинжал
-• Tenebrous Dagger","Открывает следующие рецепты:,
-• Shimmering Dagger
-• Shimmering Dagger
-• Тенеброзный кинжал"
-"Unlocks the following recipes:,
-• Shimmering Focus,• Мерцающий фокус
-• Tenebrous Focus","Открывает следующие рецепты:,
-• Shimmering Focus,• Shimmering Focus
-• Tenebrous Focus"
-"Unlocks the following recipes:,
-• Shimmering Scepter,• Мерцающий скипетр
-• Tenebrous Scepter","Открывает следующие рецепты:,
-• Shimmering Scepter,• Shimmering Scepter
-• Tenebrous Scepter"
-"Unlocks the following recipes:,
-• Shimmering Staff,• Мерцающий посох
-• Tenebrous Staff","Открывает следующие рецепты:,
-• Shimmering Staff,• Shimmering Staff
-• Tenebrous Staff"
 "Unlocks the journey to the legendary trinket Vision. If you have already fulfilled certain requirements, they will be retroactively granted.","Открывает путь к легендарному аксессуару «Видение». Если вы уже выполнили некоторые требования, они будут зачтены задним числом."
-"Unpack a target painter. This trick marks up to 50 enemy players in the area for 30 seconds. Costs 10 supply to deploy. Cannot be avoided.,«Развернуть целеуказатель. Этот трюк помечает до 50 вражеских игроков в области на 30 секунд. Стоит 10 единиц припасов для развёртывания. Нельзя избежать».
-Deployment Range: 1,200
-Effect Radius: 360","«Развернуть целеуказатель. Этот трюк помечает до 50 вражеских игроков в области на 30 секунд. Стоит 10 единиц припасов для развёртывания. Нельзя избежать».
-Дальность развёртывания: 1,200
-Радиус действия: 360"
 Unstable Rift Motivations can be found in tier 2 and 3 rifts or bought from the Trading Post.,Нестабильные мотивации разлома можно найти в разломах 2 и 3 уровня или купить на Торговой площадке.
 "Unsworn""",Непоклявшийся
 "Usable by any character, this pack comes with everything a pirate captain needs to pillage
@@ -1799,7 +1541,6 @@ Use this to sign your account up for weekly Visions of Eternity Launch Supply Dr
 5 ключей от сундука Чёрного льва, 2 билета на миниатюру Чёрного льва
 Используйте это, чтобы подписаться на еженедельные припасы запуска «Visions of Eternity». Получите первую каплю немедленно и ещё три до 25 ноября."
 Use this to sign your account up for weekly War Eternal Supply Drops. Receive the first immediately and three more between now and May 21.,"Используйте это, чтобы подписать свой аккаунт на еженедельные поставки Войны вечности. Первая доставка будет сразу, ещё три — с сегодняшнего дня по 21 мая."
-"Use to gain a Target Painter trap. This trap marks up to 50 enemies when activated. Costs 5 supply to deploy. Cannot be avoided.,'Используйте","чтобы получить ловушку «Target Painter». Эта ловушка отмечает до 50 врагов при активации. Стоит 5 единиц припасов для установки. Нельзя избежать"".'"
 Used by jade bot technicians to upgrade to Mount Energy Booster 3.,Используется техниками джейд-ботов для улучшения до Усилителя энергии скакуна 3.
 Used by jade bot technicians to upgrade to Rescue Protocol Recharge 3.,Используется техниками джейд-ботов для улучшения до Восстановления протокола спасения 3.
 Used by jade bot technicians to upgrade to Skiff Supercharger 3.,Используется техниками джейд-ботов для улучшения до Суперзарядчика скифа 3.
@@ -1868,15 +1609,8 @@ Used to create a Gift of Shadowstones.,Используется для созд�
 "Used to create a Gift of Shadowstones.,
 'Purchased from the renown heart vendor in Pilgrim''s Rest in Eternity''s Garden.'","Используется для создания Дара теневых камней.,
 Покупается у торговца сердца известности в Приюте Пилигрима в Саду Вечности."
-"Used to create a Gift of the Elders and a Gift of the Seas.,Используется для создания Дара старейшин и Дара морей.","Используется для создания Да́ра старейшин и Да́ра морей.,Используется для создания Дара старейшин и Дара морей."
 Used to create a Gift of the People.,Используется для создания Дара народа.
 Used to create a Gift of the Survivors.,Используется для создания Дара выживших.
-"Used to create a Gift of the Survivors.,
-Earned by completing the Shipwreck Strand Mastery achievement.,Получено за выполнение достижения «Мастерство Кораблекрушения».
-Additional copies can be purchased from Visions of Eternity vendors afterward.","Используется для создания Дара выживших.
-Получено за выполнение достижения «Мастерство Кораблекрушения».
-Дополнительные копии можно приобрести у торговцев «Visions of Eternity»."
-"Used to create legendary equipment.,Используется для создания легендарного снаряжения.","Используется для создания легендарного снаряжения.,Используется для создания легендарного снаряжения."
 Used to create legendary weapon and trinket gift items.,Используется для создания предметов дара для легендарного оружия и аксессуаров.
 "Used to detect and dig up chunks of Brandstone that fall on Istan. ,
 Costs 3 Volatile Magic per 5-minute charge.","Используется для обнаружения и выкапывания кусков Камня бренда, падающих на Истан. ,
@@ -1886,9 +1620,6 @@ Used to gather all plants.,Используется для сбора всех �
 Used to gather all plants.","Используется для сбора цукини, капусты
 Используется для сбора всех растений.,Используется для сбора всех растений.
 Используется для сбора всех растений."
-"Used to gather all plants. Rewards unbound magic in addition to harvesting results. Unlimited use.,«Используется для сбора всех растений. В награду за сбор даёт необузданную магию. Неограниченное использование.»
-<c=@Reminder>This item can be exchanged for an updated version at the Black Lion Exchange Specialist.</c>","Используется для сбора всех растений. Даёт несвязанную магию в дополнение к результатам сбора. Неограниченное использование.,
-<c=@Reminder>Этот предмет можно обменять на обновлённую версию у специалиста по обмену «Black Lion».</c>"
 Used to harvest all plants.,Используется для сбора всех растений.
 "Used to harvest all plants. Unlimited use. In addition to your harvesting results, this tool has a small chance to reward additional items after gathering completes.",Используется для сбора всех растений. Безлимитное использование. В дополнение к результатам сбора этот инструмент с небольшим шансом может дать дополнительные предметы после завершения сбора.
 "Used to harvest all plants.,
@@ -1901,11 +1632,6 @@ Used to mine all metals. Unlimited uses. This tool has a small chance to reward 
 "Used to mine all metals.,
 Replaces gathering results with ores used in higher-level crafting recipes. Material types are determined by the type of node gathered from. Mithril ore can be improved a limited number of times each day.","Используется для добычи всех металлов.,
 Заменяет результаты сбора на руду, используемую в рецептах крафта более высокого уровня. Типы материалов определяются типом узла, с которого производится сбор. Мифриловую руду можно улучшать ограниченное количество раз в день."
-"Used to open trade crates in the Crystal Desert.,
-'<c=@flavor>""Don''t waste time watching a merchant''s eyes or lips; watch their hands to find their keys.""','<c=@flavor>""Не трать время, глядя в глаза или на губы торговца; следи за руками, чтобы найти ключи.""'
-—Zalambur.</c>","Используется для открытия торговых ящиков в Пустыне Хрустала.,
-'<c=@flavor>""Не трать время, глядя в глаза или на губы торговца; следи за руками, чтобы найти ключи.""','<c=@flavor>""Не трать время, глядя в глаза или на губы торговца; следи за руками, чтобы найти ключи.""'
-—Заламбур.</c>"
 "Used to refine Crystalline Ore into Crystalline Ingots. Crafted from Obsidian Shards, Airship Oil
 Used to refine Meteorite Ore.,Используется для очистки Метеоритной руды.
 Used to refine decorations.,Используется для улучшения украшений.
@@ -1916,11 +1642,7 @@ Used to track calming actions and thoughts.","Используется для о
 Используется для улучшения или состаривания украшений.
 Используется для отслеживания успокаивающих действий и мыслей."
 Using this item automatically equips it while running outside of combat. The effect can be removed by using the Stop Riding skill or by double-clicking this item again.,"Использование этого предмета автоматически берёт его, когда вы бежите вне боя. Эффект можно снять умением «Прекратить поездку» или повторным двойным щелчком по этому предмету."
-"Using this will unlock all weight classes of this skin.,Использование откроет все классы веса этого скина.",Использование откроет все классы веса этого облика.
 Vantage points do not host any services.,Смотровые площадки не предоставляют никаких услуг.
-"Various toys of all sizes and descriptions. These would make a fine gift for any child looking to amuse themselves.,'«Различные игрушки всех размеров и видов. Это будет отличный подарок для любого ребенка, который хочет развлечься.'
-'<c=@flavor>""It''s a miracle I was able to retrieve these without getting them wet!""</c>'","Разнообразные игрушки всех размеров и видов. Это будет отличный подарок для любого ребёнка, который хочет развлечься.
-<c=@flavor>«Это чудо, что мне удалось достать их, не намочив!»</c>"
 "Vaulz Baelwalker,
 576 Frost 0X0I,576 Мороз 0X0I
 Knowledge","Вольц Бэйлуокер,
@@ -1955,7 +1677,6 @@ Mystery Box","Зима летом
 Knowledge","Йеккси Строгий,
 092 Прилив 00XI,
 Знания."
-"You become an owl.,Вы превращаетесь в сову.","Вы превращаетесь в сову.,Вы превращаетесь в сову."
 You cannot help but hide this jar from others.,"Вы не можете удержаться, чтобы не спрятать эту банку от других."
 You simply cannot wait to find the material that belongs in this jar.,"Тебе не терпится найти материал, который должен быть в этой банке."
 You would much rather not be carrying this jar.,Вы бы предпочли не нести эту банку.


### PR DESCRIPTION
Второй по величине класс ошибок после имён: строки, где в колонке `english` стоит кириллица. Это разъехавшиеся колонки — оригинал и перевод слиплись через запятую и попали в одно поле. Хеш считается от испорченного `english`, поэтому в игре записи нет, и CLAUDE.md велит такие удалять.

## Сначала я хотел не удалять, а разрезать обратно

Половины выглядели целыми, и казалось, что строку можно оживить:

```
мёртвая   <c=@flavor>"Good for herding dolyaks.",<c=@flavor>""Хорошо подходит…""
разрез    <c=@flavor>"Good for herding dolyaks."
```

**Проверка это опровергла.** Настоящий оригинал длиннее — при разрыве потерялась не только закрывающая метка, но и целая строка подписи:

```
items_001:501   <c=@flavor>"Good for herding dolyaks."
                —Maxtar Rapidstep</c>
```

Обрубок не дал бы того же хеша, и строка осталась бы мёртвой. А главное — она и не нужна: **здоровый двойник уже лежит в корпусе и уже переведён** («Хорошо подходит для выпаса дольяков. —Макстар Быстрый Шаг»).

## Что сделано

Удалены только те строки, у которых двойник найден **и переведён** — 174 из 263, все в `items_125`, `items_126`, `items_127`. Двойник ищется по английской половине склейки среди живых записей корпуса и слоя.

| файл | строк было | стало | мёртвых было | стало |
|---|---|---|---|---|
| `items/items_125.csv` | 500 | 467 | 36 | 3 |
| `items/items_126.csv` | 501 | 419 | 116 | 34 |
| `items/items_127.csv` | 501 | 442 | 79 | 20 |

## Что осталось и почему

* **57 строк в items**, где двойника не нашлось;
* **32 строки в hearts** — обрывки писем, которых больше нигде нет: «—Ardra,Отличная работа с чистильщиками». Двойника нет ни по английскому, ни по переводу — проверял отдельно, нашёлся ровно у одной из 32. Строка в игре мертва, но перевод пропадёт вместе с ней, и это уже решение владельца.

## Проверки

* уцелевшие строки во всех трёх файлах сверены с main **построчно и совпали до символа**;
* заголовок `english,translate` на месте;
* класс «в колонке english кириллица» — **263 → 89**;
* число строк в батчах уменьшилось: это ожидаемо и есть суть правки.

Штатного инструмента для класса нет — `langfilter.py` ищет немецкий, испанский и французский, `gluefix.py` и `seams.py` чинят потерянные переносы строк. Если такой разбор нужен регулярно, скрипт могу оформить в `tools/`.

## Пересажено на новую сборку

Ветка была отведена до `3eaa238b` и `98d9fe47` — до того, как место и существование строки стали решать батчи (`ROUTES.txt`, `frombatches --prune`, выгрузка накопившегося в `orphans/` и `pn/`), и до прохода `tools/namelatin.py`. Правки перенесены не текстом, а смыслом: строка ищется по колонке `english` (привязки к номеру строки после переработки не осталось), и к НЫНЕШНЕМУ тексту `main` применяются только те замены ветки, которые ещё нужны.

Удаления перенесены по ключу `english`: все 172 записи в новом `main` на месте (свои 2 047 мёртвых — потерянный CR+LF, вырезанный токен, пустой `english` — сборка снесла сама, у этих `english` цел). Места записей взяты из текущей раскладки.

Гейт: между собой ветки очереди не спорят — 304 общих строки, расхождений 0.
