### PR TITLE
Слой: семья Dragon Slayer сведена к одному канону, 195 записей

### DIFF
--- a/pn/pn_items_001.csv
+++ b/pn/pn_items_001.csv
@@ -147,22 +147,22 @@ Awakened Raptor,Пробужденный раптор
 Awakened Skimmer,Пробужденный скиммер
 Awakened Springer,Пробужденный спрингер
 Azure Denaturizing Agent,Лазурный денатурирующий агент
-Azure Dragon Slayer Axe,Топор лазурного дракона-убийцы
-Azure Dragon Slayer Dagger,Лазурный кинжал драконоборца
-Azure Dragon Slayer Focus,Фокус «Убийца лазурного дракона»
-Azure Dragon Slayer Greatsword,Лазурный двуручный меч драконоборца
-Azure Dragon Slayer Hammer,Молот Лазурного дракона
-Azure Dragon Slayer Longbow,Длинный лук убийцы лазурного дракона
-Azure Dragon Slayer Mace,Булава «Лазурный убийца драконов»
-Azure Dragon Slayer Pistol,Пистолет убийцы лазурного дракона
-Azure Dragon Slayer Rifle,Винтовка убийцы лазурного дракона
-Azure Dragon Slayer Scepter,Скипетр Убийцы Лазурного дракона
-Azure Dragon Slayer Shield,Щит убийцы лазурного дракона
-Azure Dragon Slayer Short Bow,Короткий лук «Лазурный драконоборец»
-Azure Dragon Slayer Staff,Посох «Убийца лазурного дракона»
-Azure Dragon Slayer Sword,Меч убийцы лазурного дракона
-Azure Dragon Slayer Torch,Факел убийцы лазурных драконов
-Azure Dragon Slayer Warhorn,Боевой рог лазурного дракона-убийцы
+Azure Dragon Slayer Axe,Лазурный топор убийцы драконов
+Azure Dragon Slayer Dagger,Лазурный кинжал убийцы драконов
+Azure Dragon Slayer Focus,Лазурный фокус убийцы драконов
+Azure Dragon Slayer Greatsword,Лазурный двуручный меч убийцы драконов
+Azure Dragon Slayer Hammer,Лазурный молот убийцы драконов
+Azure Dragon Slayer Longbow,Лазурный длинный лук убийцы драконов
+Azure Dragon Slayer Mace,Лазурная булава убийцы драконов
+Azure Dragon Slayer Pistol,Лазурный пистолет убийцы драконов
+Azure Dragon Slayer Rifle,Лазурная винтовка убийцы драконов
+Azure Dragon Slayer Scepter,Лазурный скипетр убийцы драконов
+Azure Dragon Slayer Shield,Лазурный щит убийцы драконов
+Azure Dragon Slayer Short Bow,Лазурный короткий лук убийцы драконов
+Azure Dragon Slayer Staff,Лазурный посох убийцы драконов
+Azure Dragon Slayer Sword,Лазурный меч убийцы драконов
+Azure Dragon Slayer Torch,Лазурный факел убийцы драконов
+Azure Dragon Slayer Warhorn,Лазурный боевой рог убийцы драконов
 Baelfire's Ember,Уголёк Бейлфайра
 Ball of Dark Energy,Шар тёмной энергии
 Bane's Tooth,Зуб Бейна

--- a/pn/pn_items_002.csv
+++ b/pn/pn_items_002.csv
@@ -26,22 +26,22 @@ Emblazoned Pants,Гербовые штаны
 Emblazoned Shoulders,Гербовые наплечники
 Eldritch Scroll,Мистический свиток
 Copper Ingot,Медный слиток
-Dragon Slayer Axe,Топор драконоборца
-Dragon Slayer Dagger,Кинжал Драконоборца
-Dragon Slayer Focus,Фокус драконоборца
-Dragon Slayer Greatsword,Двуручный меч драконоборца
-Dragon Slayer Hammer,Молот драконоборца
-Dragon Slayer Longbow,Длинный лук дракона-убийцы
-Dragon Slayer Mace,Булава Убийцы драконов
+Dragon Slayer Axe,Топор убийцы драконов
+Dragon Slayer Dagger,Кинжал убийцы драконов
+Dragon Slayer Focus,Фокус убийцы драконов
+Dragon Slayer Greatsword,Двуручный меч убийцы драконов
+Dragon Slayer Hammer,Молот убийцы драконов
+Dragon Slayer Longbow,Длинный лук убийцы драконов
+Dragon Slayer Mace,Булава убийцы драконов
 Dragon Slayer Pistol,Пистолет убийцы драконов
-Dragon Slayer Rifle,Винтовка Убийцы драконов
+Dragon Slayer Rifle,Винтовка убийцы драконов
 Dragon Slayer Scepter,Скипетр убийцы драконов
-Dragon Slayer Shield,Щит драконоборца
-Dragon Slayer Short Bow,Короткий лук драконоборца
-Dragon Slayer Staff,Посох драконоборца
+Dragon Slayer Shield,Щит убийцы драконов
+Dragon Slayer Short Bow,Короткий лук убийцы драконов
+Dragon Slayer Staff,Посох убийцы драконов
 Dragon Slayer Sword,Меч убийцы драконов
 Dragon Slayer Torch,Факел убийцы драконов
-Dragon Slayer Warhorn,Боевой рог драконоборца
+Dragon Slayer Warhorn,Боевой рог убийцы драконов
 Dye Pack,Набор красок
 "Eikasia, Mists-Grasper","Эйказия, Хватающая Туманы"
 Butternut Squash,Мускатная тыква
@@ -174,22 +174,22 @@ Corrosive Paste,Едкая паста
 Corrupted Ice Shard,Осквернённый ледяной осколок
 Counterweighting Mechanism,Механизм противовеса
 Crafting Booster,Усилитель ремесла
-Crimson Dragon Slayer Axe,Топор «Багровый драконоборец»
-Crimson Dragon Slayer Dagger,Кинжал алого дракона
-Crimson Dragon Slayer Focus,Фокус «Алый драконоборец»
+Crimson Dragon Slayer Axe,Багровый топор убийцы драконов
+Crimson Dragon Slayer Dagger,Багровый кинжал убийцы драконов
+Crimson Dragon Slayer Focus,Багровый фокус убийцы драконов
 Crimson Dragon Slayer Greatsword,Багровый двуручный меч убийцы драконов
-Crimson Dragon Slayer Hammer,Молот борца с алым драконом
-Crimson Dragon Slayer Longbow,Длинный лук убийцы багровых драконов
-Crimson Dragon Slayer Mace,Багровая булава драконоборца
+Crimson Dragon Slayer Hammer,Багровый молот убийцы драконов
+Crimson Dragon Slayer Longbow,Багровый длинный лук убийцы драконов
+Crimson Dragon Slayer Mace,Багровая булава убийцы драконов
 Crimson Dragon Slayer Pistol,Багровый пистолет убийцы драконов
-Crimson Dragon Slayer Rifle,Винтовка алого драконоборца
-Crimson Dragon Slayer Scepter,Скипетр убийцы багрового дракона
-Crimson Dragon Slayer Shield,Щит алого драконоборца
-Crimson Dragon Slayer Short Bow,Короткий лук багрового драконоборца
-Crimson Dragon Slayer Staff,Посох алого драконоборца
-Crimson Dragon Slayer Sword,Малиновый меч Убийцы драконов
-Crimson Dragon Slayer Torch,Факел алого драконоборца
-Crimson Dragon Slayer Warhorn,Боевой рог «Багровый драконоборец»
+Crimson Dragon Slayer Rifle,Багровая винтовка убийцы драконов
+Crimson Dragon Slayer Scepter,Багровый скипетр убийцы драконов
+Crimson Dragon Slayer Shield,Багровый щит убийцы драконов
+Crimson Dragon Slayer Short Bow,Багровый короткий лук убийцы драконов
+Crimson Dragon Slayer Staff,Багровый посох убийцы драконов
+Crimson Dragon Slayer Sword,Багровый меч убийцы драконов
+Crimson Dragon Slayer Torch,Багровый факел убийцы драконов
+Crimson Dragon Slayer Warhorn,Багровый боевой рог убийцы драконов
 Crystal Lodestone,Кристальный магнетит
 Crystal Shard,Кристальный осколок
 Crystallized Chaos,Кристаллизованный хаос

--- a/pn/pn_items_003.csv
+++ b/pn/pn_items_003.csv
@@ -407,22 +407,22 @@ Feast of Carne Khan Chili,Пир из чили «Карне Хан»
 Feast of Nopalitos Sauté,Пир из жаркого с нопалом
 Feather of the Owl,Перо совы
 Feathers of the Zephyr,Перья Зефира
-Fiery Dragon Slayer Axe,Топор огненного убийцы драконов
+Fiery Dragon Slayer Axe,Огненный топор убийцы драконов
 Fiery Dragon Slayer Dagger,Огненный кинжал убийцы драконов
-Fiery Dragon Slayer Focus,Пламенный фокус драконоборца
-Fiery Dragon Slayer Greatsword,Пылающий двуручный меч драконоборца
-Fiery Dragon Slayer Hammer,Огненный драконий молот истребителя
-Fiery Dragon Slayer Longbow,Огненный длинный лук драконоборца
-Fiery Dragon Slayer Mace,Пламенная булава драконоборца
-Fiery Dragon Slayer Pistol,Пистолет «Огненный драконоборец»
+Fiery Dragon Slayer Focus,Огненный фокус убийцы драконов
+Fiery Dragon Slayer Greatsword,Огненный двуручный меч убийцы драконов
+Fiery Dragon Slayer Hammer,Огненный молот убийцы драконов
+Fiery Dragon Slayer Longbow,Огненный длинный лук убийцы драконов
+Fiery Dragon Slayer Mace,Огненная булава убийцы драконов
+Fiery Dragon Slayer Pistol,Огненный пистолет убийцы драконов
 Fiery Dragon Slayer Rifle,Огненная винтовка убийцы драконов
-Fiery Dragon Slayer Scepter,Скипетр огненного драконоборца
-Fiery Dragon Slayer Shield,Огненный щит драконоборца
-Fiery Dragon Slayer Short Bow,Огненный короткий лук Убийцы драконов
+Fiery Dragon Slayer Scepter,Огненный скипетр убийцы драконов
+Fiery Dragon Slayer Shield,Огненный щит убийцы драконов
+Fiery Dragon Slayer Short Bow,Огненный короткий лук убийцы драконов
 Fiery Dragon Slayer Staff,Огненный посох убийцы драконов
 Fiery Dragon Slayer Sword,Огненный меч убийцы драконов
-Fiery Dragon Slayer Torch,Пылающий факел убийцы драконов
-Fiery Dragon Slayer Warhorn,Пламенный боевой рог драконоборца
+Fiery Dragon Slayer Torch,Огненный факел убийцы драконов
+Fiery Dragon Slayer Warhorn,Огненный боевой рог убийцы драконов
 Fighting Pit Training Sword,Тренировочный меч для боевой ямы
 "Final Words of Zei Ri to His Supporters, 1637 CC","Последние слова Зей Ри своим сторонникам, 1637 ПЦ"
 Finite Wings,Конечные крылья

--- a/pn/pn_items_004.csv
+++ b/pn/pn_items_004.csv
@@ -366,21 +366,21 @@ Ice Reaver Legguards,Набедренники Ледяного жнеца
 Ice Reaver Pauldrons,Наплечники Ледяного жнеца
 Icy Demon Horns,Ледяные рога демона
 Icy Dragon Slayer Axe,Ледяной топор убийцы драконов
-Icy Dragon Slayer Dagger,Кинжал ледяного драконоборца
+Icy Dragon Slayer Dagger,Ледяной кинжал убийцы драконов
 Icy Dragon Slayer Focus,Ледяной фокус убийцы драконов
-Icy Dragon Slayer Greatsword,Ледяной двуручный меч драконоборца
-Icy Dragon Slayer Hammer,Ледяной молот драконоборца
+Icy Dragon Slayer Greatsword,Ледяной двуручный меч убийцы драконов
+Icy Dragon Slayer Hammer,Ледяной молот убийцы драконов
 Icy Dragon Slayer Longbow,Ледяной длинный лук убийцы драконов
-Icy Dragon Slayer Mace,Ледяная булава Убийцы драконов
+Icy Dragon Slayer Mace,Ледяная булава убийцы драконов
 Icy Dragon Slayer Pistol,Ледяной пистолет убийцы драконов
 Icy Dragon Slayer Rifle,Ледяная винтовка убийцы драконов
 Icy Dragon Slayer Scepter,Ледяной скипетр убийцы драконов
-Icy Dragon Slayer Shield,Ледяной щит драконоборца
-Icy Dragon Slayer Short Bow,Короткий лук убийцы ледяных драконов
-Icy Dragon Slayer Staff,Посох ледяного драконоборца
-Icy Dragon Slayer Sword,Ледяной меч драконоборца
-Icy Dragon Slayer Torch,Факел Ледяного убийцы драконов
-Icy Dragon Slayer Warhorn,Ледяной драконий боевой рог истребителя
+Icy Dragon Slayer Shield,Ледяной щит убийцы драконов
+Icy Dragon Slayer Short Bow,Ледяной короткий лук убийцы драконов
+Icy Dragon Slayer Staff,Ледяной посох убийцы драконов
+Icy Dragon Slayer Sword,Ледяной меч убийцы драконов
+Icy Dragon Slayer Torch,Ледяной факел убийцы драконов
+Icy Dragon Slayer Warhorn,Ледяной боевой рог убийцы драконов
 Icy Rime,Ледяной иней
 Igneous Chair,Огненный стул
 Impact Site Marker,Маркер места удара

--- a/pn/pn_items_059.csv
+++ b/pn/pn_items_059.csv
@@ -322,22 +322,22 @@ Marauder Auric Staff,Аурический посох мародёра
 Marauder Auric Sword,Аурический меч мародёра
 Marauder Auric Torch,Аурический факел мародёра
 Marauder Auric Warhorn,Аурический боевой рог мародёра
-Marauder Azure Dragon Slayer Axe,Топор «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Dagger,Кинжал «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Focus,Фокус «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Greatsword,Двуручный меч «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Hammer,Молот «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Longbow,Длинный лук «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Mace,Булава «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Pistol,Пистолет «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Rifle,Винтовка «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Scepter,Скипетр «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Shield,Щит «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Short Bow,Короткий лук «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Staff,Посох «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Sword,Меч «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Torch,Факел «Лазурный драконоборец» мародёра
-Marauder Azure Dragon Slayer Warhorn,Боевой рог «Лазурный драконоборец» мародёра
+Marauder Azure Dragon Slayer Axe,Лазурный топор убийцы драконов мародёра
+Marauder Azure Dragon Slayer Dagger,Лазурный кинжал убийцы драконов мародёра
+Marauder Azure Dragon Slayer Focus,Лазурный фокус убийцы драконов мародёра
+Marauder Azure Dragon Slayer Greatsword,Лазурный двуручный меч убийцы драконов мародёра
+Marauder Azure Dragon Slayer Hammer,Лазурный молот убийцы драконов мародёра
+Marauder Azure Dragon Slayer Longbow,Лазурный длинный лук убийцы драконов мародёра
+Marauder Azure Dragon Slayer Mace,Лазурная булава убийцы драконов мародёра
+Marauder Azure Dragon Slayer Pistol,Лазурный пистолет убийцы драконов мародёра
+Marauder Azure Dragon Slayer Rifle,Лазурная винтовка убийцы драконов мародёра
+Marauder Azure Dragon Slayer Scepter,Лазурный скипетр убийцы драконов мародёра
+Marauder Azure Dragon Slayer Shield,Лазурный щит убийцы драконов мародёра
+Marauder Azure Dragon Slayer Short Bow,Лазурный короткий лук убийцы драконов мародёра
+Marauder Azure Dragon Slayer Staff,Лазурный посох убийцы драконов мародёра
+Marauder Azure Dragon Slayer Sword,Лазурный меч убийцы драконов мародёра
+Marauder Azure Dragon Slayer Torch,Лазурный факел убийцы драконов мародёра
+Marauder Azure Dragon Slayer Warhorn,Лазурный боевой рог убийцы драконов мародёра
 Marauder Boots,Сапоги мародёра
 Marauder Draconic Boots,Сапоги драконьей чешуи мародёра
 Marauder Draconic Coat,Куртка драконьей чешуи мародёра

--- a/pn/pn_items_076.csv
+++ b/pn/pn_items_076.csv
@@ -314,22 +314,22 @@ Recipe: Asuran Speargun,Рецепт: асурское гарпунное руж
 Recipe: Asuran Trident,Рецепт: асуранский трезубец
 Recipe: Atzintli's Spear,Рецепт: копьё Атцинтли
 Recipe: Avocado Smoothie,Рецепт: авокадо-смузи
-Recipe: Azure Dragon Slayer Axe,Рецепт: топор убийцы лазурного дракона
-Recipe: Azure Dragon Slayer Dagger,Рецепт: кинжал «Убийца лазоревого дракона»
-Recipe: Azure Dragon Slayer Focus,Рецепт: фокус лазурного дракона-убийцы
-Recipe: Azure Dragon Slayer Greatsword,Рецепт: двуручный меч «Убийца лазурного дракона»
-Recipe: Azure Dragon Slayer Hammer,Рецепт: молот убийцы лазурного дракона
-Recipe: Azure Dragon Slayer Longbow,Рецепт: длинный лук «Убийца лазурного дракона»
-Recipe: Azure Dragon Slayer Mace,Рецепт: лазурная булава драконоборца
-Recipe: Azure Dragon Slayer Pistol,Рецепт: пистолет убийцы лазурного дракона
-Recipe: Azure Dragon Slayer Rifle,Рецепт: винтовка убийцы лазурного дракона
-Recipe: Azure Dragon Slayer Scepter,Рецепт: скипетр Лазурного дракона
-Recipe: Azure Dragon Slayer Shield,Рецепт: щит «Лазурный драконоборец»
-Recipe: Azure Dragon Slayer Short Bow,Рецепт: короткий лук убийцы лазурного дракона
-Recipe: Azure Dragon Slayer Staff,Рецепт: посох Убийцы Лазурного Дракона
-Recipe: Azure Dragon Slayer Sword,Рецепт: меч убийцы лазурного дракона
-Recipe: Azure Dragon Slayer Torch,Рецепт: факел убийцы лазурных драконов
-Recipe: Azure Dragon Slayer Warhorn,Рецепт: лазурный боевой рог драконоборца
+Recipe: Azure Dragon Slayer Axe,Рецепт: лазурный топор убийцы драконов
+Recipe: Azure Dragon Slayer Dagger,Рецепт: лазурный кинжал убийцы драконов
+Recipe: Azure Dragon Slayer Focus,Рецепт: лазурный фокус убийцы драконов
+Recipe: Azure Dragon Slayer Greatsword,Рецепт: лазурный двуручный меч убийцы драконов
+Recipe: Azure Dragon Slayer Hammer,Рецепт: лазурный молот убийцы драконов
+Recipe: Azure Dragon Slayer Longbow,Рецепт: лазурный длинный лук убийцы драконов
+Recipe: Azure Dragon Slayer Mace,Рецепт: лазурная булава убийцы драконов
+Recipe: Azure Dragon Slayer Pistol,Рецепт: лазурный пистолет убийцы драконов
+Recipe: Azure Dragon Slayer Rifle,Рецепт: лазурная винтовка убийцы драконов
+Recipe: Azure Dragon Slayer Scepter,Рецепт: лазурный скипетр убийцы драконов
+Recipe: Azure Dragon Slayer Shield,Рецепт: лазурный щит убийцы драконов
+Recipe: Azure Dragon Slayer Short Bow,Рецепт: лазурный короткий лук убийцы драконов
+Recipe: Azure Dragon Slayer Staff,Рецепт: лазурный посох убийцы драконов
+Recipe: Azure Dragon Slayer Sword,Рецепт: лазурный меч убийцы драконов
+Recipe: Azure Dragon Slayer Torch,Рецепт: лазурный факел убийцы драконов
+Recipe: Azure Dragon Slayer Warhorn,Рецепт: лазурный боевой рог убийцы драконов
 Recipe: Bag of Cassava Flour,Рецепт: мешок муки маниоки
 Recipe: Bag of Popped Candy Corn,Рецепт: мешок воздушной кукурузы в карамели
 Recipe: Banner Pennon,Рецепт: знамя вымпела

--- a/pn/pn_items_077.csv
+++ b/pn/pn_items_077.csv
@@ -326,22 +326,22 @@ Recipe: Corsair Maintenance Oil,Рецепт: масло для обслужив
 Recipe: Corsair Sharpening Stone,Рецепт: точильный камень корсара
 Recipe: Corsair Tuning Crystal,Рецепт: корсарский настраивающий кристалл
 Recipe: Counterweighting Mechanism,Рецепт: механизм противовеса
-Recipe: Crimson Dragon Slayer Axe,Рецепт: топор «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Dagger,Рецепт: кинжал «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Focus,Рецепт: фокус «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Greatsword,Рецепт: двуручный меч «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Hammer,Рецепт: молот «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Longbow,Рецепт: длинный лук «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Mace,Рецепт: булава «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Pistol,Рецепт: пистолет «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Rifle,Рецепт: винтовка «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Scepter,Рецепт: скипетр «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Shield,Рецепт: щит «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Short Bow,Рецепт: короткий лук «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Staff,Рецепт: посох «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Sword,Рецепт: меч «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Torch,Рецепт: факел «Багровый драконоборец»
-Recipe: Crimson Dragon Slayer Warhorn,Рецепт: боевой рог «Багровый драконоборец»
+Recipe: Crimson Dragon Slayer Axe,Рецепт: багровый топор убийцы драконов
+Recipe: Crimson Dragon Slayer Dagger,Рецепт: багровый кинжал убийцы драконов
+Recipe: Crimson Dragon Slayer Focus,Рецепт: багровый фокус убийцы драконов
+Recipe: Crimson Dragon Slayer Greatsword,Рецепт: багровый двуручный меч убийцы драконов
+Recipe: Crimson Dragon Slayer Hammer,Рецепт: багровый молот убийцы драконов
+Recipe: Crimson Dragon Slayer Longbow,Рецепт: багровый длинный лук убийцы драконов
+Recipe: Crimson Dragon Slayer Mace,Рецепт: багровая булава убийцы драконов
+Recipe: Crimson Dragon Slayer Pistol,Рецепт: багровый пистолет убийцы драконов
+Recipe: Crimson Dragon Slayer Rifle,Рецепт: багровая винтовка убийцы драконов
+Recipe: Crimson Dragon Slayer Scepter,Рецепт: багровый скипетр убийцы драконов
+Recipe: Crimson Dragon Slayer Shield,Рецепт: багровый щит убийцы драконов
+Recipe: Crimson Dragon Slayer Short Bow,Рецепт: багровый короткий лук убийцы драконов
+Recipe: Crimson Dragon Slayer Staff,Рецепт: багровый посох убийцы драконов
+Recipe: Crimson Dragon Slayer Sword,Рецепт: багровый меч убийцы драконов
+Recipe: Crimson Dragon Slayer Torch,Рецепт: багровый факел убийцы драконов
+Recipe: Crimson Dragon Slayer Warhorn,Рецепт: багровый боевой рог убийцы драконов
 Recipe: Crude Leather Book,Рецепт: книга из грубой кожи
 Recipe: Crusader Intricate Gossamer Insignia,Рецепт: искусная инсигния из паутинки крестоносца
 Recipe: Crusader Orichalcum Imbued Inscription,Рецепт: орихалковая пропитанная гравировка крестоносца
@@ -414,22 +414,22 @@ Recipe: Dragon Hatchling Doll Adornments,Рецепт: украшения кук
 Recipe: Dragon Hatchling Doll Eyes,Рецепт: глаза куклы-дракончика
 Recipe: Dragon Hatchling Doll Frame,Рецепт: каркас куклы дракончика
 Recipe: Dragon Hatchling Doll Hide,Рецепт: шкура куклы драконьего детёныша
-Recipe: Dragon Slayer Axe,Рецепт: топор «Драконоборец»
-Recipe: Dragon Slayer Dagger,Рецепт: кинжал «Драконоборец»
-Recipe: Dragon Slayer Focus,Рецепт: фокус «Драконоборец»
-Recipe: Dragon Slayer Greatsword,Рецепт: двуручный меч «Драконоборец»
-Recipe: Dragon Slayer Hammer,Рецепт: молот «Драконоборец»
-Recipe: Dragon Slayer Longbow,Рецепт: длинный лук «Драконоборец»
-Recipe: Dragon Slayer Mace,Рецепт: булава «Драконоборец»
-Recipe: Dragon Slayer Pistol,Рецепт: пистолет «Драконоборец»
-Recipe: Dragon Slayer Rifle,Рецепт: винтовка «Драконоборец»
-Recipe: Dragon Slayer Scepter,Рецепт: скипетр «Драконоборец»
-Recipe: Dragon Slayer Shield,Рецепт: щит «Драконоборец»
-Recipe: Dragon Slayer Short Bow,Рецепт: короткий лук «Драконоборец»
-Recipe: Dragon Slayer Staff,Рецепт: посох «Драконоборец»
-Recipe: Dragon Slayer Sword,Рецепт: меч «Драконоборец»
-Recipe: Dragon Slayer Torch,Рецепт: факел «Драконоборец»
-Recipe: Dragon Slayer Warhorn,Рецепт: боевой рог «Драконоборец»
+Recipe: Dragon Slayer Axe,Рецепт: топор убийцы драконов
+Recipe: Dragon Slayer Dagger,Рецепт: кинжал убийцы драконов
+Recipe: Dragon Slayer Focus,Рецепт: фокус убийцы драконов
+Recipe: Dragon Slayer Greatsword,Рецепт: двуручный меч убийцы драконов
+Recipe: Dragon Slayer Hammer,Рецепт: молот убийцы драконов
+Recipe: Dragon Slayer Longbow,Рецепт: длинный лук убийцы драконов
+Recipe: Dragon Slayer Mace,Рецепт: булава убийцы драконов
+Recipe: Dragon Slayer Pistol,Рецепт: пистолет убийцы драконов
+Recipe: Dragon Slayer Rifle,Рецепт: винтовка убийцы драконов
+Recipe: Dragon Slayer Scepter,Рецепт: скипетр убийцы драконов
+Recipe: Dragon Slayer Shield,Рецепт: щит убийцы драконов
+Recipe: Dragon Slayer Short Bow,Рецепт: короткий лук убийцы драконов
+Recipe: Dragon Slayer Staff,Рецепт: посох убийцы драконов
+Recipe: Dragon Slayer Sword,Рецепт: меч убийцы драконов
+Recipe: Dragon Slayer Torch,Рецепт: факел убийцы драконов
+Recipe: Dragon Slayer Warhorn,Рецепт: боевой рог убийцы драконов
 Recipe: Dragon's Intricate Gossamer Insignia,Рецепт: замысловатая паутинная инсигния дракона
 Recipe: Dragon's Orichalcum Imbued Inscription,Рецепт: пропитанная гравировка из орихалка дракона
 Recipe: Dragon's Revelry Starcake,Рецепт: звёздный пирог драконьего веселья

--- a/pn/pn_items_078.csv
+++ b/pn/pn_items_078.csv
@@ -178,22 +178,22 @@ Recipe: Ferratus's Visor,Рецепт: забрало Ферратуса
 Recipe: Ferratus's Warfists,Рецепт: боевые рукавицы Ферратуса
 Recipe: Ferratus's Wristguards,Рецепт: наручи Ферратуса
 Recipe: Festive Fall Tent,Рецепт: праздничный осенний шатер
-Recipe: Fiery Dragon Slayer Axe,Рецепт: огненный топор «Драконоборец»
-Recipe: Fiery Dragon Slayer Dagger,Рецепт: огненный кинжал «Драконоборец»
-Recipe: Fiery Dragon Slayer Focus,Рецепт: огненный фокус «Драконоборец»
-Recipe: Fiery Dragon Slayer Greatsword,Рецепт: огненный двуручный меч «Драконоборец»
-Recipe: Fiery Dragon Slayer Hammer,Рецепт: огненный молот «Драконоборец»
-Recipe: Fiery Dragon Slayer Longbow,Рецепт: огненный длинный лук «Драконоборец»
-Recipe: Fiery Dragon Slayer Mace,Рецепт: огненная булава «Драконоборец»
-Recipe: Fiery Dragon Slayer Pistol,Рецепт: огненный пистолет «Драконоборец»
-Recipe: Fiery Dragon Slayer Rifle,Рецепт: огненная винтовка «Драконоборец»
-Recipe: Fiery Dragon Slayer Scepter,Рецепт: огненный скипетр «Драконоборец»
-Recipe: Fiery Dragon Slayer Shield,Рецепт: огненный щит «Драконоборец»
-Recipe: Fiery Dragon Slayer Short Bow,Рецепт: огненный короткий лук «Драконоборец»
-Recipe: Fiery Dragon Slayer Staff,Рецепт: огненный посох «Драконоборец»
-Recipe: Fiery Dragon Slayer Sword,Рецепт: огненный меч «Драконоборец»
-Recipe: Fiery Dragon Slayer Torch,Рецепт: огненный факел «Драконоборец»
-Recipe: Fiery Dragon Slayer Warhorn,Рецепт: огненный боевой рог «Драконоборец»
+Recipe: Fiery Dragon Slayer Axe,Рецепт: огненный топор убийцы драконов
+Recipe: Fiery Dragon Slayer Dagger,Рецепт: огненный кинжал убийцы драконов
+Recipe: Fiery Dragon Slayer Focus,Рецепт: огненный фокус убийцы драконов
+Recipe: Fiery Dragon Slayer Greatsword,Рецепт: огненный двуручный меч убийцы драконов
+Recipe: Fiery Dragon Slayer Hammer,Рецепт: огненный молот убийцы драконов
+Recipe: Fiery Dragon Slayer Longbow,Рецепт: огненный длинный лук убийцы драконов
+Recipe: Fiery Dragon Slayer Mace,Рецепт: огненная булава убийцы драконов
+Recipe: Fiery Dragon Slayer Pistol,Рецепт: огненный пистолет убийцы драконов
+Recipe: Fiery Dragon Slayer Rifle,Рецепт: огненная винтовка убийцы драконов
+Recipe: Fiery Dragon Slayer Scepter,Рецепт: огненный скипетр убийцы драконов
+Recipe: Fiery Dragon Slayer Shield,Рецепт: огненный щит убийцы драконов
+Recipe: Fiery Dragon Slayer Short Bow,Рецепт: огненный короткий лук убийцы драконов
+Recipe: Fiery Dragon Slayer Staff,Рецепт: огненный посох убийцы драконов
+Recipe: Fiery Dragon Slayer Sword,Рецепт: огненный меч убийцы драконов
+Recipe: Fiery Dragon Slayer Torch,Рецепт: огненный факел убийцы драконов
+Recipe: Fiery Dragon Slayer Warhorn,Рецепт: огненный боевой рог убийцы драконов
 Recipe: Filtered Honey,Рецепт: фильтрованный мед
 Recipe: Fine Rift Motivation,Рецепт: тонкая мотивация разлома
 Recipe: Finely Tuned Watchwork Mechanism,Рецепт: тонко настроенный часовой механизм

--- a/pn/pn_items_079.csv
+++ b/pn/pn_items_079.csv
@@ -52,22 +52,22 @@ Recipe: Hylek Maintenance Oil,Рецепт: масло для обслужива
 Recipe: Hymenoptera,Рецепт: гименоптера
 Recipe: Hypothesis,Рецепт: гипотеза
 Recipe: Icicle,Рецепт: сосулька
-Recipe: Icy Dragon Slayer Axe,Рецепт: ледяной топор «Драконоборец»
-Recipe: Icy Dragon Slayer Dagger,Рецепт: ледяной кинжал «Драконоборец»
-Recipe: Icy Dragon Slayer Focus,Рецепт: ледяной фокус «Драконоборец»
-Recipe: Icy Dragon Slayer Greatsword,Рецепт: ледяной двуручный меч «Драконоборец»
-Recipe: Icy Dragon Slayer Hammer,Рецепт: ледяной молот «Драконоборец»
-Recipe: Icy Dragon Slayer Longbow,Рецепт: ледяной длинный лук «Драконоборец»
-Recipe: Icy Dragon Slayer Mace,Рецепт: ледяная булава «Драконоборец»
-Recipe: Icy Dragon Slayer Pistol,Рецепт: ледяной пистолет «Драконоборец»
-Recipe: Icy Dragon Slayer Rifle,Рецепт: ледяная винтовка «Драконоборец»
-Recipe: Icy Dragon Slayer Scepter,Рецепт: ледяной скипетр «Драконоборец»
-Recipe: Icy Dragon Slayer Shield,Рецепт: ледяной щит «Драконоборец»
-Recipe: Icy Dragon Slayer Short Bow,Рецепт: ледяной короткий лук «Драконоборец»
-Recipe: Icy Dragon Slayer Staff,Рецепт: ледяной посох «Драконоборец»
-Recipe: Icy Dragon Slayer Sword,Рецепт: ледяной меч «Драконоборец»
-Recipe: Icy Dragon Slayer Torch,Рецепт: ледяной факел «Драконоборец»
-Recipe: Icy Dragon Slayer Warhorn,Рецепт: ледяной боевой рог «Драконоборец»
+Recipe: Icy Dragon Slayer Axe,Рецепт: ледяной топор убийцы драконов
+Recipe: Icy Dragon Slayer Dagger,Рецепт: ледяной кинжал убийцы драконов
+Recipe: Icy Dragon Slayer Focus,Рецепт: ледяной фокус убийцы драконов
+Recipe: Icy Dragon Slayer Greatsword,Рецепт: ледяной двуручный меч убийцы драконов
+Recipe: Icy Dragon Slayer Hammer,Рецепт: ледяной молот убийцы драконов
+Recipe: Icy Dragon Slayer Longbow,Рецепт: ледяной длинный лук убийцы драконов
+Recipe: Icy Dragon Slayer Mace,Рецепт: ледяная булава убийцы драконов
+Recipe: Icy Dragon Slayer Pistol,Рецепт: ледяной пистолет убийцы драконов
+Recipe: Icy Dragon Slayer Rifle,Рецепт: ледяная винтовка убийцы драконов
+Recipe: Icy Dragon Slayer Scepter,Рецепт: ледяной скипетр убийцы драконов
+Recipe: Icy Dragon Slayer Shield,Рецепт: ледяной щит убийцы драконов
+Recipe: Icy Dragon Slayer Short Bow,Рецепт: ледяной короткий лук убийцы драконов
+Recipe: Icy Dragon Slayer Staff,Рецепт: ледяной посох убийцы драконов
+Recipe: Icy Dragon Slayer Sword,Рецепт: ледяной меч убийцы драконов
+Recipe: Icy Dragon Slayer Torch,Рецепт: ледяной факел убийцы драконов
+Recipe: Icy Dragon Slayer Warhorn,Рецепт: ледяной боевой рог убийцы драконов
 Recipe: Illuminated Boreal Axe,Рецепт: озарённый бореальный топор
 Recipe: Illuminated Boreal Dagger,Рецепт: озарённый бореальный кинжал
 Recipe: Illuminated Boreal Focus,Рецепт: озарённый бореальный фокус

--- a/pn/pn_items_105.csv
+++ b/pn/pn_items_105.csv
@@ -133,38 +133,38 @@ Undying Shackles Cape Skin,Облик накидки «Неумирающие о
 Undying Shackles Cape and Glider Combo,Набор «Неумирающие оковы»: плащ и планер
 Undying Shackles Glider,Планер «Бессмертные оковы»
 Unethical Test Results,Неэтичные результаты тестов
-Unfinished Azure Dragon Slayer Axe,Незавершённый топор убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Dagger,Незавершённый кинжал убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Focus,Незавершённый фокус убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Greatsword,Незавершённый двуручный меч убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Hammer,Незавершённый молот убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Longbow,Незавершённый длинный лук убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Mace,Незавершённая булава убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Pistol,Незавершённый пистолет убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Rifle,Незавершённая винтовка убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Scepter,Незавершённый скипетр убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Shield,Незавершённый щит убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Short Bow,Незавершённый короткий лук убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Staff,Незавершённый посох убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Sword,Незавершённый меч убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Torch,Незавершённый факел убийцы лазурного дракона
-Unfinished Azure Dragon Slayer Warhorn,Незавершённый боевой рог убийцы лазурного дракона
-Unfinished Crimson Dragon Slayer Axe,Незавершённый топор убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Dagger,Незавершённый кинжал убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Focus,Незавершённый фокус убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Greatsword,Незавершённый двуручный меч убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Hammer,Незавершённый молот убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Longbow,Незавершённый длинный лук убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Mace,Незавершённая булава убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Pistol,Незавершённый пистолет убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Rifle,Незавершённая винтовка убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Scepter,Незавершённый скипетр убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Shield,Незавершённый щит убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Short Bow,Незавершённый короткий лук убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Staff,Незавершённый посох убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Sword,Незавершённый меч убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Torch,Незавершённый факел убийцы багрового дракона
-Unfinished Crimson Dragon Slayer Warhorn,Незавершённый боевой рог убийцы багрового дракона
+Unfinished Azure Dragon Slayer Axe,Незавершённый лазурный топор убийцы драконов
+Unfinished Azure Dragon Slayer Dagger,Незавершённый лазурный кинжал убийцы драконов
+Unfinished Azure Dragon Slayer Focus,Незавершённый лазурный фокус убийцы драконов
+Unfinished Azure Dragon Slayer Greatsword,Незавершённый лазурный двуручный меч убийцы драконов
+Unfinished Azure Dragon Slayer Hammer,Незавершённый лазурный молот убийцы драконов
+Unfinished Azure Dragon Slayer Longbow,Незавершённый лазурный длинный лук убийцы драконов
+Unfinished Azure Dragon Slayer Mace,Незавершённая лазурная булава убийцы драконов
+Unfinished Azure Dragon Slayer Pistol,Незавершённый лазурный пистолет убийцы драконов
+Unfinished Azure Dragon Slayer Rifle,Незавершённая лазурная винтовка убийцы драконов
+Unfinished Azure Dragon Slayer Scepter,Незавершённый лазурный скипетр убийцы драконов
+Unfinished Azure Dragon Slayer Shield,Незавершённый лазурный щит убийцы драконов
+Unfinished Azure Dragon Slayer Short Bow,Незавершённый лазурный короткий лук убийцы драконов
+Unfinished Azure Dragon Slayer Staff,Незавершённый лазурный посох убийцы драконов
+Unfinished Azure Dragon Slayer Sword,Незавершённый лазурный меч убийцы драконов
+Unfinished Azure Dragon Slayer Torch,Незавершённый лазурный факел убийцы драконов
+Unfinished Azure Dragon Slayer Warhorn,Незавершённый лазурный боевой рог убийцы драконов
+Unfinished Crimson Dragon Slayer Axe,Незавершённый багровый топор убийцы драконов
+Unfinished Crimson Dragon Slayer Dagger,Незавершённый багровый кинжал убийцы драконов
+Unfinished Crimson Dragon Slayer Focus,Незавершённый багровый фокус убийцы драконов
+Unfinished Crimson Dragon Slayer Greatsword,Незавершённый багровый двуручный меч убийцы драконов
+Unfinished Crimson Dragon Slayer Hammer,Незавершённый багровый молот убийцы драконов
+Unfinished Crimson Dragon Slayer Longbow,Незавершённый багровый длинный лук убийцы драконов
+Unfinished Crimson Dragon Slayer Mace,Незавершённая багровая булава убийцы драконов
+Unfinished Crimson Dragon Slayer Pistol,Незавершённый багровый пистолет убийцы драконов
+Unfinished Crimson Dragon Slayer Rifle,Незавершённая багровая винтовка убийцы драконов
+Unfinished Crimson Dragon Slayer Scepter,Незавершённый багровый скипетр убийцы драконов
+Unfinished Crimson Dragon Slayer Shield,Незавершённый багровый щит убийцы драконов
+Unfinished Crimson Dragon Slayer Short Bow,Незавершённый багровый короткий лук убийцы драконов
+Unfinished Crimson Dragon Slayer Staff,Незавершённый багровый посох убийцы драконов
+Unfinished Crimson Dragon Slayer Sword,Незавершённый багровый меч убийцы драконов
+Unfinished Crimson Dragon Slayer Torch,Незавершённый багровый факел убийцы драконов
+Unfinished Crimson Dragon Slayer Warhorn,Незавершённый багровый боевой рог убийцы драконов
 Unholy Mackerel,Нечестивая скумбрия
 Unicorn Fish,Рыба-единорог
 Unicorn Horn Helm Skin,Облик шлема «Рог единорога»

--- a/pn/pn_items_108.csv
+++ b/pn/pn_items_108.csv
@@ -10,13 +10,13 @@ Viper's Crimson Dragon Slayer Axe,Багровый топор убийцы др�
 Viper's Crimson Dragon Slayer Dagger,Багровый кинжал убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Focus,Багровый фокус убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Greatsword,Багровый двуручный меч убийцы драконов гадюки
-Viper's Crimson Dragon Slayer Hammer,Молот «Гнев дракона» из чешуи гадюки
+Viper's Crimson Dragon Slayer Hammer,Багровый молот убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Longbow,Багровый длинный лук убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Mace,Багровая булава убийцы драконов гадюки
-Viper's Crimson Dragon Slayer Pistol,Пистолет гадюки «Багровый драконоборец»
+Viper's Crimson Dragon Slayer Pistol,Багровый пистолет убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Rifle,Багровая винтовка убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Scepter,Багровый скипетр убийцы драконов гадюки
-Viper's Crimson Dragon Slayer Shield,Щит Багрового убийцы драконов Гадюки
+Viper's Crimson Dragon Slayer Shield,Багровый щит убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Short Bow,Багровый короткий лук убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Staff,Багровый посох убийцы драконов гадюки
 Viper's Crimson Dragon Slayer Sword,Багровый меч убийцы драконов гадюки


### PR DESCRIPTION
Тот же класс, что вы сводили у семьи `Dawn*`: одно имя — несколько русских форм. Здесь их пять на одну семью, **278 записей слоя**.

## Что видит игрок

Сет `Azure Dragon Slayer` — шестнадцать предметов, лежащих в гардеробе рядом:

| ключ | было |
|---|---|
| `Azure Dragon Slayer Axe` | Топор лазурного дракона-убийцы |
| `Azure Dragon Slayer Dagger` | Лазурный кинжал драконоборца |
| `Azure Dragon Slayer Focus` | Фокус «Убийца лазурного дракона» |
| `Azure Dragon Slayer Hammer` | Молот Лазурного дракона ← `Slayer` потерян вовсе |
| `Azure Dragon Slayer Mace` | Булава «Лазурный убийца драконов» |
| `Azure Dragon Slayer Torch` | Факел убийцы лазурных драконов ← множественное |

## Канон и откуда он

**«убийца драконов»**, по трём независимым основаниям:

* **человеческий корпус** — 241 строка против 32 у «драконоборца». Большинство идёт из `ach_030`, а он подписан «Arelion — сверено по глоссарию»;
* **базовая запись самого слоя**: `Dragon Slayer` → «Убийца драконов»;
* **единообразный кусок внутри семьи** — все шестнадцать `Commander's Dragon Slayer *` уже переведены «<предмет> убийцы драконов командира». Он и взят образцом схемы.

Приставка сета — прилагательное к **предмету**, а не к убийце: корпус пишет «обликов лазурного оружия убийцы драконов». Род согласован по последнему слову названия предмета, поэтому «Лазурная булава», но «Лазурный топор»; в рецептах предмет со строчной, как и во всех нетронутых записях рецептов.

## Стало

```
Dragon Slayer Axe              Топор убийцы драконов
Azure Dragon Slayer Axe        Лазурный топор убийцы драконов
Marauder Azure … Focus         Лазурный фокус убийцы драконов мародёра
Unfinished Crimson … Pistol    Незавершённый багровый пистолет убийцы драконов
Recipe: Icy … Short Bow        Рецепт: ледяной короткий лук убийцы драконов
```

Правлено 195 записей в 11 файлах слоя. Ядро «убийцы драконов» теперь у **247 записей семьи из 278**.

## Что осталось

* **32 записи с добавочным суффиксом** (`of Destroyer Slaying`, `of Icebrood Slaying`): там кривая не только в ядре, но и во всей структуре — «Топор «Ледяной драконоборец» истребления разрушителей», — и правка одного ядра её не выпрямит. Нужен отдельный заход, и лучше с вашим решением о схеме;
* **6 записей вне набора оружия**: `Weapon Collector`, `Arms Master`, `Chest of the Dragon Slayer` и само `Dragon Slayer`.

Гейт: линтер по одиннадцати изменённым файлам — **дельта 0**, обе его ошибки в `pn_items_105` лежали там до правки.

Побочно это разблокирует класс имён: `Dragon Slayer` держал 141 находку `layer_name_lost` и стоял у меня в чёрном списке именно потому, что канон слоя расходился сам с собой.
