### PR TITLE
Слой: расставлена потерянная ё, 753 записи

### DIFF
--- a/pn/pn_achievements_001.csv
+++ b/pn/pn_achievements_001.csv
@@ -1,8 +1,8 @@
 english,translate
-Festival of the Four Winds,Фестиваль четырех ветров
+Festival of the Four Winds,Фестиваль четырёх ветров
 Griffon Expert,Эксперт по грифонам
 Fractal Incursion,Вторжение фрактала
-Bazaar of the Four Winds,Базар Четырех Ветров
+Bazaar of the Four Winds,Базар Четырёх Ветров
 Fractal Rush,Фрактальный раш
 """Where's Balthazar?""",«Где Balthazar?»
 A Titanic Voyage,Титаническое путешествие
@@ -18,7 +18,7 @@ Heads up!,Внимание!
 Kookoochoo the Incredulous,Kookoochoo Невероятный
 A New Friend,Новый друг
 Balrior Peak,Пик Балриора
-Four Winds Customs,Обычаи Четырех Ветров
+Four Winds Customs,Обычаи Четырёх Ветров
 "Gnashbash ""Birthday"" Celebration",Празднование «Дня рождения» Гнашбаша
 Goemm's Lab,Лаборатория Goemm
 Kaineng Blackout,Затемнение в Kaineng
@@ -47,7 +47,7 @@ Home Sweet Home,"Дом, милый дом"
 Janthir Syntri Mastery,Мастерство Janthir Syntri
 Klobjarne Geirr: World Boss or Meta-Event Completions,Klobjarne Geirr: завершение мировых боссов или мета-событий
 (Annual) Dragon Bash Feats,(Ежегодно) Подвиги Драконьего празднества
-(Annual) Four Winds Customs,(Ежегодное) Обычаи Четырех Ветров
+(Annual) Four Winds Customs,(Ежегодное) Обычаи Четырёх Ветров
 A Bold Strategy,Смелая стратегия
 A New Look,Новый облик
 A Quiet Celebration,Тихое празднование
@@ -78,7 +78,7 @@ A Season for Work in Paradise,Сезон работы в раю
 A Wrench in the Works,Поломка в механизме
 Acolyte of Dwayna,Аколит Двайны
 Adventure Guide: Volume Five,Руководство искателя приключений: Том пятый
-Adventure Guide: Volume Four,Руководство искателя приключений: Том четвертый
+Adventure Guide: Volume Four,Руководство искателя приключений: Том четвёртый
 Artificer's Rise Jumping Puzzle,Прыжковая головоломка Artificer's Rise
 Assist Mabon,Помогите Mabon
 Bash the Dragon,Разбейте дракона
@@ -102,7 +102,7 @@ Elder Druid Protection,Защита старшего друида
 Establishing a Foothold,Создание плацдарма
 Eyes on Lake Doric,Взгляд на озеро Дорик
 Forgotten Lore,Забытые знания
-Four Winds Gale,Шторм Четырех Ветров
+Four Winds Gale,Шторм Четырёх Ветров
 Friend to Djinn,Друг джиннов
 Frozen in Ice,Застывшие во льду
 Fumbling in the Dark,Нащупывая в темноте
@@ -147,7 +147,7 @@ A Season of Merriment,Сезон веселья
 Abaddon's Ascent,Восхождение Abaddon
 Against the Wall,Спиной к стене
 All You Can Eat,"Всё, что сможешь съесть"
-Ascended Recycling,Переработка вознесенных предметов
+Ascended Recycling,Переработка вознесённых предметов
 Ascension Captured,Вознесение захвачено
 Assist Lyhr,Помогите Lyhr
 At All Costs,Любой ценой
@@ -176,7 +176,7 @@ Crystal Circuit Racer,Гонщик Кристальной цепи
 Crystal Oasis Champion Bounties,Чемпионские награды Кристальный оазис
 Crystal Oasis Legendary Bounties,Легендарные награды Кристальный оазис
 Dawn of the Next Journey,Рассвет следующего путешествия
-Death to the Corrupted,Смерть оскверненным
+Death to the Corrupted,Смерть осквернённым
 Death to the Dominion,Смерть Доминиону
 Deer Commander,Коммандир оленей
 Defeat Awakened or Risen,Одолейте Пробуждённых или Восставших
@@ -208,7 +208,7 @@ Flights of Fancy,Полёты фантазии
 Follow the Magic,Следуй за магией
 For Lion's Arch,За Lion's Arch
 Forager's Hunt Renown Mastery,Мастерство известности охотника-собирателя
-Four Winds Zephyr,Зефир Четырех Ветров
+Four Winds Zephyr,Зефир Четырёх Ветров
 Fractal Champion,Чемпион фракталов
 Fractal Prodigy,Фрактальный вундеркинд
 Fractal Savant,Фрактальный учёный

--- a/pn/pn_achievements_002.csv
+++ b/pn/pn_achievements_002.csv
@@ -113,7 +113,7 @@ Return to Rising Flames,Возвращение к: Восходящее плам
 Return to Seeds of Truth and Point of No Return,Возвращение к: Семена истины и Точка невозврата
 Return to The Head of the Snake,Возвращение к: Глава змеи
 Return to War Eternal,Возвращение к: Вечная война
-Return to Whisper in the Dark,Возвращение к: Шепот во тьме
+Return to Whisper in the Dark,Возвращение к: Шёпот во тьме
 Revels & Rivals,Пиры и соперники
 Sabotage Fort Evennia,Саботаж форта Evennia
 Savior of the Underworld,Спаситель подземного мира
@@ -163,7 +163,7 @@ Poster Child,Пример для подражания
 Profession Achievements,Достижения профессий
 Professor Portmatt's Lab,Лаборатория Professor Portmatt
 Prologue: Bound by Blood,Пролог: Связанные кровью
-Raise the Banners: Amnoon Arbitrator,Поднять знамена: Арбитр Амуну
+Raise the Banners: Amnoon Arbitrator,Поднять знамёна: Арбитр Амуну
 Rare Collections,Редкие коллекции
 Reading Between the Lines,Читать между строк
 Relics—Secrets of the Obscure Set 1,"Реликвии — Тайны Сокрытого, набор 1"
@@ -333,7 +333,7 @@ Respects Paid,Дань уважения
 Return to Bloodstone Fen,Возвращение в Bloodstone Fen
 "Return to Fahranur, the First City","Возвращение в Fahranur, the First City"
 "Return to One Charr, One Dragon, One Champion","Возвращение в One Charr, One Dragon, One Champion"
-Reverie of a Thorn,Грезы о шипах
+Reverie of a Thorn,Грёзы о шипах
 Riches Unveiled,Богатства раскрыты
 Rift Hunter Armor,Доспехи охотника на разломы
 Rift Warden,Страж разломов

--- a/pn/pn_achievements_003.csv
+++ b/pn/pn_achievements_003.csv
@@ -1,6 +1,6 @@
 english,translate
 Your Majesty,Ваше Величество
-Whisper in the Dark,Шепот во тьме
+Whisper in the Dark,Шёпот во тьме
 Weaponmaster Training,Тренировка мастера оружия
 World vs. World Rush,Натиск World vs. World
 Wizard's Tower Trial,Испытание Wizard's Tower

--- a/pn/pn_achievements_005.csv
+++ b/pn/pn_achievements_005.csv
@@ -116,7 +116,7 @@ english,translate
 (Bonus) Strike Back: Rally at the Eye,(Бонус) Ответный удар: Сбор у Ока
 (Bonus) Strike Back: Raven Sanctum,(Бонус) Ответный удар: Святилище Ворона
 (Bonus) Strike Back: Shiverpeaks Pass,(Бонус) Ответный удар: Перевал Шиверпик
-(Bonus) Strike Back: Whisper of Jormag,(Бонус) Ответный удар: Шепот Jormag
+(Bonus) Strike Back: Whisper of Jormag,(Бонус) Ответный удар: Шёпот Jormag
 (Daily) Choya Carnival,(Ежедневное) Карнавал чойя
 (Daily) Cozy Café,(Ежедневное) Уютное кафе
 (Daily) Future Fashionable,(Ежедневное) Модник будущего
@@ -146,7 +146,7 @@ english,translate
 (Weekly) Challenge Mode Convergences: Outer Nayos,(Еженедельное) Режим испытания Конвергенций: Внешний Nayos
 (Weekly) Dolyak Denier,(Еженедельное) Отрицатель дольяков
 (Weekly) Dragon Bash Festivities,(Еженедельное) Празднование Dragon Bash
-(Weekly) Four Winds Festivities,(Еженедельное) Празднование Четырех Ветров
+(Weekly) Four Winds Festivities,(Еженедельное) Празднование Четырёх Ветров
 (Weekly) Halloween Festivities,(Еженедельное) Празднование Хэллоуина
 (Weekly) Homestead Trick-or-Treating,(Еженедельное) Сладость или гадость в Усадьбе
 (Weekly) Invader Incinerator,(Еженедельное) Испепелитель захватчиков
@@ -173,7 +173,7 @@ english,translate
 3v3 Elite,Элита 3х3
 A Blooming Errand,Цветущее поручение
 A Bountiful Pastime,Щедрое времяпрепровождение
-A Branded Blast,Клейменный взрыв
+A Branded Blast,Клеймённый взрыв
 A Breath of Filtered Air,Глоток очищенного воздуха
 A Brief Reprieve,Краткая передышка
 A Brotherhood's Best Friend,Лучший друг братства
@@ -226,10 +226,10 @@ A Sweet Friend,Милый друг
 A Test of Your Reflexes,Проверка ваших рефлексов
 A Thunderous Fall,Громоподобное падение
 A Trip Down Memory Lane,Путешествие по закоулкам памяти
-A Very Merry Wintersday '12,Веселый День зимы '12
-A Very Merry Wintersday '13,Веселый День зимы '13
-A Very Merry Wintersday '14,Веселый День зимы '14
-A Very Merry Wintersday '15,Веселый День зимы '15
+A Very Merry Wintersday '12,Весёлый День зимы '12
+A Very Merry Wintersday '13,Весёлый День зимы '13
+A Very Merry Wintersday '14,Весёлый День зимы '14
+A Very Merry Wintersday '15,Весёлый День зимы '15
 A Waddle to Remember,"Прогулка, которую стоит запомнить"
 A Woman of Culture,Женщина культуры
 A World Under 3,Мир под 3
@@ -415,7 +415,7 @@ Amnytas Insight: Obscured by the Clouds,Прозрение в Амнитасе: 
 Amnytas Insight: The Arboretum,Прозрение в Амнитасе: Дендрарий
 Amnytas Insight: The Debate Hall,Прозрение в Амнитасе: Зал дебатов
 Amnytas Insight: The Plaza of Wisdom,Прозрение в Амнитасе: Площадь мудрости
-Amnytas Insight: Windy Bluff,Прозрение в Амнитасе: Ветреный утес
+Amnytas Insight: Windy Bluff,Прозрение в Амнитасе: Ветреный утёс
 Amnytas Mastery,Мастерство Амнитаса
 Amnytas Rift Hunting,Охота на разломы в Амнитасе
 An Audible Voyage,Слышимое путешествие
@@ -492,10 +492,10 @@ Ascalonian Event Completer,Завершитель событий в Аскало
 Ascalonian Fisher,Рыболов Аскалона
 Ascalonian Killer,Убийца аскалонцев
 Ascalonian Veteran Killer,Убийца ветеранов-аскалонцев
-Ascendant,Вознесенный
-Ascended Accoutrement,Вознесенная экипировка
+Ascendant,Вознесённый
+Ascended Accoutrement,Вознесённая экипировка
 Ascended Achiever,Достигший высот
-Ascended Spirit,Вознесенный дух
+Ascended Spirit,Вознесённый дух
 Ascent to Zephyr Sanctum,Восхождение в Зефирный святилище
 Ash Legion Diplomacy,Дипломатия Пепельного легиона
 Ash Training Course: Gold,Курс подготовки Пепла: Золото

--- a/pn/pn_achievements_006.csv
+++ b/pn/pn_achievements_006.csv
@@ -25,7 +25,7 @@ Attend the Party,Посетите вечеринку
 Attendant of the Month,Служитель месяца
 Attentive Audience,Внимательный слушатель
 Attuned,Настроенный
-Augury Ascended,Вознесенное пророчество
+Augury Ascended,Вознесённое пророчество
 Aurene Said Knock You Out,Aurene сказала «вырубить тебя»
 Aurene's Facet of Crystal,Кристальный аспект Aurene
 Aurene's Facet of Fire,Огненный аспект Aurene
@@ -36,7 +36,7 @@ Aurene's Facet of Shadows,Теневой аспект Aurene
 Auric Basin Explorer,Исследователь Золотой лощины
 Auric Basin Incursions,Вторжения в Золотую лощину
 Auric Basin Insight: Burnisher Quarry,Обзор Золотой лощины: Карьер Полировщика
-Auric Basin Insight: Eastwatch Bluff,Обзор Золотой лощины: Утес Восточного дозора
+Auric Basin Insight: Eastwatch Bluff,Обзор Золотой лощины: Утёс Восточного дозора
 Auric Basin Insight: Jawatl Grounds,Обзор Золотой лощины: Земли Jawatl
 Auric Basin Insight: Lastgear Standing,Обзор Золотой лощины: Последняя передача
 Auric Basin Insight: Luminate's Throne,Обзор Золотой лощины: Трон Luminate
@@ -70,7 +70,7 @@ Avid World Class Fisher,Заядлый рыбак мирового класса
 Await the Offgoing!,Ожидайте отправления!
 Awake End,Пробуждение конца
 Awakened Aftereffects,Последствия пробуждения
-Awakened Melodist,Пробужденный мелодист
+Awakened Melodist,Пробуждённый мелодист
 Awakening Threat,Пробуждающаяся угроза
 Awakening the Druid Stone,Пробуждение Камня друидов
 Axe Master,Мастер топоров
@@ -95,7 +95,7 @@ Bane of the Scorned,Бич презираемых
 Banisher of Legends,Изгнавший легенд
 Bar Bouncer,Вышибала
 Barnstormer,Гастролер
-Barnstorming the Cliffs,Штурм утесов
+Barnstorming the Cliffs,Штурм утёсов
 Baron of the Arena,Барон Арены
 Baroness of the Arena,Баронесса Арены
 Barren of Mistburned,Пустоши туманных ожогов
@@ -165,7 +165,7 @@ Bjora Marches Insight: Aberrant Forest,Обзор Маршей Bjora: Аберр
 Bjora Marches Insight: Asgeir's Legacy,Обзор Маршей Bjora: Наследие Asgeir
 Bjora Marches Insight: Drakkar's Lair,Обзор Маршей Bjora: Логово Drakkar
 Bjora Marches Insight: Fallen Mountain Overlook,Обзор Маршей Bjora: Обзор на Падшей горе
-Bjora Marches Insight: Frozen Waterfall,Обзор Маршей Bjora: Замерзший водопад
+Bjora Marches Insight: Frozen Waterfall,Обзор Маршей Bjora: Замёрзший водопад
 Bjora Marches Insight: Ravenfrost Caverns,Обзор Маршей Bjora: Пещеры Ravenfrost
 Bjora Marches Insight: The Lost Kodan Ship,Обзор Маршей Bjora: Потерянный корабль Kodan
 Black Citadel Agent,Агент Чёрной цитадели
@@ -283,7 +283,7 @@ Bottoms Up,Пьем до дна
 Boundless Bringing Balance,Безграничное восстановление равновесия
 Bounty Hunter: Domain of Istan,Охотник за головами: Domain of Istan
 Bounty Hunter: Domain of Kourna,Охотник за головами: Владения Курна
-Bounty Hunter: Jahai Bluffs,Охотник за головами: Джахайские утесы
+Bounty Hunter: Jahai Bluffs,Охотник за головами: Джахайские утёсы
 Bounty Hunter: Sandswept Isles,Охотник за головами: Песчаные острова
 Braham - Retake Cragstead,Брэм — отбить Утёсную усадьбу
 Braham: Help from the Legions,Брам: Помощь от легионов
@@ -327,7 +327,7 @@ Build-a-Quaggan: Gather Wool,Собери кваггана: собрать ше�
 Building a Better Bot,Создание бота получше
 Bulldozer,Бульдозер
 Bullet Dodger,Уклонист от пуль
-Bundle Looter,Мародер
+Bundle Looter,Мародёр
 Bunker Buster,Разрушитель бункеров
 Burden of Choice,Бремя выбора
 Burgling the Burglars,Ограбление грабителей

--- a/pn/pn_achievements_007.csv
+++ b/pn/pn_achievements_007.csv
@@ -92,7 +92,7 @@ Complete a Renown Heart,Завершите «Сердце возрождения
 Complete any raid encounter.,Завершите любое рейдовое столкновение.
 Complete the Antre of Adjournment Jumping Puzzle,Пройдите головоломку-прыжку «Грот отсрочки».
 Complete the Behem Gauntlet Jumping Puzzle,Пройдите головоломку-прыжку «Ристалище Бегемота».
-Complete the Branded Mine Jumping Puzzle,Пройдите головоломку-прыжку «Клейменый рудник».
+Complete the Branded Mine Jumping Puzzle,Пройдите головоломку-прыжку «Клеймёный рудник».
 Complete the Chaos Crystal Cavern Jumping Puzzle,Пройдите головоломку-прыжку «Пещера кристаллов хаоса».
 Complete the Coddler's Cove Jumping Puzzle,Пройдите прыжковую головоломку «Бухта баловня»
 Complete the Collapsed Observatory Jumping Puzzle,Пройдите прыжковую головоломку «Разрушенная обсерватория»
@@ -142,7 +142,7 @@ Conquer Your Fears,Победите свои страхи
 Conquer the Creator,Победите Создателя
 Conqueror,Завоеватель
 Conqueror of the Lake,Завоеватель озера
-Consecrated Saryx Weapon Collector,Коллекционер освященного оружия Saryx
+Consecrated Saryx Weapon Collector,Коллекционер освящённого оружия Saryx
 Conservation of Magic,Сохранение магии
 Conserve the Land,Сохранение земли
 Console Crasher,Крушитель консолей
@@ -196,7 +196,7 @@ Court Duty: Where Lunatics Dare,Придворный долг: Где осмел
 Court Is Adjourned,Суд окончен
 Courtly Discourtesy,Придворная невежливость
 Courtly Service,Придворная служба
-Covered in Bees!,Покрыт пчелами!
+Covered in Bees!,Покрыт пчёлами!
 Cozy Creator,Уютный творец
 Crab Kickin',Крабий футбол
 Crab Toss Champion,Чемпион по Крабьему броску
@@ -233,7 +233,7 @@ Crop Harvester: Dry Top,Сборщик урожая: Сухие Топи
 Crop Harvester: Ember Bay,Сборщик урожая: Залив Углей
 Crop Harvester: Forging Steel,Сборщик урожая: Forging Steel
 Crop Harvester: Grothmar Valley,Сборщик урожая: Долина Гротмар
-Crop Harvester: Jahai Bluffs,Сборщик урожая: Джахайские утесы
+Crop Harvester: Jahai Bluffs,Сборщик урожая: Джахайские утёсы
 Crop Harvester: Lake Doric,Сборщик урожая: Озеро Дорик
 Crop Harvester: Sandswept Isles,"Сборщик урожая: Острова, заметаемые песком"
 Crop Harvester: Silverwastes,Сборщик урожая: Silverwastes
@@ -353,9 +353,9 @@ Daily Bonus Rewards: Piñata Smashing,Ежедневные бонусные на
 Daily Bonus Rewards: Snowball Mayhem,Ежедневные бонусные награды: Снежковый хаос
 Daily Bonus Rewards: Snowfall Sprint Race,Ежедневные бонусные награды: Спринт «Снегопад»
 Daily Bonus Rewards: Toypocalypse,Ежедневные бонусные награды: Игрушечный апокалипсис
-Daily Bonus Rewards: Twisted Marionette,Ежедневные бонусные награды: Искаженная марионетка
+Daily Bonus Rewards: Twisted Marionette,Ежедневные бонусные награды: Искажённая марионетка
 Daily Bonus Rewards: Winter Wonderland,Ежедневные бонусные награды: Зимняя сказка
-Daily Branded Mine Jumping Puzzle,Ежедневный прыжковый пазл «Клейменная шахта»
+Daily Branded Mine Jumping Puzzle,Ежедневный прыжковый пазл «Клеймённая шахта»
 Daily Brisban Wildlands Dragon Response Mission,Ежедневная миссия по реагированию на драконов: Брисбанские дикие земли
 Daily Brisban Wildlands Event Completer,Ежедневный участник событий в Брисбанских диких землях
 Daily Buried Archives Jumping Puzzle,Ежедневный прыжковый пазл «Захороненные архивы»
@@ -374,7 +374,7 @@ Daily Collapsed Observatory Jumping Puzzle,Ежедневный прыжковы
 Daily Conundrum Cubed Jumping Puzzle,Ежедневный прыжковый пазл: Conundrum Cubed
 Daily Convergence: Mount Balrior,Ежедневная конвергенция: Mount Balrior
 Daily Convergence: Outer Nayos,Ежедневная конвергенция: Outer Nayos
-Daily Corrupted Spirit Cleansing,Ежедневное очищение оскверненного духа
+Daily Corrupted Spirit Cleansing,Ежедневное очищение осквернённого духа
 Daily Crash Site Jumping Puzzle,Ежедневный прыжковый пазл: Crash Site
 Daily Craze's Folly Jumping Puzzle,Ежедневный прыжковый пазл: Craze's Folly
 Daily Crimson Plateau Jumping Puzzle,Ежедневный прыжковый пазл: Crimson Plateau
@@ -412,7 +412,7 @@ Daily Diessa Plateau Event Completer,Ежедневное завершение �
 Daily Dodger,Ежедневный уклонист
 Daily Domain of Istan,Ежедневные задания области Истан
 Daily Domain of Istan Adventurer,Ежедневное: Искатель приключений в Истане
-Daily Domain of Istan Awakened Slayer,Ежедневное: Истребитель Пробужденных в Истане
+Daily Domain of Istan Awakened Slayer,Ежедневное: Истребитель Пробуждённых в Истане
 Daily Domain of Istan Bounty Hunter,Ежедневное: Охотник за головами в Истане
 Daily Domain of Istan Corpse Caravan Disruptor,Ежедневное: Разрушитель караванов трупов в Истане
 Daily Domain of Istan Hidden Stash Hunter,Ежедневное: Охотник за тайниками в Истане

--- a/pn/pn_achievements_008.csv
+++ b/pn/pn_achievements_008.csv
@@ -13,14 +13,14 @@ Daily Engineer or Elementalist Winner,Ежедневная победа инже
 Daily Engineer or Mesmer Winner,Ежедневная победа инженера или месмера
 Daily Engineer or Necromancer Winner,Ежедневная победа инженера или некроманта
 Daily Engineer or Thief Winner,Ежедневный победитель: Инженер или Вор
-Daily Essence Chest Looter,Ежедневный мародер эссенций
+Daily Essence Chest Looter,Ежедневный мародёр эссенций
 Daily Eventful Dragonfall,Ежедневное событие: Драконий Пад
 Daily Events,Ежедневные события
 Daily Exotic Crafter,Ежедневный мастер экзотического снаряжения
 Daily Fallen Hunter,Ежедневный охотник на падших
 Daily Fawcett's Bounty Jumping Puzzle,Ежедневный прыжковый пазл: Награда Fawcett
 Daily Feast,Ежедневный пир
-Daily Festival of the Four Winds,Ежедневный Фестиваль четырех ветров
+Daily Festival of the Four Winds,Ежедневный Фестиваль четырёх ветров
 Daily Fields of Ruin Dragon Response Mission,Ежедневная миссия реагирования на драконов: Поля Руин
 Daily Fields of Ruin Event Completer,Ежедневный завершитель событий: Поля Руин
 Daily Fire Elemental,Ежедневный огненный элементаль
@@ -95,9 +95,9 @@ Daily Invasion Responder,Ежедневный участник отражени�
 Daily Iron Marches Event Completer,Ежедневный участник событий в Железных Топях
 Daily Jahai Bluffs,Ежедневные Скалы Джахай
 Daily Jahai Bluffs Bounty Hunter,Ежедневный охотник за головами в Скалах Джахай
-Daily Jahai Bluffs Branded Awakened Champions Defeater,Ежедневный победитель чемпионов Брендированных Пробужденных в Скалах Джахай
+Daily Jahai Bluffs Branded Awakened Champions Defeater,Ежедневный победитель чемпионов Брендированных Пробуждённых в Скалах Джахай
 Daily Jahai Bluffs Death-Branded Shatterer Battler,Ежедневный участник битвы с Разрушителем Смерти в Скалах Джахай
-Daily Jahai Bluffs Displaced Tower Jumping Puzzle,Ежедневный прыжковый пазл «Смещенная башня» в Скалах Джахай
+Daily Jahai Bluffs Displaced Tower Jumping Puzzle,Ежедневный прыжковый пазл «Смещённая башня» в Скалах Джахай
 Daily Jahai Bluffs Inner Keep Completer,Ежедневный участник «Внутренней крепости» в Скалах Джахай
 Daily Jahai Bluffs Rift Event,Ежедневное событие разломов в Скалах Джахай
 Daily Jahai Bluffs Tornado Ride,Ежедневная поездка на торнадо в Скалах Джахай
@@ -172,7 +172,7 @@ Daily New Kaineng City Taskmaster,Ежедневный мастер задани
 Daily New Kaineng Jade Brotherhood Slayer,Ежедневный убийца членов Jade Brotherhood в Новом Кайненге
 Daily New Kaineng Naga Slayer,Ежедневный убийца наг в Новом Кайненге
 Daily New Kaineng Purist Slayer,Ежедневный убийца пуристов в Новом Кайненге
-Daily New Kaineng Unchained Slayer,Ежедневный убийца освобожденных в Новом Кайненге
+Daily New Kaineng Unchained Slayer,Ежедневный убийца освобождённых в Новом Кайненге
 Daily Only Zuhl Jumping Puzzle,Ежедневная прыжковая головоломка «Only Zuhl»
 Daily Orb Cavern Jumping Puzzle,Ежедневная прыжковая головоломка «Orb Cavern»
 Daily Orr Fisher,Ежедневный рыболов в Орре
@@ -291,7 +291,7 @@ Daily Rolling Racer,Ежедневный гонщик
 Daily Ruined City of Arah,Ежедневный «Разрушенный город Арах»
 Daily Sandswept Isles,Ежедневные «Песчаные острова»
 Daily Sandswept Isles Adventurer,Ежедневный искатель приключений на Песчаных островах
-Daily Sandswept Isles Awakened Slayer,Ежедневный истребитель пробужденных на Песчаных островах
+Daily Sandswept Isles Awakened Slayer,Ежедневный истребитель пробуждённых на Песчаных островах
 Daily Sandswept Isles Bounty Hunter,Ежедневный охотник за головами на Песчаных островах
 Daily Sandswept Isles Inquest Slayer,Ежедневный истребитель инквезиции на Песчаных островах
 Daily Sandswept Isles Racer,Ежедневный гонщик на Песчаных островах
@@ -308,7 +308,7 @@ Daily Seitung Province Event Completer,Ежедневное завершение
 Daily Seitung Province Naga Slayer,Ежедневный истребитель наг в Seitung Province
 Daily Seitung Province Purist Slayer,Ежедневный истребитель пуристов в Seitung Province
 Daily Seitung Province Taskmaster,Ежедневный мастер заданий в Seitung Province
-Daily Seitung Province Unchained Slayer,Ежедневный истребитель освобожденных в Seitung Province
+Daily Seitung Province Unchained Slayer,Ежедневный истребитель освобождённых в Seitung Province
 Daily Shadow Behemoth,Ежедневный «Теневой бегемот»
 Daily Shaman's Rookery Jumping Puzzle,Ежедневная прыжковая головоломка «Шаманское гнездо»
 Daily Shattered Ice Ruins Jumping Puzzle,Ежедневная прыжковая головоломка «Руины разбитого льда»
@@ -354,8 +354,8 @@ Daily Thief or Necromancer Winner,Ежедневный победитель: В�
 Daily Thunderhead Keep Dragon Response Mission,Ежедневная миссия реагирования на драконов: Крепость Громовой головы
 Daily Thunderhead Peaks,Ежедневно: Пики Громовой головы
 Daily Thunderhead Peaks Adventurer,Ежедневный искатель приключений в Пиках Громовой головы
-Daily Thunderhead Peaks Branded Masses Collector,Ежедневный сборщик клейменных масс в Пиках Громовой головы
-Daily Thunderhead Peaks Branded Slayer,Ежедневный убийца клейменных в Пиках Громовой головы
+Daily Thunderhead Peaks Branded Masses Collector,Ежедневный сборщик клеймённых масс в Пиках Громовой головы
+Daily Thunderhead Peaks Branded Slayer,Ежедневный убийца клеймённых в Пиках Громовой головы
 Daily Thunderhead Peaks Chest Hunter,Ежедневный охотник за сундуками в Пиках Громовой головы
 Daily Thunderhead Peaks Hidden Dwarven-Treasure Hunter,Ежедневный охотник за скрытыми сокровищами гномов в Пиках Громовой головы
 Daily Thunderhead Peaks Legendary Slayer,Ежедневный убийца легенд в Пиках Громовой головы
@@ -389,7 +389,7 @@ Daily Tier 2 Aetherblade,Ежедневный фрактал 2 уровня: Э�
 Daily Tier 2 Aquatic Ruins,Ежедневный фрактал 2 уровня: Водные руины
 Daily Tier 2 Captain Mai Trin Boss,Ежедневный фрактал 2 уровня: Босс Капитан Май Трин
 Daily Tier 2 Chaos,Ежедневный фрактал 2 уровня: Хаос
-Daily Tier 2 Cliffside,Ежедневный фрактал 2 уровня: Утес
+Daily Tier 2 Cliffside,Ежедневный фрактал 2 уровня: Утёс
 Daily Tier 2 Deepstone,Ежедневный фрактал 2 уровня: Глубокий камень
 Daily Tier 2 Kinfall,Ежедневный фрактал 2 уровня: Кинфолл
 Daily Tier 2 Lonely Tower,Ежедневный фрактал 2 уровня: Одинокая башня
@@ -413,7 +413,7 @@ Daily Tier 3 Aetherblade,Ежедневный фрактал 3 уровня: Э�
 Daily Tier 3 Aquatic Ruins,Ежедневный фрактал 3 уровня: Водные руины
 Daily Tier 3 Captain Mai Trin Boss,Ежедневный фрактал 3 уровня: Босс Капитан Май Трин
 Daily Tier 3 Chaos,Ежедневный фрактал 3 уровня: Хаос
-Daily Tier 3 Cliffside,Ежедневный фрактал 3 уровня: Утес
+Daily Tier 3 Cliffside,Ежедневный фрактал 3 уровня: Утёс
 Daily Tier 3 Deepstone,Ежедневный фрактал 3 уровня: Глубокий камень
 Daily Tier 3 Kinfall,Ежедневный фрактал 3 уровня: Кинфолл
 Daily Tier 3 Lonely Tower,Ежедневный фрактал 3 уровня: Одинокая башня
@@ -437,7 +437,7 @@ Daily Tier 4 Aetherblade,Ежедневный 4-й уровень: Эфирны�
 Daily Tier 4 Aquatic Ruins,Ежедневный 4-й уровень: Водные руины
 Daily Tier 4 Captain Mai Trin Boss,Ежедневный 4-й уровень: Босс Капитан Май Трин
 Daily Tier 4 Chaos,Ежедневный 4-й уровень: Хаос
-Daily Tier 4 Cliffside,Ежедневный 4-й уровень: Утес
+Daily Tier 4 Cliffside,Ежедневный 4-й уровень: Утёс
 Daily Tier 4 Deepstone,Ежедневный 4-й уровень: Глубокий камень
 Daily Tier 4 Kinfall,Ежедневный 4-й уровень: Кинфолл
 Daily Tier 4 Lonely Tower,Ежедневный 4-й уровень: Одинокая башня
@@ -465,7 +465,7 @@ Daily Trial of Koda,Ежедневный: Испытание Кода
 Daily Tribulation Caverns Jumping Puzzle,Ежедневная прыжковая головоломка «Пещеры страданий»
 Daily Tribulation Rift Jumping Puzzle,Ежедневная прыжковая головоломка «Разлом страданий»
 Daily Twilight Arbor,Ежедневный: Сумеречная беседка
-Daily Twisted Marionette,Ежедневный: Искаженная марионетка
+Daily Twisted Marionette,Ежедневный: Искажённая марионетка
 Daily Under New Management Jumping Puzzle,Ежедневная прыжковая головоломка «Под новым руководством»
 Daily Unique Maps Played,Ежедневный: Уникальные сыгранные карты
 Daily Urmaug's Secret Jumping Puzzle,Ежедневная прыжковая головоломка «Urmaug's Secret»

--- a/pn/pn_achievements_009.csv
+++ b/pn/pn_achievements_009.csv
@@ -345,7 +345,7 @@ Dragonfall Insight: Skyscale Eyrie,Падение дракона: Прозрен
 Dragonsblood,Кровь дракона
 Drake Slayer,Убийца дрейков
 Dream Warrior,Воин сна
-Dreams of a Thorn,Грезы о шипах
+Dreams of a Thorn,Грёзы о шипах
 Dreamthistle Weapon Collection,Коллекция оружия Dreamthistle
 Dredge Slayer,Убийца дрегов
 Dredgehaunt Cliffs Insight: Dostoev Sky Peak,Скалистые Скалы Дреджей: Прозрение на пике Dostoev

--- a/pn/pn_achievements_010.csv
+++ b/pn/pn_achievements_010.csv
@@ -24,7 +24,7 @@ Essence Collector—Champion,Собиратель эссенции — Чемп�
 Essence Collector—Elite,Собиратель эссенции — Элита
 Essence Collector—Recruit,Собиратель эссенции — Рекрут
 Essence Collector—Veteran,Собиратель эссенции — Ветеран
-Essence Looter,Мародер эссенции
+Essence Looter,Мародёр эссенции
 Essence Manipulation 101,Манипуляция эссенцией 101
 Eternal Aetherblade Shenanigans,Вечные проделки Aetherblade
 Eternal Alchemist,Вечный алхимик
@@ -134,7 +134,7 @@ Fashion Forward,Модный прорыв
 Fast Break,Быстрый отрыв
 Fast Constructor's Weapon Collector,Коллекционер оружия быстрого строителя
 Fast Fire and Frost Fighter,Быстрый боец огня и льда
-Faster than Four Winds,Быстрее четырех ветров
+Faster than Four Winds,Быстрее четырёх ветров
 Faster than a Speeding Bullet,Быстрее пули
 Fatal Fangs,Смертоносные клыки
 Fatebreaker,Разрушитель судеб
@@ -219,7 +219,7 @@ Focus Master,Мастер фокуса
 Foefire Assaulter,Нападающий Огня врагов
 Foefire Defender,Защитник Огня врагов
 Foefire Weapon Collection,Коллекция оружия Огня врагов
-Foes Reborn: Awakened,Возрожденные враги: Пробужденные
+Foes Reborn: Awakened,Возрожденные враги: Пробуждённые
 Foes Reborn: Chak,Возрожденные враги: Чак
 Foes Reborn: Forged,Возрожденные враги: Кованые
 Foes Reborn: Mordrem,Возрожденные враги: Мордремы
@@ -256,7 +256,7 @@ Fractal Fortnight,Фрактальная двухнеделька
 Fractal Fortnight: Aetherblade,Фрактальная двухнеделька: Эфирный клинок
 Fractal Fortnight: Aquatic Ruins,Фрактальная двухнеделька: Водные руины
 Fractal Fortnight: Battleground,Фрактальная двухнеделька: Поле битвы
-Fractal Fortnight: Cliffside,Фрактальная двухнеделька: Утес
+Fractal Fortnight: Cliffside,Фрактальная двухнеделька: Утёс
 Fractal Fortnight: Molten Furnace,Фрактальная двухнеделька: Плавильная печь
 Fractal Fortnight: Molten Might,Фрактальная двухнеделька: Мощь расплавленных
 Fractal Fortnight: Snowblind,Фрактальная двухнеделька: Снежная слепота

--- a/pn/pn_achievements_011.csv
+++ b/pn/pn_achievements_011.csv
@@ -105,7 +105,7 @@ Home Sweet Homestead: Elon Riverlands,"Дом, милый дом: Элонски
 Home Sweet Homestead: Fractals of the Mists,"Дом, милый дом: Fractals of the Mists"
 Home Sweet Homestead: Grothmar Valley,"Дом, милый дом: Долина Гротмар"
 Home Sweet Homestead: Inner Nayos,"Дом, милый дом: Inner Nayos"
-Home Sweet Homestead: Jahai Bluffs,"Дом, милый дом: Джахайские утесы"
+Home Sweet Homestead: Jahai Bluffs,"Дом, милый дом: Джахайские утёсы"
 Home Sweet Homestead: Janthir Wilds Lore Collector,"Дом, милый дом: Коллекционер знаний Диких земель Джанфир"
 Home Sweet Homestead: Kryta,"Дом, милый дом: Крайта"
 Home Sweet Homestead: Lake Doric,"Дом, милый дом: Озеро Дорик"
@@ -201,7 +201,7 @@ Illustrious Legend,Легенда прославленных
 Immunocompromiser,Иммунокомпромисс
 Imp Slayer,Убийца импов
 Imperial Everbloom Weapon Collection,Коллекция имперского вечноцветущего оружия
-Important: Bazaar of the Four Winds,Важно: Базар Четырех Ветров
+Important: Bazaar of the Four Winds,Важно: Базар Четырёх Ветров
 Imposter Syndrome,Синдром самозванца
 Impressionable Youth,Впечатлительная молодежь
 Impressive Pugilist,Впечатляющий кулачный боец

--- a/pn/pn_achievements_012.csv
+++ b/pn/pn_achievements_012.csv
@@ -159,13 +159,13 @@ League Slayer—Champion,Убийца лиги — Чемпион
 League Slayer—Conquest,Убийца лиги — Завоевание
 League Slayer—Conquest Season Forty,Убийца лиги — Сезон завоеваний сороковой
 League Slayer—Conquest Season Forty-Five,Убийца лиги — Сезон завоеваний сорок пятый
-League Slayer—Conquest Season Forty-Four,Убийца лиги — Сезон завоеваний сорок четвертый
+League Slayer—Conquest Season Forty-Four,Убийца лиги — Сезон завоеваний сорок четвёртый
 League Slayer—Conquest Season Forty-One,Убийца лиги — Сезон завоеваний сорок первый
 League Slayer—Conquest Season Forty-Two,Убийца лиги — Сезон завоеваний сорок второй
 League Slayer—Conquest Season Thirty,Убийца лиги — Сезон завоеваний тридцатый
 League Slayer—Conquest Season Thirty-Eight,Убийца лиги — Сезон завоеваний тридцать восьмой
 League Slayer—Conquest Season Thirty-Five,Убийца лиги — Сезон завоеваний тридцать пятый
-League Slayer—Conquest Season Thirty-Four,Убийца лиги — Сезон завоеваний тридцать четвертый
+League Slayer—Conquest Season Thirty-Four,Убийца лиги — Сезон завоеваний тридцать четвёртый
 League Slayer—Conquest Season Thirty-Nine,Убийца лиги — Сезон завоеваний тридцать девятый
 League Slayer—Conquest Season Thirty-One,Убийца лиги — Сезон завоеваний тридцать первый
 League Slayer—Conquest Season Thirty-Seven,Убийца лиги — Сезон завоеваний тридцать седьмой
@@ -174,7 +174,7 @@ League Slayer—Conquest Season Thirty-Three,Убийца лиги — Сезо�
 League Slayer—Conquest Season Thirty-Two,Убийца лиги — Сезон завоеваний тридцать второй
 League Slayer—Conquest Season Twenty-Eight,Убийца лиги — Сезон завоеваний двадцать восьмой
 League Slayer—Conquest Season Twenty-Five,Убийца лиги — Сезон завоеваний двадцать пятый
-League Slayer—Conquest Season Twenty-Four,Убийца лиги — Сезон завоеваний двадцать четвертый
+League Slayer—Conquest Season Twenty-Four,Убийца лиги — Сезон завоеваний двадцать четвёртый
 League Slayer—Conquest Season Twenty-Nine,Убийца лиги — Сезон завоеваний двадцать девятый
 League Slayer—Conquest Season Twenty-One,Убийца лиги — Сезон завоеваний двадцать первый
 League Slayer—Conquest Season Twenty-Seven,Убийца лиги — Сезон завоеваний двадцать седьмой
@@ -288,7 +288,7 @@ Leveling Up I,Повышение уровня I
 Leveling Up II,Повышение уровня II
 Leveling Up III,Повышение уровня III
 Leveling Up IV,Повышение уровня IV
-Ley Line Glider,Планер лей-линии
+Ley Line Glider,Планёр лей-линии
 Ley Line Researched,Исследование лей-линии
 Ley Line Weapon Collection,Коллекция оружия лей-линии
 Ley of the Land,Закон земли
@@ -382,8 +382,8 @@ Local Response: Grothmar Valley,Местный отклик: Долина Гро
 Local Response: Grothmar Valley (Weekly),Местный отклик: Долина Гротмар (еженедельно)
 Local Response: Gyala Delve,Местный отклик: Шахты Гьяла
 Local Response: Inner Nayos,Местный отклик: Inner Nayos
-Local Response: Jahai Bluffs,Местный отклик: Джахайские утесы
-Local Response: Jahai Bluffs (Weekly),Местный отклик: Джахайские утесы (еженедельно)
+Local Response: Jahai Bluffs,Местный отклик: Джахайские утёсы
+Local Response: Jahai Bluffs (Weekly),Местный отклик: Джахайские утёсы (еженедельно)
 Local Response: Janthir Rifts,Местный отклик: Janthir Rifts
 Local Response: Janthir Syntri,Местный отклик: Janthir Syntri
 Local Response: Kessex Hills (Weekly),Местный отклик: Kessex Hills (еженедельно)

--- a/pn/pn_achievements_013.csv
+++ b/pn/pn_achievements_013.csv
@@ -43,7 +43,7 @@ Manor Magnate,Магнат поместья
 Mantis Pose,Поза богомола
 Mantle Mauler,Крушитель мантии
 Mantle Pieces,Кусочки Mantle
-Marauder,Мародер
+Marauder,Мародёр
 Marionette Defender,Защитник марионетки
 Marionette Deregulator,Дегулятор марионетки
 Marionette Dismisser,Устранитель марионетки
@@ -130,7 +130,7 @@ Master of Trades,Мастер торговли
 Master of the Ancestral Forge,Мастер Кузни Предков
 Master of the Arena,Мастер арены
 Master of the Forge,Мастер кузни
-Master of the Four Winds,Мастер четырех ветров
+Master of the Four Winds,Мастер четырёх ветров
 Master of the Marionette,Мастер марионетки
 Master of the Maze,Мастер лабиринта
 Master of the Molten Ore,Мастер расплавленной руды
@@ -491,7 +491,7 @@ Ore Miner: Dry Top,Добытчик руды: Сухие вершины
 Ore Miner: Ember Bay,Добытчик руды: Угольный залив
 Ore Miner: Forging Steel,Добытчик руды: Ковка стали
 Ore Miner: Grothmar Valley,Добытчик руды: Долина Гротмар
-Ore Miner: Jahai Bluffs,Добытчик руды: Джахайские утесы
+Ore Miner: Jahai Bluffs,Добытчик руды: Джахайские утёсы
 Ore Miner: Lake Doric,Добытчик руды: Озеро Дорик
 Ore Miner: Sandswept Isles,Добытчик руды: Песчаные острова
 Ore Miner: Silverwastes,Добытчик руды: Серебряные пустоши

--- a/pn/pn_achievements_014.csv
+++ b/pn/pn_achievements_014.csv
@@ -128,7 +128,7 @@ Priority Cantha Strike: Kaineng Overlook,Приоритетный удар по 
 Priority Cantha Strike: Xunlai Jade Junkyard,Приоритетный удар по Cantha: Нефритовая свалка Xunlai
 Priority Horn of Maguuma Strike: Cosmic Observatory,Приоритетный удар по Рогу Магуумы: Космическая обсерватория
 Priority Horn of Maguuma Strike: Temple of Febe,Приоритетный удар по Horn of Maguuma: Храм Febe
-Priority Raid Encounter: Whisper of Jormag,Приоритетный рейд: Шепот Jormag
+Priority Raid Encounter: Whisper of Jormag,Приоритетный рейд: Шёпот Jormag
 Priority Strike: Boneskinner,Приоритетный удар: Boneskinner
 Priority Strike: Cold War,Приоритетный удар: Холодная война
 Priority Strike: Fraenir of Jormag,Приоритетный удар: Fraenir of Jormag
@@ -137,7 +137,7 @@ Priority Strike: Shiverpeaks Pass,Приоритетный удар: Перев�
 Priority Strike: Voice of the Fallen and Claw of the Fallen,Приоритетный удар: Голос Падших и Коготь Падших
 Priory Expedition Renown Mastery,Мастерство известности экспедиции Приората
 Prismatic Percher,Призматический насест
-Prismatic Plunderer,Призматический мародер
+Prismatic Plunderer,Призматический мародёр
 Prison Breaker,Побег из тюрьмы
 Privateer Weapon Collection,Коллекция оружия капера
 Pro Scavenger,Профессиональный мусорщик
@@ -156,7 +156,7 @@ Protector of the Beacon of Ages and Garenhoff,Защитник Маяка Век
 Protector of the Rata Novus Promenade and Primal Maguuma,Защитник Променада Рата Новус и Первобытной Магуумы
 Protector of the Skyward Marches,Защитник Небесных рубежей
 Pruning the Weed,Подрезка сорняка
-Pulse Room Glider,Планер в комнате импульсов
+Pulse Room Glider,Планёр в комнате импульсов
 Pumpkin Carving,Резьба по тыкве
 Pumpkin Hacker,Тыквенный хакер
 Pumpkin Hacker II,Тыквенный хакер II
@@ -200,7 +200,7 @@ Queen's Gauntlet Climber,Восходящий в Королевской перч
 Queen's Jubilee Completionist,Мастер Юбилея Королевы
 Queensdale Novice Explorer,Начинающий исследователь Queensdale
 Quell the Storm,Усмири шторм
-Queller of Profane Whispers,Укротитель оскверненных шепотов
+Queller of Profane Whispers,Укротитель оскверненных шёпотов
 Questionable Choices,Сомнительный выбор
 Questions for Mai,Вопросы для Mai
 Quick March,Быстрый марш
@@ -276,9 +276,9 @@ Raid Mentor: Xera,Наставник рейдов: Xera
 Raiders of the Lost Parts,Рейдеры потерянных частей
 Raiders of the Lost Parts II,Рейдеры потерянных частей II
 Raids,Рейды
-Raise the Banners: Amnoon Independence,Поднять знамена: Независимость Амуну
-Raise the Banners: Salute to Palawa Joko,Поднять знамена: Салют Palawa Joko
-Raise the Banners: Sunspear Support,Поднять знамена: Поддержка Солнечных копий
+Raise the Banners: Amnoon Independence,Поднять знамёна: Независимость Амуну
+Raise the Banners: Salute to Palawa Joko,Поднять знамёна: Салют Palawa Joko
+Raise the Banners: Sunspear Support,Поднять знамёна: Поддержка Солнечных копий
 Rallying,Восстановление
 Rallying the Crystal Bloom,Сбор Хрустального расцвета
 Rallying the Deldrimor Dwarves,Сбор дворфов Делдримора
@@ -291,7 +291,7 @@ Rallying the Tengu,Сбор тенгу
 Rampage Router,Маршрутизатор ярости
 Rank Doesn't Matter Here,Здесь ранг не имеет значения
 Ranoah Grindsteel's Footsteps,Следы Ranoah Grindsteel
-Ransacker,Мародер
+Ransacker,Мародёр
 Raptor Ride: Chantry of the Crab,Поездка на рапторе: Обитель Краба
 Raptor Runner: Echovald Wilds,Бегун на рапторе: Echovald Wilds
 Raptor Runner: New Kaineng City,Бегун на рапторе: Новый Каиненг
@@ -325,7 +325,7 @@ Realm Avenger X,Мститель Царства X
 Realm Defender,Защитник Царства
 Realm-Portal Spiker,Шипомет портала Царства
 Reaper,Жнец
-Reaper of the Awakened,Жнец Пробужденных
+Reaper of the Awakened,Жнец Пробуждённых
 Reaper's Return,Возвращение Жнеца
 Reawakening Threat,Пробуждающаяся угроза
 Rebooting IG-6417,Перезагрузка IG-6417

--- a/pn/pn_achievements_015.csv
+++ b/pn/pn_achievements_015.csv
@@ -76,8 +76,8 @@ Revenge of the Champions: Dragonfall,Месть чемпионов: Дракон
 Revenge of the Champions: Dragonfall (Weekly),Месть чемпионов: Драконий предел (еженедельно)
 Revenge of the Claw of Jormag,Месть Claw of Jormag
 Revenge of the Claw of Jormag (Weekly),Месть Claw of Jormag (еженедельно)
-Revenge of the Death-Branded Shatterer,Месть Death-Клейменные Shatterer
-Revenge of the Death-Branded Shatterer (Weekly),Месть Death-Клейменные Shatterer (еженедельно)
+Revenge of the Death-Branded Shatterer,Месть Death-Клеймённые Shatterer
+Revenge of the Death-Branded Shatterer (Weekly),Месть Death-Клеймённые Shatterer (еженедельно)
 Revenge of the Demolisher,Месть Demolisher
 Revenge of the Destroyer Twins,Месть близнецов-разрушителей
 Revenge of the Destroyer Twins (Weekly),Месть близнецов-разрушителей (еженедельно)
@@ -152,7 +152,7 @@ Roller Beetle Training: Silver,Тренировка кругложука: Сер
 Rolling Ace: Ghostfire Run,Ас перекатов: Призрачный огонь
 Rolling Ace: Infernal Leap,Ас перекатов: Адский прыжок
 Rolling Ace: Jormag's Fang,Ас перекатов: Клык Йормаг
-Rolling Ace: Lakeside Loop,Ас перекатов: Озерная петля
+Rolling Ace: Lakeside Loop,Ас перекатов: Озёрная петля
 Rolling Ace: Shoreside Sprint,Ас перекатов: Прибрежный спринт
 Rolling Ace: Tropic Valley Raceway,Ас перекатов: Тропическая трасса
 Rolling Competitor: Ghostfire Run,Участник гонок: Призрачный огонь
@@ -161,8 +161,8 @@ Rolling Competitor: Infernal Leap,Участник гонок: Адский пр
 Rolling Competitor: Infernal Leap (Weekly),Участник гонок: Адский прыжок (еженедельно)
 Rolling Competitor: Jormag's Fang,Участник гонок: Клык Йормаг
 Rolling Competitor: Jormag's Fang (Weekly),Соревнующийся на жуке-катке: Клык Йормага (Еженедельно)
-Rolling Competitor: Lakeside Loop,Участник гонок: Озерная петля
-Rolling Competitor: Lakeside Loop (Weekly),Участник гонок: Озерная петля (еженедельно)
+Rolling Competitor: Lakeside Loop,Участник гонок: Озёрная петля
+Rolling Competitor: Lakeside Loop (Weekly),Участник гонок: Озёрная петля (еженедельно)
 Rolling Competitor: Shoreside Sprint,Участник гонок: Прибрежный спринт
 Rolling Competitor: Shoreside Sprint (Weekly),Участник гонок: Прибрежный спринт (еженедельно)
 Rolling Competitor: Tropic Valley Raceway,Участник гонок: Тропическая трасса
@@ -174,8 +174,8 @@ Rolling Racer: Infernal Leap,Гонщик: Адский прыжок
 Rolling Racer: Infernal Leap (Weekly),Гонщик: Адский прыжок (еженедельно)
 Rolling Racer: Jormag's Fang,Гонщик: Клык Йормаг
 Rolling Racer: Jormag's Fang (Weekly),Гонщик на жуке-катке: Клык Йормага (Еженедельно)
-Rolling Racer: Lakeside Loop,Гонщик: Озерная петля
-Rolling Racer: Lakeside Loop (Weekly),Гонщик: Озерная петля (еженедельно)
+Rolling Racer: Lakeside Loop,Гонщик: Озёрная петля
+Rolling Racer: Lakeside Loop (Weekly),Гонщик: Озёрная петля (еженедельно)
 Rolling Racer: Shoreside Sprint,Гонщик: Прибрежный спринт
 Rolling Racer: Shoreside Sprint (Weekly),Гонщик: Прибрежный спринт (еженедельно)
 Rolling Racer: Tropic Valley Raceway,Гонщик: Трасса Тропической долины
@@ -251,7 +251,7 @@ Scholar of Ahdashim,Учёный из Ахдашима
 Scholar of the Garden,Учёный Сада
 Scientific Weapon Collection,Коллекция научного оружия
 Sclerite Weapon Collection,Коллекция склеритового оружия
-Scorched,Опаленный
+Scorched,Опалённый
 Scourge Buster,Истребитель Scourge
 Scourge of the White Mantle,Бич Белой Мантии
 Scouting the Area,Разведка местности
@@ -303,8 +303,8 @@ Seeking Scarlet: Old Lion's Court (Weekly),В поисках Scarlet: Стары
 Seeking Scarlet: Thaumanova Reactor,В поисках Scarlet: Реактор Thaumanova
 Seeking Scarlet: Thaumanova Reactor (Weekly),В поисках Scarlet: Реактор Thaumanova (еженедельно)
 Seeking Scarlet: Twilight Arbor Aetherpath,В поисках Scarlet: Эфирный путь Twilight Arbor
-Seeking Scarlet: Twisted Marionette,В поисках Scarlet: Искривленная марионетка
-Seeking Scarlet: Twisted Marionette (Weekly),В поисках Scarlet: Искривленная марионетка (еженедельно)
+Seeking Scarlet: Twisted Marionette,В поисках Scarlet: Искривлённая марионетка
+Seeking Scarlet: Twisted Marionette (Weekly),В поисках Scarlet: Искривлённая марионетка (еженедельно)
 Seen Better Days,Видывали и лучшие дни
 Seer-Enchanted Weapon Collector,Коллекционер зачарованного провидцами оружия
 Seimur Was Wrong,Seimur был неправ

--- a/pn/pn_achievements_016.csv
+++ b/pn/pn_achievements_016.csv
@@ -32,7 +32,7 @@ Slaver's Extinction,Истребление работорговцев
 Slayer,Истребитель
 Sled Defender,Защитник саней
 Sleep Now in the Fire,Спи в огне
-Sleepy Kitty,Сонный котенок
+Sleepy Kitty,Сонный котёнок
 Slippery Slubling,Скользкий слизень
 Slither-less,Без гадов
 Slumbering Lightborne Weapon Collector,Коллекционер дремлющего оружия Lightborne
@@ -214,7 +214,7 @@ Starlit Weald Insight: Overgrown Thicket,Обзор Звёздной рощи: �
 Starlit Weald Insight: Skyshroud Canopy,Обзор Звёздной рощи: Небесный полог
 Starlit Weald Insight: Skyshroud Canopy Ruins,Обзор Звёздной рощи: Руины небесного полога
 Starlit Weald Insight: The Winding Passage,Прозрение Звёздной рощи: Извилистый проход
-Starlit Weald Insight: Untamed Crags,Прозрение Звёздной рощи: Дикие утесы
+Starlit Weald Insight: Untamed Crags,Прозрение Звёздной рощи: Дикие утёсы
 Starlit Weald Ley Line Adventure: Bronze,Приключение по лей-линии Звёздной рощи: Бронза
 Starlit Weald Ley Line Adventure: Gold,Приключение по лей-линии Звёздной рощи: Золото
 Starlit Weald Ley Line Adventure: Silver,Приключение по лей-линии Звёздной рощи: Серебро

--- a/pn/pn_achievements_017.csv
+++ b/pn/pn_achievements_017.csv
@@ -55,9 +55,9 @@ The Voidwalker,Странник Пустоты
 The Warden Will See You Now,Warden примет вас сейчас
 The Wayward Wisp: Vault Dispatch,Wayward Wisp: Депеша из хранилища
 The Wayward Wisp: Welcoming the Wisp,Wayward Wisp: Приветствуя Wisp
-The Wayward Wisp: Wisp Outreach,Блуждающий огонек: Поиск огоньков
-The Wayward Wisp: Wisp Sighting,Блуждающий огонек: Обнаружение огоньков
-The Whispers Way,Путь Шепота
+The Wayward Wisp: Wisp Outreach,Блуждающий огонёк: Поиск огоньков
+The Wayward Wisp: Wisp Sighting,Блуждающий огонёк: Обнаружение огоньков
+The Whispers Way,Путь Шёпота
 The Wintersday Gauntlet,Зимний день: Испытание
 The Withered Rose,Увядшая роза
 The Wizard's Vault,Хранилище Волшебника
@@ -191,7 +191,7 @@ Transfer Chaser,Преследователь трансферов
 Transmuting Skins,Трансмутация обликов
 Trash Collector,Мусорщик
 Traveler,Путешественник
-Traveler of Four Winds,Путешественник Четырех Ветров
+Traveler of Four Winds,Путешественник Четырёх Ветров
 Traversing the Titan,Пересекая Титана
 Treachery,Предательство
 Tread Lightly,Ступай осторожно
@@ -216,12 +216,12 @@ Trebuchet Expertise,Мастерство требюше
 Trebuchet Tactician,Тактик требюше
 Tree-Hugger Hugger,Обниматель древообнимателей
 Treetop Retriever,Собиратель верхушек деревьев
-Trial by Fire,Испытание огнем
+Trial by Fire,Испытание огнём
 Triangulation,Триангуляция
 Tribune Slayer,Убийца трибунов
 Tribune Weapons Collector,Коллекционер оружия трибунов
 Trick or Treat bags opened.,Открыто сумок с угощениями.
-Trick-or-Treat across Tyria,Кошелек или жизнь по всей Tyria
+Trick-or-Treat across Tyria,Кошелёк или жизнь по всей Tyria
 Trick-or-Treater,Любитель угощений
 Trick-or-Treater II,Любитель угощений II
 Trick-or-Treater III,Любитель угощений III
@@ -405,7 +405,7 @@ Visions of the Past: You Made a Friend,Видения прошлого: Вы з�
 Vista Viewer,Исследователь видов
 Vlast from the Past,Vlast из прошлого
 Voice of the Deceased,Голос усопшего
-Void Corrupted Weapon Collection,"Коллекция оружия, оскверненного Пустотой"
+Void Corrupted Weapon Collection,"Коллекция оружия, осквернённого Пустотой"
 Voidwalker,Странник Пустоты
 Volcanic Fractal Stabilizer,Вулканический стабилизатор фрактала
 Volcanic Stormcaller Armaments Collector,Коллекционер вооружения вулканического громовержца

--- a/pn/pn_items_001.csv
+++ b/pn/pn_items_001.csv
@@ -2,7 +2,7 @@ english,translate
 Black Lion Chest Key,Ключ от сундука Чёрного Льва
 Anthology of Villains,Антология злодеев
 Black Lion Weapons Voucher,Ваучер на оружие Чёрного Льва
-Branded Crystal,Клейменый кристалл
+Branded Crystal,Клеймёный кристалл
 +1 Agony Infusion,Инфузия агонии +1
 Black Lion Claim Ticket,Билет Чёрного Льва
 Aetherblade Cache,Тайник Эфирных клинков
@@ -141,11 +141,11 @@ Attuned Grow Lamp,Настроенная лампа для растений
 Aurene's Voice,Голос Аурены
 Aviator Cap Skin,Облик шлема авиатора
 Awakened Dye Kit,Набор красок Пробуждённых
-Awakened Griffon,Пробужденный грифон
-Awakened Jackal,Пробужденный шакал
-Awakened Raptor,Пробужденный раптор
-Awakened Skimmer,Пробужденный скиммер
-Awakened Springer,Пробужденный спрингер
+Awakened Griffon,Пробуждённый грифон
+Awakened Jackal,Пробуждённый шакал
+Awakened Raptor,Пробуждённый раптор
+Awakened Skimmer,Пробуждённый скиммер
+Awakened Springer,Пробуждённый спрингер
 Azure Denaturizing Agent,Лазурный денатурирующий агент
 Azure Dragon Slayer Axe,Топор лазурного дракона-убийцы
 Azure Dragon Slayer Dagger,Лазурный кинжал драконоборца
@@ -210,11 +210,11 @@ Box of Vigorous Scale Armor,Коробка бодрой чешуйчатой б�
 Box of Vital Chain Armor,Коробка живучей кольчатой брони
 Boxing Gloves,Боксёрские перчатки
 Branded Devourer Ichor,Ихор клеймёного пожирателя
-Branded Jackal,Клейменный шакал
-Branded Raptor,Клейменный раптор
+Branded Jackal,Клеймённый шакал
+Branded Raptor,Клеймённый раптор
 Branded Shard,Клеймёный осколок
-Branded Skimmer,Клейменный скиммер
-Branded Springer,Клейменный спрингер
+Branded Skimmer,Клеймённый скиммер
+Branded Springer,Клеймённый спрингер
 Brandspark Jewel,Самоцвет искры Клейма
 """/Channel"" Emote Tome","Том эмоций ""/Channel"""
 """/Flex"" Emote Tome","Том эмоций ""/Flex"""
@@ -271,7 +271,7 @@ Airship Essence,Эссенция дирижабля
 Airship Part,Деталь дирижабля
 Alchemical Bottle,Алхимическая бутылка
 Alchemist Backpack and Glider Combo,Набор «Рюкзак алхимика»: рюкзак и планер
-Alchemist Glider,Планер алхимика
+Alchemist Glider,Планёр алхимика
 Alpine Lily,Альпийская лилия
 Amber Trout,Янтарная форель
 Amulet of Protection,Амулет защиты
@@ -386,7 +386,7 @@ Basic Mithril Mace,Простая мифриловая булава
 Basic Mithril Pistol,Простой мифриловый пистолет
 Basic Mithril Rifle,Простая мифриловая винтовка
 Bat Guano,Гуано летучих мышей
-Bat Wings Glider,Планер «Крылья летучей мыши»
+Bat Wings Glider,Планёр «Крылья летучей мыши»
 Bat Wings Headpiece,Головной убор из крыльев летучей мыши
 Bay Leaf,Лавровый лист
 Bear Finisher,Финишёр «Медведь»
@@ -398,7 +398,7 @@ Birthday Blaster,Именинный бластер
 Black Diamond Orichalcum Amulet,Амулет из чёрного алмаза и орихалка
 Black Diamond Orichalcum Earring,Серьга из чёрного алмаза и орихалка
 Black Diamond Orichalcum Ring,Кольцо из чёрного алмаза и орихалка
-Black Feather Wings Glider,Планер «Чёрные пернатые крылья»
+Black Feather Wings Glider,Планёр «Чёрные пернатые крылья»
 Black Lion Glider Voucher,Ваучер на планер Чёрного Льва
 Black Lion Held Toy Voucher,Ваучер на игрушку в руках Чёрного Льва
 Black Lion Introductory Package,Вводный набор Чёрного Льва

--- a/pn/pn_items_002.csv
+++ b/pn/pn_items_002.csv
@@ -150,7 +150,7 @@ Charged Dwarven Spell Trap,Заряженная дварфийская лову�
 Charged Titan Ore,Заряженная титановая руда
 Charr Alarm Clock,Чаррский будильник
 Charr Constellation Chapter,Глава о созвездии чарров
-Charr Helicopter Gearbox,Редуктор вертолета чарров
+Charr Helicopter Gearbox,Редуктор вертолёта чарров
 Charr Mine,Шахта чарров
 Chatoyant Elixir,Переливчатый эликсир
 Chef's Tasting Platter,Дегустационное блюдо повара
@@ -201,9 +201,9 @@ Curious Mursaat Remnants,Любопытные останки мурсаатов
 Damaged Airship Compass,Повреждённый компас дирижабля
 Data Crystal,Кристалл данных
 Dawn Experiment,Эксперимент «Рассвет»
-DeLana's Coinpurse,Кошелек ДеЛаны
+DeLana's Coinpurse,Кошелёк ДеЛаны
 Decade Enhancement Station,Станция усиления Десятилетия
-Destroyer Heated Stone,Раскаленный камень разрушителя
+Destroyer Heated Stone,Раскалённый камень разрушителя
 Destructive Substance,Разрушительная субстанция
 Difluorite Crystal,Кристалл дифторида
 Dilled Poultry Piccata,Куриное пикката с укропом
@@ -338,7 +338,7 @@ Chiminea Ward,Оберег «Чиминея»
 Chromatic Bubbles,Хроматические пузыри
 Chunk of Ice,Кусок льда
 Citadel Assault Backpack and Glider Combo,Комплект рюкзака и планера «Штурм Цитадели»
-Citadel Assault Glider,Планер «Штурм Цитадели»
+Citadel Assault Glider,Планёр «Штурм Цитадели»
 Citadel Assault Pack,Наспинник «Штурм Цитадели»
 Classic Leather Boots,Классические кожаные сапоги
 Claw of Execution,Коготь казни
@@ -427,11 +427,11 @@ Dawn Chorus,Утренний хор
 Deadly Nightshade,Смертельный паслён
 Decima's Token,Жетон Децимы
 Deer Finisher,Олений финишер
-Defiant Glass Outfit,Наряд из закаленного стекла
+Defiant Glass Outfit,Наряд из закалённого стекла
 Delicate Lace Cape,Нежный кружевной плащ
 Demon-Slaying Station,Станция убийства демонов
 Dendritic Avenger,Дендритный Мститель
-Desert King Glider,Планер Короля пустыни
+Desert King Glider,Планёр Короля пустыни
 Desert King Reliquary,Реликварий Короля пустыни
 Desert King Reliquary Backpiece,Спинная броня: Реликварий короля пустыни
 Destroyer Jar,Кувшин Разрушителя
@@ -446,11 +446,11 @@ Divine Conqueror Cape,Плащ божественного завоевателя
 Dollop of Choya Harissa,Кусочек харрисы чойя
 Dolyak Finisher,Финишер дольяка
 Draconic Wings Backpack and Glider Combo,Комплект: рюкзак и планер «Драконьи крылья»
-Draconic Wings Glider,Планер «Драконьи крылья»
+Draconic Wings Glider,Планёр «Драконьи крылья»
 Draconis Mons Hero,Герой Драконис Монс
 Dragon Emblem Cape,Плащ с инсигнией дракона
 Dragon Fireworks Backpiece,Наспинник «Драконьи фейерверки»
-Dragon Fireworks Glider,Планер «Драконьи фейерверки»
+Dragon Fireworks Glider,Планёр «Драконьи фейерверки»
 Dragon Mastery Crystal 1,Кристалл драконьего мастерства 1
 Dragon Mastery Crystal 2,Кристалл драконьего мастерства 2
 Dragon Mastery Crystal 3,Кристалл драконьего мастерства 3

--- a/pn/pn_items_003.csv
+++ b/pn/pn_items_003.csv
@@ -302,7 +302,7 @@ End of Dragons Launch Supply Drop: Week Two,Стартовый сброс при
 Endless Cloudseeker Tonic,Бесконечный тоник «Облакоискатель»
 Endless Halloween Enchantment,Бесконечное хэллоуинское зачарование
 Equinox Wings Backpack and Glider Combo,Набор: рюкзак и планер «Крылья равноденствия»
-Equinox Wings Glider,Планер «Крылья Равноденствия»
+Equinox Wings Glider,Планёр «Крылья Равноденствия»
 Equipment Bag,Сумка с экипировкой
 Essence of Ancient Knowledge,Эссенция древнего знания
 Essence of Ancient Mysticism,Эссенция древнего мистицизма
@@ -463,7 +463,7 @@ Foefire Wraps,Обмотки Фоефайра
 Forge Gavel,Кузнечный молоток
 Forged Backpack,Кованый рюкзак
 Forged Backpack and Glider Combo,Набор: рюкзак и планер Кованых
-Forged Glider,Планер «Кованый»
+Forged Glider,Планёр «Кованый»
 Forgotten Brilliance,Забытое сияние
 Forgotten Glyph,Забытый глиф
 Forgotten Seal,Забытая печать

--- a/pn/pn_items_004.csv
+++ b/pn/pn_items_004.csv
@@ -160,7 +160,7 @@ Grothmar Skyscale Challenge: Silver,Гротмарское испытание н
 Guild Insignia,Гильдейская инсигния
 Hardy Ball,Выносливый мяч
 Haunted Gramophone,Граммофон с привидениями
-Heart of Thorns Glider,Планер «Сердце Терний»
+Heart of Thorns Glider,Планёр «Сердце Терний»
 Heart of a Fire Elemental,Сердце огненного элементаля
 Heart of a Fire Imp,Сердце огненного беса
 Heart of an Ember,Сердце уголька
@@ -247,7 +247,7 @@ Glorious Wristplates,Славные наручи
 Glyphic Short Bow,Глифический короткий лук
 Golden Dragon Fishing Rod,Золотая удочка-дракон
 Golden Dragon Fishing Rod Skin,Облик удочки «Золотой дракон»
-Golden Feather Wings Glider,Планер «Золотые перьевые крылья»
+Golden Feather Wings Glider,Планёр «Золотые перьевые крылья»
 Golden Fortune Scrap,Золотой обрывок фортуны
 Golden Fractal Relic,Золотая фрактальная реликвия
 Golden Mushroom,Золотой гриб
@@ -267,7 +267,7 @@ Greer's Token,Жетон Грира
 Grenth's Regalia Outfit,Регалии Grenth
 Griffon Egg,Яйцо грифона
 Griffon Hatchling Backpack,Рюкзак для птенца грифона
-Griffon Hatchling Glider,Планер «Детеныш грифона»
+Griffon Hatchling Glider,Планёр «Детёныш грифона»
 Grilled Mushroom,Жареный гриб
 Grilled Portobello Mushroom,Жареный гриб портобелло
 Grilled Poultry,Жареная птица
@@ -322,7 +322,7 @@ Hallows Fortune Fireworks,Фейерверк «Удача Хэллоуина»
 Hammer of the Three Realms,Молот Трех Миров
 Hand Furnace,Ручная печь
 Handwoven Olmakhan Bandolier,Ручной работы олмакханская бандольера
-Hawk Wings Glider,Планер «Крылья ястреба»
+Hawk Wings Glider,Планёр «Крылья ястреба»
 Heart of Mellaggan,Сердце Меллаггана
 Heart of Thorn,Сердце Шипа
 Heart of Thorns Veteran's Armor Voucher,Купон на броню ветерана дополнения «Сердце Терний»
@@ -409,7 +409,7 @@ Infusible Cloth Aquabreather,Насыщаемая тканевая дыхате�
 Infusible Leather Aquabreather,Насыщаемая кожаная дыхательная маска
 Infusible Metal Aquabreather,Насыщаемая металлическая дыхательная маска
 Infusion Extraction Device,Устройство для извлечения инфузий
-Inquest Overseer Glider,Планер «Надзиратель Инквеста»
+Inquest Overseer Glider,Планёр «Надзиратель Инквеста»
 Inquest Skimmer,Скиммер Инквеста
 Intelligence Report: Palawa Joko I,Разведывательное донесение: Палава Джоко I
 Intelligence Report: Palawa Joko I Page 01,"Разведданные: Палава Джоко I, страница 01"
@@ -433,7 +433,7 @@ Intricate Topaz Jewel,Искусный топазовый самоцвет
 Intricate Watchwork Box,Искусная коробка с часовым механизмом
 Intricately Carved Orrian Relic,Искусно вырезанная оррианская реликвия
 Invasion of Vabbi,Вторжение в Вабби
-Inverted Blade Wings Glider,Планер «Перевернутые крылья-лезвия»
+Inverted Blade Wings Glider,Планёр «Перевёрнутые крылья-лезвия»
 Investigation Kit,Набор исследователя
 Invisible Boot Box,Коробка с невидимыми сапогами
 Invisible Boots,Невидимые сапоги
@@ -464,7 +464,7 @@ Janthir Wilds Launch Supply Drop: Week One,Стартовая поставка �
 Janthir Wilds Launch Supply Drop: Week Three,Стартовая поставка припасов Диких земель Джантира: неделя третья
 Janthir Wilds Launch Supply Drop: Week Two,Стартовая поставка припасов Диких земель Джантира: неделя вторая
 Jeweled Scarab Backpiece,Наспинник «Украшенный самоцветами скарабей»
-Jeweled Scarab Glider,Планер «Драгоценный скарабей»
+Jeweled Scarab Glider,Планёр «Драгоценный скарабей»
 Jora's Cape,Плащ Джоры
 Jormag's Claw,Коготь Йормага
 Jormag's Claw Fragment,Обломок когтя Йормага
@@ -495,7 +495,7 @@ Large Mist Defensive Potion,Большое защитное зелье тума�
 Large Mist Mobility Potion,Большое зелье подвижности туманов
 Large Mist Offensive Potion,Большое атакующее зелье туманов
 Large Scale,Большая чешуя
-Largos Fin Glider,Планер «Плавник Ларгоса»
+Largos Fin Glider,Планёр «Плавник Ларгоса»
 Last Rites,Последние обряды
 Last Words,Последние слова
 Leather Aquabreather,Кожаная дыхательная маска

--- a/pn/pn_items_005.csv
+++ b/pn/pn_items_005.csv
@@ -69,7 +69,7 @@ Lightbringer's Pack,Ранец Светоносца
 Lorekeeper Weapon Select Box,Коробка выбора оружия Хранителя знаний
 Luminate's Backplate,Наспинник Светила
 Lunar Rabbit Helm,Шлем лунного кролика
-Magic Carpet Glider,Планер «Ковер-самолет»
+Magic Carpet Glider,Планёр «Ковер-самолет»
 Magical Unicorn Horn,Магический рог единорога
 Magister's Pack,Рюкзак магистра
 Magnanimous Tuning Crystal,Великодушный кристалл настройки
@@ -89,7 +89,7 @@ Mini Starry Shiba Inu,Мини-звёздная сиба-ину
 Mini White Jackal Pup,Мини-белый щенок шакала
 Mini White Skimmer Pup,Мини-белый щенок скиммера
 Mini White Tigris Cub,Мини-белый детёныш тигриса
-Mini White and Purple Turtle Hatchling,Мини-белый и фиолетовый детеныш черепахи
+Mini White and Purple Turtle Hatchling,Мини-белый и фиолетовый детёныш черепахи
 Mini Yellow Springer Kit,Мини-жёлтый детёныш спрингера
 Mini Yellow Turtle Hatchling,Мини-жёлтый детёныш черепахи
 Mist-Hardened Lockbox Key,Ключ от закалённой туманами шкатулки
@@ -224,7 +224,7 @@ Legendary Inscription,Легендарная гравировка
 Legendary Rune,Легендарная руна
 Legendary Sigil,Легендарный сигил
 Legion Boots,Сапоги легиона
-Legion Jetpack Glider,Планер «Легионерский реактивный ранец»
+Legion Jetpack Glider,Планёр «Легионерский реактивный ранец»
 Legionnaire Greatsword,Двуручный меч легионера
 Letter Home,Письмо домой
 Ley Line Finisher,Добивающий удар «Лей-линия»
@@ -233,11 +233,11 @@ Libeh's Truthteller,Правдолюб Либеха
 "Lifeblood of Nourys, Eyes of the Abyss","Жизненная сила Нуриса, Очей Бездны"
 Light of Deldrimor Plate—Bottom Half,Пластина «Свет Дельдримора» — нижняя половина
 Light of Deldrimor Plate—Top Half,Пластина «Свет Дельдримора» — верхняя половина
-Lightbinder Blades Glider,Планер «Клинки Светоносца»
+Lightbinder Blades Glider,Планёр «Клинки Светоносца»
 Lightbinder Blades Wings,Крылья «Клинки светоносца»
 Linen Gloves,Льняные перчатки
 Linen Shoulders,Льняные наплечники
-Lingering Branded Aether,Затяжной эфир Клейменых
+Lingering Branded Aether,Затяжной эфир Клеймёных
 Lingering Destroyer Aether,Затяжной эфир Разрушителей
 Lingering Icebrood Aether,Затяжной эфир Ледоклыков
 Lingering Mordrem Aether,Длящийся эфир мордрема
@@ -306,7 +306,7 @@ Mini Drooburt's Ghost,Призрак мини-Друбурта
 Mini Plush Griffon,Мини Плюшевый грифон
 Mini Rox,Мини Рокс
 Mini Shrine Guardian,Мини-страж святилища
-Mini Snow Cougar Cub,Мини-детеныш снежной пумы
+Mini Snow Cougar Cub,Мини-детёныш снежной пумы
 Mini Snow Flurry Dragon,Мини-дракон Снежной Вьюги
 Mini Snuggles,Мини-Снагглз
 Mini Squire Aurene,Мини-сквайр Аурена
@@ -423,13 +423,13 @@ Mordrem Shield,Щит мордрема
 Mordrem Thrasher Gas Bladder,Газовый пузырь мордремского трещотника
 Mordremoth's Bane Guild Decoration,Гильдейское украшение «Проклятие Мордремофа»
 Morning Glory,Утренняя слава
-Moth Wings Glider,Планер «Крылья мотылька»
+Moth Wings Glider,Планёр «Крылья мотылька»
 Mothusi's Echoing Voice,Эхо голоса Мотхуси
 Mournstone Amulet,Амулет из скорбного камня
 Mournstone Earring,Серьга из скорбного камня
 Mournstone Ring,Кольцо из скорбного камня
 Mummy Tonic,Тоник мумии
-Mursaat Wings Glider,Планер «Крылья Мурсаатов»
+Mursaat Wings Glider,Планёр «Крылья Мурсаатов»
 Mystery Cooking Ingredient Box,Коробка таинственных кулинарных ингредиентов
 Mystic Aspect,Мистический аспект
 Mystic Chest,Мистический сундук

--- a/pn/pn_items_006.csv
+++ b/pn/pn_items_006.csv
@@ -121,7 +121,7 @@ Rhedo's Revenge,Месть Редо
 Ride the Ley Line,Прогулка по лей-линии
 Riding Gloves,Перчатки для верховой езды
 Riding Pants,Штаны для верховой езды
-Salvaged Dredge Inferno Backpack,Спасенный рюкзак Дреджа «Инферно»
+Salvaged Dredge Inferno Backpack,Спасённый рюкзак Дреджа «Инферно»
 Ogden's Notes,Записки Огдена
 Oiled Ancient Pistol Frame,Масляная древняя оправа пистолета
 Oiled Ancient Scepter Core,Масляная древняя сердцевина скипетра
@@ -319,7 +319,7 @@ Peach Tart,Персиковый тарт
 Peppermint Oil,Мятное масло
 Peppermint Omnomberry Bar,Мятно-омномберриевый батончик
 Personal Gyrocopter Chair,Персональное кресло-гирокоптер
-Personal Gyrocopter Glider,Планер «Персональный гирокоптер»
+Personal Gyrocopter Glider,Планёр «Персональный гирокоптер»
 Phantom Residue,Фантомный остаток
 Phialslinger Outfit,Наряд «Алхимик»
 Piece of Rare Unidentified Gear,Кусок редкого неопознанного снаряжения
@@ -432,7 +432,7 @@ Restored Boreal Torch,Восстановленный бореальный фак
 Restored Boreal Warhorn,Восстановленный бореальный боевой рог
 Return to Hortensia,Вернуться к Гортензии
 Rice Ball,Рисовый шарик
-Riding Broom Glider,Планер «Метла»
+Riding Broom Glider,Планёр «Метла»
 Rift Warden Helm,Шлем стража разлома
 Rift Warden Helm Skin,Облик шлема Стража разлома
 Road Marker,Дорожный знак

--- a/pn/pn_items_007.csv
+++ b/pn/pn_items_007.csv
@@ -184,7 +184,7 @@ Spearmarshal's Shoes,Туфли копьёмаршала
 Spearmarshal's Shoulderpads,Наплечники копьёмаршала
 Spearmarshal's Vambraces,Наручи копьёмаршала
 Spearmarshal's Vestments,Одеяния копьёмаршала
-Spellforged Glider,Планер «Магическая ковка»
+Spellforged Glider,Планёр «Магическая ковка»
 Spiked Choya Psionic Tonic,Псионический тоник «Шипованный чойя»
 Spirit Quest Tonic,Тоник Квеста Духа
 Spirit Weave,Сплетёние Духов
@@ -350,13 +350,13 @@ Shimmering Torch,Мерцающий факел
 Shimmering Warhorn,Мерцающий боевой рог
 Shimmerwing Skyscale Skin,Облик скайскейла «Мерцающее крыло»
 Shining Blade Backpack,Рюкзак Сияющего Клинка
-Shining Blade Glider,Планер «Сияющий клинок»
+Shining Blade Glider,Планёр «Сияющий клинок»
 Shiny Foil Candy Wrapper,Блестящая фольговая обёртка конфеты
 Shiny Stolen Gear,Блестящее украденное снаряжение
 "Shiro Tagachi: Legacy of the Betrayer, Vol. 1","Широ Тагачи: Наследие предателя, Том 1"
 "Shiro Tagachi: Legacy of the Betrayer, Vol. 2","Широ Тагачи: Наследие предателя, Том 2"
 Shiverpeaks Hunter Backpack,Рюкзак охотника Дрожащих Пиков
-Shiverpeaks Hunter Glider,Планер «Охотник Шиверпика»
+Shiverpeaks Hunter Glider,Планёр «Охотник Шиверпика»
 Shorewatcher's Backup,Поддержка Берегового Дозора
 Shoulder Scarf,Наплечный шарф
 Shrine Guardian Backpack,Рюкзак хранителя святилища
@@ -408,7 +408,7 @@ Sinister Pearl Stinger,Жемчужное жало зловещего
 Sinister Pearl Trident,Жемчужный трезубец зловещего
 Siren's Landing Hero,Герой Пристанища сирены
 Skeletal Wings Backpack and Glider Combo,Комплект «Скелетные крылья» (рюкзак и планер)
-Skeletal Wings Glider,Планер «Скелетные крылья»
+Skeletal Wings Glider,Планёр «Скелетные крылья»
 Skritt Support Mark,Знак поддержки скриттов
 Skyscale Fever,Лихорадка скайскейла
 Skyscale Flight,Полёт скайскейла

--- a/pn/pn_items_008.csv
+++ b/pn/pn_items_008.csv
@@ -5,7 +5,7 @@ The Olmakhan,Олмакханы
 Vision Crystal,Кристалл видения
 Tome of Knowledge,Книга знаний
 The Hunter,Охотник
-The Lover,Влюбленный
+The Lover,Влюблённый
 The Chosen,Избранный
 TT6-B Devourer,TT6-B Пожиратель
 The Spirits of the Wild,Духи Дикой Природы
@@ -376,7 +376,7 @@ True Assassin's Guise Outfit,Наряд «Обличье истинного уб
 Tuning Icicle,Сосулька настройки
 Twin Sisters,Две сёстры
 Twisted Imaginarium Homestead Package,Набор усадьбы «Искажённый имагинариум»
-Twisted Watchwork Finisher,Добивание «Искаженный механизм»
+Twisted Watchwork Finisher,Добивание «Искажённый механизм»
 Twisted Watchwork Shoulders,Наплечники Искривленного Часового Механизма
 Umbral Serpent Backpack,Рюкзак умбрального змея
 Umbral Serpent Backpack and Glider Combo,Набор «Теневой змей»: рюкзак и планер
@@ -494,7 +494,7 @@ Vision of Enemies: Ley-Infused Enemy,Видение врагов: Пропита
 Vision of Enemies: Olori Ogun,Видение врагов: Олори Огун
 Vision of Enemies: Warden Amala,Видение врагов: Хранительница Амала
 Vision of Enemies: Wrathbringer,Видение врагов: Гневный вестник
-Visions of Eternity Launch Supply Drop: Week Four,Припасы запуска «Видения вечности»: четвертая неделя
+Visions of Eternity Launch Supply Drop: Week Four,Припасы запуска «Видения вечности»: четвёртая неделя
 Visions of Eternity Launch Supply Drop: Week One,Набор припасов запуска «Видения вечности»: неделя первая
 Visions of Eternity Launch Supply Drop: Week Three,Припасы запуска «Видений вечности»: третья неделя
 Visions of Eternity Launch Supply Drop: Week Two,«Видения вечности»: поставка припасов второй недели

--- a/pn/pn_items_009.csv
+++ b/pn/pn_items_009.csv
@@ -14,7 +14,7 @@ War Commendation,Боевая благодарность
 Warclaw Helmet,Шлем боевого когтя
 Warmaster's Pack,Набор военачальника
 Wayfinder's Versatile Table,Универсальный стол Путеводителя
-Wings of Love Glider,Планер «Крылья любви»
+Wings of Love Glider,Планёр «Крылья любви»
 Volatile Compound,Нестабильное соединение
 War Auger,Бур войны
 Warclaw Emblem,Инсигния боевого когтя
@@ -82,13 +82,13 @@ Wanderer's Pearl Speargun,Жемчужное гарпунное ружьё ст�
 Wanderer's Pearl Stinger,Жемчужное жало странника
 Wanderer's Pearl Trident,Жемчужный трезубец странника
 Wandering Cloud Chair,Кресло «Блуждающее облако»
-Wandering Cloud Glider,Планер «Блуждающее облако»
+Wandering Cloud Glider,Планёр «Блуждающее облако»
 Wandering Weapon Master Cape,Плащ странствующего мастера оружия
 War Eternal Supply Drop: Week Four,Снабжение Вечной войны: Четвертая неделя
 War Eternal Supply Drop: Week One,Припасы «Вечной войны»: неделя первая
 War Eternal Supply Drop: Week Three,Припасы Вечной войны: третья неделя
 War Eternal Supply Drop: Week Two,Припасы Вечной войны: Неделя вторая
-War-Torn Marauder,Израненный мародер
+War-Torn Marauder,Израненный мародёр
 Warbeast Boots,Сапоги боевого зверя
 Warbeast Breastplate,Нагрудник боевого зверя
 Warbeast Cowl,Капюшон боевого зверя
@@ -113,10 +113,10 @@ Warden Helm,Шлем стража
 Warmaster's Family Heirloom,Семейная реликвия военачальника
 Watchwork Box,Часовая коробка
 Watchwork Wings Backpack,Часовые крылья (рюкзак)
-Watchwork Wings Glider,Планер «Заводные крылья»
+Watchwork Wings Glider,Планёр «Заводные крылья»
 Water Bucket,Ведро воды
 Wayward Wisp Quest License,Лицензия на задание «Блуждающий огонёк»
-White Feather Wings Glider,Планер «Крылья из белых перьев»
+White Feather Wings Glider,Планёр «Крылья из белых перьев»
 White Mantle Elite Guard Mask,Маска элитной гвардии Белой Мантии
 White Mantle Ritual Goblet,Ритуальный кубок Белой Мантии
 Wiley's Work Song,Рабочая песня Уайли

--- a/pn/pn_items_011.csv
+++ b/pn/pn_items_011.csv
@@ -408,7 +408,7 @@ Acrid Dye,Краска «Едкость»
 Acrophobia,Акрофобия
 Across the Sea of Sorrow,Через Море Скорби
 Activated-Charcoal Paste,Активированная угольная паста
-Ad Infinitum Glider,Планер Ad Infinitum
+Ad Infinitum Glider,Планёр Ad Infinitum
 Adamant Guard Axe,Топор Адамантовой Стражи
 Adamant Guard Blade,Клинок Адамантовой Стражи
 Adamant Guard Bow,Лук Адамантовой Стражи

--- a/pn/pn_items_012.csv
+++ b/pn/pn_items_012.csv
@@ -141,7 +141,7 @@ Agony Impedance 1,Импеданс агонии 1
 Agony Impedance 3,Импеданс агонии 3
 Agony Impedance 4,Импеданс агонии 4
 Agony Resistance Study Supplies,Припасы для изучения сопротивления агонии
-Ahamid's Armor Chest,Сундук с броней Ахамида
+Ahamid's Armor Chest,Сундук с бронёй Ахамида
 Ahamid's Breastplate,Нагрудник Ахамида
 Ahamid's Breeches,Бриджи Ахамида
 Ahamid's Cloth Breather,Тканевый респиратор Ахамида

--- a/pn/pn_items_013.csv
+++ b/pn/pn_items_013.csv
@@ -438,7 +438,7 @@ Aquatic Frog,Водяная лягушка
 Aquatic Loot Box,Коробка с подводной добычей
 Aquatic Ruin Challenge Mote,Частица испытания «Водные руины»
 Aqueous Amulet,Водный амулет
-Arachnid Glider,Планер-паук
+Arachnid Glider,Планёр-паук
 Arachnophobia,Арахнофобия
 Arah Armor Box,Коробка с доспехами из Араха
 Arah Token Loot Box,Коробка с жетонами Араха
@@ -489,7 +489,7 @@ Archaius Sprinter,Архаичный спринтер
 Archdemon Wings Backpack,Рюкзак «Крылья архидемона»
 Archdemon Wings Backpack Skin,Облик рюкзака «Крылья архидемона»
 Archdemon Wings Backpack and Glider Combo,Набор: рюкзак и планер «Крылья архидемона»
-Archdemon Wings Glider,Планер «Крылья архидемона»
+Archdemon Wings Glider,Планёр «Крылья архидемона»
 Archdiviner's Talisman,Талисман архипровидца
 Architeuthis,Архитевтис
 Archon Boots,Сапоги архонта

--- a/pn/pn_items_015.csv
+++ b/pn/pn_items_015.csv
@@ -422,7 +422,7 @@ Aureate Musket of Corruption,Золочёный мушкет порчи
 Aureate Musket of Energy,Золочёный мушкет энергии
 Aureate Musket of Water,Золочёный мушкет воды
 Aureate Partisan,Золочёная алебарда
-Aureate Pistol,Золоченый пистолет
+Aureate Pistol,Золочёный пистолет
 Aureate Pistol Skin,Облик «Золочёный пистолет»
 Aureate Pistol of Air,Золочёный пистолет воздуха
 Aureate Pistol of Energy,Золочёный пистолет энергии
@@ -460,7 +460,7 @@ Aureate Targe,Ауреат-тарж
 Aureate Targe Skin,Облик «Золочёный тарч»
 Aureate Targe of Air,Золочёный тарч воздуха
 Aureate Targe of Energy,Золочёный тарч энергии
-Aureate Trident,Золоченый трезубец
+Aureate Trident,Золочёный трезубец
 Aureate Trident Skin,Облик «Золочёный трезубец»
 Aureate Trident of Air,Золочёный трезубец воздуха
 Aureate Trident of Energy,Золочёный трезубец энергии

--- a/pn/pn_items_016.csv
+++ b/pn/pn_items_016.csv
@@ -135,7 +135,7 @@ Awakened Officer's Service Medallion,Служебный медальон про�
 Awakened Pistol,Пробуждённый пистолет
 Awakened Raptor Skin,Облик пробуждённого раптора
 Awakened Rifle,Пробуждённая винтовка
-Awakened Roller Beetle,Пробужденный кругложук
+Awakened Roller Beetle,Пробуждённый кругложук
 Awakened Scepter,Пробуждённый скипетр
 Awakened Shield,Пробуждённый щит
 Awakened Short Bow,Пробуждённый короткий лук
@@ -146,7 +146,7 @@ Awakened Staff,Пробуждённый посох
 Awakened Sword,Пробуждённый меч
 Awakened Torch,Пробуждённый факел
 Awakened Warhorn,Пробуждённый боевой рог
-Awakened Zealot Outfit,Наряд пробужденного фанатика
+Awakened Zealot Outfit,Наряд пробуждённого фанатика
 Awakening of the Heart,Пробуждение сердца
 Axe,Топор
 Axe Token,Жетон топора
@@ -463,10 +463,10 @@ Banner of the Flame Legion,Знамя Flame Legion
 Banner of the Iron Legion,Знамя Iron Legion
 Banner of the Steel Warband,Знамя отряда Стали
 Banners of Amnoon,Знамёна Амнуна
-Banners of Ancient Elona,Знамена Древней Элоны
+Banners of Ancient Elona,Знамёна Древней Элоны
 Banners of King Palawa Joko I,Знамёна короля Палавы Джоко I
 Banners of the Sunspear,Знамёна Солнечных копий
-Banners of the Sunspear Order,Знамена Ордена Копьеносцев Солнца
+Banners of the Sunspear Order,Знамёна Ордена Копьеносцев Солнца
 Bantamweight Hatchling,Детёныш легчайшего веса
 "Banur, Who Targets the Just of Severance","Банур, карающий справедливых из Разрыва"
 Barb,Шип

--- a/pn/pn_items_017.csv
+++ b/pn/pn_items_017.csv
@@ -121,7 +121,7 @@ Beastslayer Dagger,Кинжал убийцы зверей
 Beastslayer Dagger Skin,Облик кинжала зверобоя
 Beastslayer Focus,Фокус истребителя зверей
 Beastslayer Focus Skin,Облик фокуса зверобоя
-Beastslayer Glider,Планер убийцы зверей
+Beastslayer Glider,Планёр убийцы зверей
 Beastslayer Greatsword,Двуручный меч истребителя чудовищ
 Beastslayer Greatsword Skin,Облик двуручного меча зверобоя
 Beastslayer Hammer,Молот зверобоя

--- a/pn/pn_items_020.csv
+++ b/pn/pn_items_020.csv
@@ -227,7 +227,7 @@ Bloodstone Empowerment,Усиление кровавым камнем
 Bloodstone Fen Portal Scroll,Свиток портала в Топь Кровавого Камня
 Bloodstone Focus,Фокус из кровавого камня
 Bloodstone Focus Skin,Облик фокуса из кровавого камня
-Bloodstone Glider,Планер кровавого камня
+Bloodstone Glider,Планёр кровавого камня
 Bloodstone Greatsword,Кровавый каменный двуручный меч
 Bloodstone Greatsword Skin,Облик двуручного меча из кровавого камня
 Bloodstone Hammer,Молот из кровавого камня

--- a/pn/pn_items_021.csv
+++ b/pn/pn_items_021.csv
@@ -436,21 +436,21 @@ Bramm's Sturdy Leather Boots,Прочные кожаные сапоги Брам
 Bramm's Sturdy Shoes,Прочные туфли Брамма
 Branch of an Ancestor Tree,Ветвь древа предков
 Brand Crystal,Кристалл Клейма
-Branded Axe,Клейменый топор
+Branded Axe,Клеймёный топор
 Branded Axe Skin,Облик клеймёного топора
 Branded Backpiece,Клеймёный наспинник
 Branded Cache,Тайник Клеймёных
 Branded Crystalline Phial,Клеймёный кристаллический фиал
-Branded Dagger,Клейменый кинжал
+Branded Dagger,Клеймёный кинжал
 Branded Dagger Skin,Облик клеймёного кинжала
 Branded Devourer Monument Token,Жетон монумента клеймёного пожирателя
 Branded Dye,Краска «Клеймо»
 Branded Eel,Клеймёный угорь
 Branded Eye of Argon,Клеймёное око Аргона
-Branded Focus,Клейменый фокус
+Branded Focus,Клеймёный фокус
 Branded Focus Skin,Облик клеймёного фокуса
 Branded Geodermite,Клеймёный геодермит
-Branded Greatsword,Клейменый двуручный меч
+Branded Greatsword,Клеймёный двуручный меч
 Branded Greatsword Skin,Облик клеймёного двуручного меча
 Branded Griffon Skin,Облик клеймёного грифона
 Branded Hammer,Клеймёный молот
@@ -470,32 +470,32 @@ Branded Residue Research,Исследование клеймёного осад�
 Branded Rifle,Клеймёная винтовка
 Branded Rifle Skin,Облик клеймёной винтовки
 Branded Riftstone,Клеймёный камень разлома
-Branded Roller Beetle,Клейменный кругложук
-Branded Scepter,Клейменый скипетр
+Branded Roller Beetle,Клеймённый кругложук
+Branded Scepter,Клеймёный скипетр
 Branded Scepter Skin,Облик клеймёного скипетра
-Branded Shield,Клейменый щит
+Branded Shield,Клеймёный щит
 Branded Shield Skin,Облик клеймёного щита
-Branded Short Bow,Клейменый короткий лук
+Branded Short Bow,Клеймёный короткий лук
 Branded Short Bow Skin,Облик клеймёного короткого лука
 Branded Skimmer Skin,Облик клеймёного скиммера
-Branded Skyscale,Клейменный скайскейл
+Branded Skyscale,Клеймённый скайскейл
 Branded Skyscale Skin,Облик клеймёного скайскейла
 Branded Springer Skin,Облик клеймёного спрингера
-Branded Staff,Клейменый посох
+Branded Staff,Клеймёный посох
 Branded Staff Skin,Облик клеймёного посоха
 Branded Strongbox,Клеймёный сейф
-Branded Sword,Клейменый меч
+Branded Sword,Клеймёный меч
 Branded Sword Skin,Облик клеймёного меча
-Branded Torch,Клейменый факел
+Branded Torch,Клеймёный факел
 Branded Torch Skin,Облик клеймёного факела
-Branded Warclaw,Клейменный боевой коготь
+Branded Warclaw,Клеймённый боевой коготь
 Branded Warclaw Skin,Облик клеймёного боевого когтя
-Branded Warhorn,Клейменный боевой рог
+Branded Warhorn,Клеймённый боевой рог
 Branded Warhorn Skin,Облик клеймёного боевого рога
 Branded Weapon Box,Коробка клеймёного оружия
 Branded Wing Backpack,Рюкзак «Клеймёные крылья»
 Branded Wing Backpack and Glider Combo,Комплект рюкзака и планера «Клеймёные крылья»
-Branded Wing Glider,Планер с клейменными крыльями
+Branded Wing Glider,Планёр с клейменными крыльями
 Brandstone Multitool,Мультиинструмент из камня Клейма
 Brandstone Node,Залежь камня Клейма
-Brandstorm,Клейменный шторм
+Brandstorm,Клеймённый шторм

--- a/pn/pn_items_022.csv
+++ b/pn/pn_items_022.csv
@@ -318,7 +318,7 @@ Brushtail Nian,Кистехвостый нянь
 Brutus' Chestguard,Нагрудник Брута
 Brutus' Helm,Шлем Брута
 Brutus' Pauldrons,Наплечники Брута
-Bubble Glider,Планер-пузырь
+Bubble Glider,Планёр-пузырь
 Bubble Wand Dagger,Кинжал «Пузырьковая палочка»
 Bubble Wand Sword,Меч «Пузырьковая палочка»
 Bubblegum,Жвачка

--- a/pn/pn_items_023.csv
+++ b/pn/pn_items_023.csv
@@ -118,9 +118,9 @@ Canthan Nian Warclaw Skin,Облик боевого когтя «Кантанс�
 Canthan Noble Skyscale Skin,Облик скайскейла «Кантанский дворянин»
 Canthan Noble's Blade,Клинок кантанского дворянина
 Canthan Phoenix Backpack and Glider Combo,Комплект рюкзака и планера «Кантанский феникс»
-Canthan Phoenix Wings Glider,Планер «Крылья феникса» (Кант)
+Canthan Phoenix Wings Glider,Планёр «Крылья феникса» (Кант)
 Canthan Ritualist Satchel,Сумка кантанского ритуалиста
-Canthan Spiritualist Glider,Планер «Спиритуалист» (Кант)
+Canthan Spiritualist Glider,Планёр «Спиритуалист» (Кант)
 Canthan Spiritualist Outfit,Наряд кантанского спиритуалиста
 Canthan Sun Hat Skin,Облик кантанской шляпы от солнца
 Canthan Tigris Griffon Skin,Облик грифона «Кантанский тигр»

--- a/pn/pn_items_026.csv
+++ b/pn/pn_items_026.csv
@@ -476,7 +476,7 @@ Champion Beam the White Phoenix Loot Box,Коробка с добычей чем
 Champion Blade the White Shark Loot Box,Коробка с добычей «Чемпион Блейд Белая Акула»
 Champion Bloated Creeper Loot Box,Коробка с добычей чемпионского раздутого ползуна
 Champion Bolok Firebringer Loot Box,Коробка с добычей чемпиона Пламеносца Болта
-Champion Branded Minion Loot Box,Коробка с добычей чемпионского клейменого прислужника
+Champion Branded Minion Loot Box,Коробка с добычей чемпионского клеймёного прислужника
 Champion Brangoire Loot Box,Коробка с добычей чемпиона Брангуара
 Champion Centaur Loot Box,Коробка с добычей чемпиона-кентавра
 Champion Chest of the Mists,Сундук чемпиона Туманов

--- a/pn/pn_items_027.csv
+++ b/pn/pn_items_027.csv
@@ -220,7 +220,7 @@ Cheetah Charr Backpack Cover,Чехол рюкзака «Чарр-гепард»
 Cheetah Charr Backpack Set,Набор рюкзака «Чарр-гепард»
 Chef Starter Kit,Начальный набор повара
 Cherries in Bulk,Вишня оптом
-Cherry,Вишневый
+Cherry,Вишнёвый
 Cherry Almond Bar,Батончик «Вишня с миндалём»
 Cherry Barb,Вишнёвый барбус
 Cherry Blossom Clothing Outfit,Костюм «Цветущая сакура»
@@ -228,7 +228,7 @@ Cherry Blossom Shirt,Рубашка «Цветущая сакура»
 Cherry Cookie,Вишнёвое печенье
 Cherry Dye,Краска «Вишня»
 Cherry Passion Fruit Cake,Пирожное «Вишня-маракуйя»
-Cherry Pie,Вишневый пирог
+Cherry Pie,Вишнёвый пирог
 Cherry Salmon,Вишнёвый лосось
 Cherry Tart,Вишнёвый тарт
 Cherry Vanilla Dye,Краска «Вишня с ванилью»

--- a/pn/pn_items_029.csv
+++ b/pn/pn_items_029.csv
@@ -129,9 +129,9 @@ Cleric's Krait Wand,Жезл храмовника-крайта
 Cleric's Krait Warhammer,Боевой молот клирика «Крайт»
 Cleric's Krait Whelk,Крайт-ракушка клирика «Рожок»
 Cleric's Linen Insignia,Инсигния из льна клирика
-Cleric's Marauder Mask of Rage,Маска мародера клирика ярости
+Cleric's Marauder Mask of Rage,Маска мародёра клирика ярости
 Cleric's Marauder Mask of Vampirism,Маска мародёра клирика вампиризма
-Cleric's Marauder Mask of the Traveler,Маска клирика-мародера путешественника
+Cleric's Marauder Mask of the Traveler,Маска клирика-мародёра путешественника
 Cleric's Masquerade Boots,Сапоги маскарада клирика
 Cleric's Masquerade Gloves,Перчатки маскарада клирика
 Cleric's Masquerade Leggings,Поножи маскарада клирика
@@ -244,18 +244,18 @@ Cleric's Reinforced Scale Coat of Infiltration,Усиленная чешуйча
 Cleric's Reinforced Scale Coat of Lyssa,Усиленная чешуйчатая куртка клирика Лиссы
 Cleric's Reinforced Scale Coat of Rage,Усиленная чешуйчатая куртка гнева клирика
 Cleric's Reinforced Scale Coat of Scavenging,Укреплённая чешуйчатая куртка клирика-сборщика
-Cleric's Reinforced Scale Gauntlets of Divinity,Перчатки из укрепленной чешуи клирика божественности
+Cleric's Reinforced Scale Gauntlets of Divinity,Перчатки из укреплённой чешуи клирика божественности
 Cleric's Reinforced Scale Gauntlets of Infiltration,Перчатки из усиленной чешуи клирика проникновения
 Cleric's Reinforced Scale Gauntlets of the Citadel,Усиленные чешуйчатые рукавицы цитадели клирика
 Cleric's Reinforced Scale Helm of Hoelbrak,Целительский укреплённый чешуйчатый шлем Хоэльбрака
 Cleric's Reinforced Scale Helm of Rata Sum,Шлем клирика из усиленной чешуи Рата-Сума
 Cleric's Reinforced Scale Helm of the Flock,Укреплённый чешуйчатый шлем клирика из стаи
-Cleric's Reinforced Scale Legs of Infiltration,Укрепленные чешуйчатые наголенники клирика проникновения
+Cleric's Reinforced Scale Legs of Infiltration,Укреплённые чешуйчатые наголенники клирика проникновения
 Cleric's Reinforced Scale Legs of Mercy,Укреплённые чешуйчатые поножи милосердия клирика
 Cleric's Reinforced Scale Legs of the Eagle,Усиленные чешуйчатые поножи Орла Клирика
 Cleric's Reinforced Scale Legs of the Flock,Жреческие укреплённые чешуйчатые поножи стаи
 Cleric's Reinforced Scale Pauldrons of Grenth,Наплечники клирика из укреплённой чешуи Грента
-Cleric's Reinforced Scale Pauldrons of Vampirism,Укрепленные чешуйчатые наплечники клирика вампиризма
+Cleric's Reinforced Scale Pauldrons of Vampirism,Укреплённые чешуйчатые наплечники клирика вампиризма
 Cleric's Reinforced Scale Pauldrons of the Eagle,Наплечники клирика из усиленной чешуи «Орла»
 Cleric's Reinforced Scale Pauldrons of the Pack,Усиленные чешуйчатые наплечники стаи клирика
 Cleric's Ring,Кольцо клирика
@@ -297,7 +297,7 @@ Cleric's Seer Coat of the Eagle,Куртка прорицателя клирик
 Cleric's Seer Gloves of Vampirism,Перчатки прорицателя клирика вампиризма
 Cleric's Seer Gloves of the Afflicted,Перчатки прорицателя клирика из проклятых
 Cleric's Seer Mantle of Lyssa,Мантия прорицателя Лиссы клирика
-Cleric's Seer Mantle of Scavenging,Мантия прорицателя клирика мародерства
+Cleric's Seer Mantle of Scavenging,Мантия прорицателя клирика мародёрства
 Cleric's Seer Mask of the Eagle,Маска прорицателя клирика Орла
 Cleric's Seer Mask of the Pack,Маска прорицателя клана
 Cleric's Seer Pants of Lyssa,Штаны прорицателя Лиссы клирика

--- a/pn/pn_items_030.csv
+++ b/pn/pn_items_030.csv
@@ -334,20 +334,20 @@ Conquest Short Bow,Короткий лук завоевания
 Conquest Shoulders Skin,Облик наплечников завоевания
 Consecrated Jackal Treat,Освящённое лакомство шакала
 Consecrated Saryx Axe,Освящённый топор Сарикса
-Consecrated Saryx Dagger,Освященный сарикс кинжал
-Consecrated Saryx Focus,Освященный фокус Сарикс
-Consecrated Saryx Greatsword,Освященный сарийский двуручный меч
-Consecrated Saryx Hammer,Освященный молот Сарыкс
+Consecrated Saryx Dagger,Освящённый сарикс кинжал
+Consecrated Saryx Focus,Освящённый фокус Сарикс
+Consecrated Saryx Greatsword,Освящённый сарийский двуручный меч
+Consecrated Saryx Hammer,Освящённый молот Сарыкс
 Consecrated Saryx Longbow,Освящённый длинный лук Сарикса
 Consecrated Saryx Mace,Освящённая булава Сарикс
 Consecrated Saryx Pistol,Освящённый пистолет Сарикса
-Consecrated Saryx Rifle,Освященная винтовка сарикса
+Consecrated Saryx Rifle,Освящённая винтовка сарикса
 Consecrated Saryx Scepter,Освящённый скипетр Сарикс
 Consecrated Saryx Shield,Щит сарикса «Освящённый»
-Consecrated Saryx Short Bow,Освященный короткий лук Сарикс
-Consecrated Saryx Staff,Посох Сарикса Освященный
-Consecrated Saryx Sword,Освященный меч сарикс
-Consecrated Saryx Torch,Освященный факел Сарикс
+Consecrated Saryx Short Bow,Освящённый короткий лук Сарикс
+Consecrated Saryx Staff,Посох Сарикса Освящённый
+Consecrated Saryx Sword,Освящённый меч сарикс
+Consecrated Saryx Torch,Освящённый факел Сарикс
 Consecrated Saryx Warhorn,Освящённый боевой рог сарикса
 Consortium Cargo Container,Грузовой контейнер Консорциума
 Consortium Charm,Оберег Консорциума
@@ -429,11 +429,11 @@ Corroding Abyss,Разъедающая бездна
 Corrosive Bond,Коррозионная связь
 Corrosive Touch,Коррозийное прикосновение
 Corrupted Artifact,Осквернённый артефакт
-Corrupted Avenger,Оскверненный мститель
+Corrupted Avenger,Осквернённый мститель
 Corrupted Blade,Искажённый клинок
 Corrupted Blaster,Разрушенный бластер
 Corrupted Branch,Искажённая ветвь
-Corrupted Bulwark,Поврежденный бастион
+Corrupted Bulwark,Повреждённый бастион
 Corrupted Core,Осквернённое ядро
 Corrupted Cudgel,Порченная дубина
 Corrupted Eagle Shrine Token,Жетон осквернённого святилища орла
@@ -442,7 +442,7 @@ Corrupted Fragment,Осквернённый фрагмент
 Corrupted Greatbow,Осквернённый большой лук
 Corrupted Griffon Talon,Осквернённый коготь грифона
 Corrupted Harbinger,Испорченный предвестник
-Corrupted Harpoon Gun,Оскверненное гарпунное ружьё
+Corrupted Harpoon Gun,Осквернённое гарпунное ружьё
 Corrupted Hero Axe,Осквернённый геройский топор
 Corrupted Hero Dagger,Осквернённый геройский кинжал
 Corrupted Hero Focus,Осквернённый геройский фокус
@@ -472,9 +472,9 @@ Corrupted Short Bow,Порченый короткий лук
 Corrupted Skeggox,Испорченный Скеггокс
 Corrupted Sledgehammer,Испорченная кувалда
 Corrupted Sliver,Осквернённый осколок
-Corrupted Spear,Оскверненное копьё
-Corrupted Trident,Оскверненный трезубец
-Corrupted Wartorch,Оскверненный военный факел
+Corrupted Spear,Осквернённое копьё
+Corrupted Trident,Осквернённый трезубец
+Corrupted Wartorch,Осквернённый военный факел
 Corrupted Wolfmaster Whistle,Осквернённый свисток вожака волков
 Corrupted Wolverine Shrine Token,Жетон осквернённого святилища росомахи
 Corsair Boot Box,Коробка с корсарскими сапогами

--- a/pn/pn_items_031.csv
+++ b/pn/pn_items_031.csv
@@ -317,7 +317,7 @@ Crusader's Sword,Меч крестоносца
 Crush,Давка
 Crush Dye,Краска «Сокрушение»
 Crush Warband Honorary Patch,Почётная инсигния отряда «Сокрушение»
-Crushed Bone,Дробленая кость
+Crushed Bone,Дроблёная кость
 Crushed Bone Dye,Краска «Дроблёная кость»
 Crustacea,Ракообразные
 Crusty Brand Crystal,Заскорузлый кристалл Клейма
@@ -325,10 +325,10 @@ Crusty Mountain Griffon Egg,Потрескавшееся яйцо горного
 Cry,Плач
 Crying Thorn,Плачущий шип
 Crying Thorn of Dreams,Плачущий шип Грёзы
-Cryomancer Glider,Планер криоманта
+Cryomancer Glider,Планёр криоманта
 Cryptid Chase Unlocked,Погоня за криптидами открыта
 Crystal,Кристалл
-Crystal Arbiter Glider,Планер Кристального арбитра
+Crystal Arbiter Glider,Планёр Кристального арбитра
 Crystal Arbiter Outfit,Наряд кристального арбитра
 Crystal Bloom Axe,Топор Хрустального расцвета
 Crystal Bloom Axe Skin,Облик топора «Хрустальный расцвет»
@@ -380,7 +380,7 @@ Crystalline Bottle,Хрустальная бутылка
 Crystalline Diode,Кристаллический диод
 Crystalline Dragon Wings Backpack,Рюкзак «Кристаллические драконьи крылья»
 Crystalline Dragon Wings Backpack Glider Combo,Набор: рюкзак и планер «Кристаллические драконьи крылья»
-Crystalline Dragon Wings Glider,Планер «Кристаллические драконьи крылья»
+Crystalline Dragon Wings Glider,Планёр «Кристаллические драконьи крылья»
 Crystalline Ingot,Кристаллический слиток
 Crystalline Wings Backpack,Кристальные крылья рюкзак
 Crystallinum Weapon Chest,Сундук оружия «Кристаллинум»
@@ -399,7 +399,7 @@ Cube Matrix Glider,Планёр «Кубическая матрица»
 Cucumber,Огурец
 Cucumber Dye,Краска «Огурец»
 Cuddly Cat Backpack Skin,Облик рюкзака «Пушистый кот»
-Cuddly Cat Glider,Планер Пушистого Кота
+Cuddly Cat Glider,Планёр Пушистого Кота
 Cuddly Cat Glider Skin,Облик планера «Пушистый кот»
 Cuddly Cat Jade Bot Skin,Облик нефритового бота «Пушистый кот»
 Culicidae,Кулициды
@@ -438,8 +438,8 @@ Custom Arena Time Token,Жетон времени пользовательско
 Custom Candy Cane Hammer,Заказной молот из леденцовой трости
 Customer Appreciation Package,Пакет благодарности клиентам
 Cut of Quality Red Meat,Кусок качественного красного мяса
-Cute Angel Wings Glider,Планер «Милые крылья ангела»
-Cute Demon Wings Glider,Планер «Милые крылья демона»
+Cute Angel Wings Glider,Планёр «Милые крылья ангела»
+Cute Demon Wings Glider,Планёр «Милые крылья демона»
 Cute-Quaggan Finisher,Добивающий удар милого Кваггана
 Cutlass Fish,Рыба-сабля
 Cutthroat Caller,Призыватель головорезов
@@ -484,7 +484,7 @@ Damask Shoe Sole,Дамастовая подошва обуви
 Damask Shoe Upper,Дамастовый верх обуви
 Damp Mountain Griffon Egg,Влажное яйцо горного грифона
 Dance Platform Chair,Стул «Танцевальная платформа»
-Dance Platform Glider,Планер танцевальной платформы
+Dance Platform Glider,Планёр танцевальной платформы
 Dance Platform Package,Набор танцевальной платформы
 Dandan,Дандан
 Dandelion Blossom,Цветок одуванчика

--- a/pn/pn_items_032.csv
+++ b/pn/pn_items_032.csv
@@ -72,7 +72,7 @@ Dark Moon Shield,Щит тёмной луны
 Dark Olive,Тёмно-оливковый
 Dark Olive Dye,Краска «Тёмная олива»
 Dark Pauldrons Skin,Облик тёмных наплечников
-Dark Sanctified Axe,Тёмный освященный топор
+Dark Sanctified Axe,Тёмный освящённый топор
 Dark Sanctified Axe Skin,Облик тёмного освящённого топора
 Dark Sanctified Dagger,Тёмный освящённый кинжал
 Dark Sanctified Dagger Skin,Облик тёмного освящённого кинжала
@@ -80,27 +80,27 @@ Dark Sanctified Focus,Тёмный освящённый фокус
 Dark Sanctified Focus Skin,Облик тёмного освящённого фокуса
 Dark Sanctified Greatsword,Тёмный освящённый двуручный меч
 Dark Sanctified Greatsword Skin,Облик тёмного освящённого двуручного меча
-Dark Sanctified Hammer,Тёмный освященный молот
+Dark Sanctified Hammer,Тёмный освящённый молот
 Dark Sanctified Hammer Skin,Облик тёмного освящённого молота
 Dark Sanctified Longbow,Тёмный освящённый длинный лук
 Dark Sanctified Longbow Skin,Облик тёмного освящённого длинного лука
-Dark Sanctified Mace,Тёмная освященная булава
+Dark Sanctified Mace,Тёмная освящённая булава
 Dark Sanctified Mace Skin,Облик тёмной освящённой булавы
 Dark Sanctified Pistol,Тёмный освящённый пистолет
 Dark Sanctified Pistol Skin,Облик тёмного освящённого пистолета
 Dark Sanctified Rifle,Тёмная освящённая винтовка
 Dark Sanctified Rifle Skin,Облик тёмной освящённой винтовки
-Dark Sanctified Scepter,Тёмный освященный скипетр
+Dark Sanctified Scepter,Тёмный освящённый скипетр
 Dark Sanctified Scepter Skin,Облик тёмного освящённого скипетра
-Dark Sanctified Shield,Тёмный освященный щит
+Dark Sanctified Shield,Тёмный освящённый щит
 Dark Sanctified Shield Skin,Облик тёмного освящённого щита
-Dark Sanctified Short Bow,Тёмный освященный короткий лук
+Dark Sanctified Short Bow,Тёмный освящённый короткий лук
 Dark Sanctified Short Bow Skin,Облик тёмного освящённого короткого лука
 Dark Sanctified Staff,Тёмный освящённый посох
 Dark Sanctified Staff Skin,Облик тёмного освящённого посоха
 Dark Sanctified Sword,Тёмный освящённый меч
 Dark Sanctified Sword Skin,Облик тёмного освящённого меча
-Dark Sanctified Torch,Тёмный освященный факел
+Dark Sanctified Torch,Тёмный освящённый факел
 Dark Sanctified Torch Skin,Облик тёмного освящённого факела
 Dark Sanctified Warhorn,Тёмный освящённый боевой рог
 Dark Sanctified Warhorn Skin,Облик тёмного освящённого боевого рога
@@ -285,7 +285,7 @@ Death of the Exile,Смерть изгнанника
 Death of the Kings,Смерть королей
 Death of the Oppressed,Смерть угнетённых
 Deathcamas,Смертельный камас
-Deathcamas of Dreams,Смертоцвет грез
+Deathcamas of Dreams,Смертоцвет грёз
 Deathly Avian Mantle,Смертная Птичья Мантия
 Deathly Avian Mantle Skin,Облик оплечья «Смертельная птица»
 Deathly Avian Pauldrons,Смертные Птичьи Наплечники
@@ -327,7 +327,7 @@ Decima's Manica,Мантика Децимы
 Decimator,Разрушитель
 Deciphered Clues,Расшифрованные улики
 Decisive Evidence,Решающее доказательство
-Decoration: Arrow Cart,Декорация: Стреломет
+Decoration: Arrow Cart,Декорация: Стреломёт
 Decoration: Ballista,Декорация: Баллиста
 Decoration: Cannon,Украшение: Пушка
 Decoration: Catapult,Украшение: Катапульта
@@ -340,7 +340,7 @@ Decoration: Guild Trebuchet,Декорация: Гильдейская треб�
 Decoration: Mortar,Декорация: Мортира
 Decoration: Ram,Украшение: Баран
 Decoration: Shield Generator,Декорация: генератор щита
-Decoration: Superior Arrow Cart,Декорация: Улучшенная стрелометная телега
+Decoration: Superior Arrow Cart,Декорация: Улучшенная стреломётная телега
 Decoration: Superior Ballista,Декорация: Улучшенная баллиста
 Decoration: Superior Catapult,Декорация: Улучшенная катапульта
 Decoration: Superior Golem,Декорация: Улучшенный голем

--- a/pn/pn_items_033.csv
+++ b/pn/pn_items_033.csv
@@ -176,7 +176,7 @@ Depleted Power Source,Истощенный источник энергии
 Deployable Mortar Kit,Развёртываемый миномётный комплект
 Deployable Thumper Turret,Развёртываемая турель-трамбовка
 Deputy Peacemaker Badge,Значок заместителя миротворца
-Desert Armor Box,Коробка с пустынной броней
+Desert Armor Box,Коробка с пустынной бронёй
 Desert Crafting Material Coffer,Сундук с пустынными материалами для крафта
 Desert Explorer Kit,Набор пустынного исследователя
 Desert Harpy,Пустынная гарпия
@@ -423,7 +423,7 @@ Dire Aureate Charm of Force,Грозный золотой оберег силы
 Dire Aureate Charm of Water,Грозный ауреатный оберег воды
 Dire Aureate Dirk of Air,Кинжал аурический «Золотой» направления «Воздух»
 Dire Aureate Dirk of Corruption,Грозный золотистый кинжал Порчи
-Dire Aureate Dirk of Energy,Грозный золоченый кинжал страха
+Dire Aureate Dirk of Energy,Грозный золочёный кинжал страха
 Dire Aureate Dirk of Force,Грозный ауреатовый кортик силы
 Dire Aureate Dirk of Water,Грозный позолоченный кортик воды
 Dire Aureate Highlander Greatsword of Air,Грозный золочёный двуручный меч горца воздуха
@@ -449,17 +449,17 @@ Dire Aureate Musket of Water,Грозный мушкет воды
 Dire Aureate Pistol of Air,Грозный золочёный пистолет воздуха
 Dire Aureate Pistol of Corruption,Грозный позолоченный пистолет Порчи
 Dire Aureate Pistol of Energy,Грозный золотой пистолет энергии
-Dire Aureate Pistol of Force,Грозный золоченый пистолет силы
+Dire Aureate Pistol of Force,Грозный золочёный пистолет силы
 Dire Aureate Pistol of Water,Грозный золотой пистолет воды
 Dire Aureate Rinblade of Air,Ужасающий ауреатский ринблейд воздуха
 Dire Aureate Rinblade of Corruption,Грозный ауреатский ринблейд порчи
 Dire Aureate Rinblade of Energy,Грозный ауренский ринблэйд энергии
 Dire Aureate Rinblade of Force,Грозный ауреатский ринблейд силы
-Dire Aureate Rinblade of Water,Грозный золоченый ринблейд воды
+Dire Aureate Rinblade of Water,Грозный золочёный ринблейд воды
 Dire Aureate Sconce of Air,Грозный позолоченный бра аэромантии
 Dire Aureate Sconce of Corruption,Грозный ауреатный бра с разложением
 Dire Aureate Sconce of Energy,Грозный золотистый светильник энергии
-Dire Aureate Sconce of Force,Грозное золоченое бра силы
+Dire Aureate Sconce of Force,Грозное золочёное бра силы
 Dire Aureate Sconce of Water,Грозный позолоченный бра «Воды»
 Dire Aureate Short Bow of Air,Грозный золотистый короткий лук воздуха
 Dire Aureate Short Bow of Corruption,Грозный золотой короткий лук порчи
@@ -472,7 +472,7 @@ Dire Aureate Spear of Energy,Грозное копьё энергии из сп�
 Dire Aureate Spear of Force,Грозное авреат-копьё Силы
 Dire Aureate Spear of Water,Грозное копьё Ауреата Воды
 Dire Aureate Speargun of Air,Грозное золотистое копьеметательное ружьё воздуха
-Dire Aureate Speargun of Corruption,Грозный золоченый гарпун разложения
+Dire Aureate Speargun of Corruption,Грозный золочёный гарпун разложения
 Dire Aureate Speargun of Energy,Гарпунное ружьё «Грозное злато» энергии
 Dire Aureate Speargun of Force,Грозная золотая гарпунная пушка силы
 Dire Aureate Speargun of Water,Грозное золотое копьё воды
@@ -482,7 +482,7 @@ Dire Aureate Staff of Energy,Грозный златотканый посох э
 Dire Aureate Staff of Force,Грозный золотой посох силы
 Dire Aureate Staff of Water,Посох «Золотой аурный» воды
 Dire Aureate Targe of Air,Грозный золочёный тарч воздуха
-Dire Aureate Targe of Corruption,Грозный золоченый тарг порчи
+Dire Aureate Targe of Corruption,Грозный золочёный тарг порчи
 Dire Aureate Targe of Energy,Грозный золотой тарг энергии
 Dire Aureate Targe of Force,Грозный золотистый тарг силы
 Dire Aureate Targe of Water,Ужасающий тарч из ауреата воды

--- a/pn/pn_items_034.csv
+++ b/pn/pn_items_034.csv
@@ -237,7 +237,7 @@ Dire Krytan Warhorn of Bloodlust,Грозный крайтанский боев�
 Dire Krytan Warhorn of Earth,Дикий крайтанский боевой рог Земли
 Dire Krytan Warhorn of the Geomancer,Роковой крайтанский боевой рог геоманта
 Dire Marauder Mask of Divinity,Грозная маска мародёра божественности
-Dire Marauder Mask of the Afflicted,Маска «Грозный мародер» из комплекта «Одержимые»
+Dire Marauder Mask of the Afflicted,Маска «Грозный мародёр» из комплекта «Одержимые»
 Dire Marauder Mask of the Eagle,Маска «Грозный мародёр» Орла
 Dire Orichalcum Imbued Inscription,Грозная пропитанная гравировка из орихалка
 Dire Orrian Axe,Грозный оррианский топор

--- a/pn/pn_items_035.csv
+++ b/pn/pn_items_035.csv
@@ -221,14 +221,14 @@ Diviner's Shining Aureate Dirk of Luck,«Сияющий ауреатский к�
 Diviner's Shining Aureate Highlander Greatsword of Luck,Двуручный меч горца «Сияющий ауреат» Прорицателя удачи
 Diviner's Shining Aureate Longbow of Luck,Длинный лук «Сияющий золотой» Прорицателя удачи
 Diviner's Shining Aureate Mace of Luck,Сияющий ауреатный молот Прорицателя удачи
-Diviner's Shining Aureate Musket of Luck,Прорицателя сияющий золоченый мушкет удачи
-Diviner's Shining Aureate Pistol of Luck,Сверкающий золоченый пистолет Прорицателя удачи
+Diviner's Shining Aureate Musket of Luck,Прорицателя сияющий золочёный мушкет удачи
+Diviner's Shining Aureate Pistol of Luck,Сверкающий золочёный пистолет Прорицателя удачи
 Diviner's Shining Aureate Rinblade of Luck,Сияющий златоцветный ринблейд Удачи Прорицателя
 Diviner's Shining Aureate Sconce of Luck,Прорицателя сияющий золотой светильник удачи
 Diviner's Shining Aureate Short Bow of Luck,Сияющий золотой короткий лук удачи Прорицателя
 Diviner's Shining Aureate Staff of Luck,«Сияющий посох удачи Прорицателя»
 Diviner's Shining Aureate Targe of Luck,«Сияющий золочёный тарж удачи Прорицателя»
-Diviner's Shining Aureate Virge of Luck,«Сияющий золоченый жезл Прорицателя Удачи»
+Diviner's Shining Aureate Virge of Luck,«Сияющий золочёный жезл Прорицателя Удачи»
 Diviner's Shining Aureate Warhammer of Luck,Сияющий золотой боевой молот Прорицателя удачи
 Diviner's Shining Aureate Warhorn of Luck,Сияющий золочёный боевой рог Прорицателя удачи
 Diviner's Weapon Recipe Book,Книга рецептов оружия Прорицателя

--- a/pn/pn_items_036.csv
+++ b/pn/pn_items_036.csv
@@ -39,7 +39,7 @@ Dragon's Jade Cudgel,Нефритовая дубина дракона
 Dragon's Jade Cudgel Skin,Облик драконьей нефритовой дубинки
 Dragon's Jade Flame,Нефритовое пламя дракона
 Dragon's Jade Flame Skin,Облик драконьего нефритового пламени
-Dragon's Jade Flintlock,Драконий нефритовый кремневый пистолет
+Dragon's Jade Flintlock,Драконий нефритовый кремнёвый пистолет
 Dragon's Jade Flintlock Skin,Облик драконьего нефритового кремнёвого пистолета
 Dragon's Jade Harbinger,Драконий нефритовый предвестник
 Dragon's Jade Harbinger Skin,Облик драконьего нефритового предвестника
@@ -287,7 +287,7 @@ Dreamwalker Sword,Меч сновидца
 Dreamwalker Sword Skin,Облик меча «Странник грёз»
 Dreamwalker Wings Backpack,Рюкзак-крылья «Странник грёз»
 Dreamwalker Wings Backpack and Glider Combo,Набор: рюкзак и планер «Странник грёз»
-Dreamwalker Wings Glider,Планер Крылья Сноходца
+Dreamwalker Wings Glider,Планёр Крылья Сноходца
 Dreamy Water Sample,Образец грёзовой воды
 Dredge Barricade,Баррикада дредноута
 Dredge Baton,Дубинка дреджей

--- a/pn/pn_items_037.csv
+++ b/pn/pn_items_037.csv
@@ -41,7 +41,7 @@ Dynamics Extractor Logging Tool,Инструмент рубки «Экстрак
 Dynamics Extractor Mining Tool,Инструмент добычи «Экстрактор Динамики»
 Dynamics Hoverboard Backpack,Рюкзак «Ховерборд Динамики»
 Dynamics Hoverboard Chair,Кресло «Ховерборд Динамики»
-Dynamics Hoverboard Glider,Планер «Ховерборд Динамики»
+Dynamics Hoverboard Glider,Планёр «Ховерборд Динамики»
 Dynamics Projector Module,Проекторный модуль Динамики
 Dynamics Racing Skiff,Гоночный скиф «Динамика»
 Dynamics Racing Skiff Skin,Облик скифа «Гоночная Динамика»
@@ -306,7 +306,7 @@ Electromagnetic Epaulets,Электромагнитные наплечники
 Electromagnetic Gloves,Электромагнитные перчатки
 Electromagnetic Helm,Электромагнитный шлем
 Electromagnetic Leggings,Электромагнитные поножи
-Electromagnetic-Descender Glider,Планер «Электромагнитный спуск»
+Electromagnetic-Descender Glider,Планёр «Электромагнитный спуск»
 Electroplated Boots,Электроплакированные сапоги
 Electroplated Coat,Электроплакированная куртка
 Electroplated Epaulets,Гальванизированные эполеты
@@ -373,7 +373,7 @@ Element of the Oakhearts,Стихия Дубовых Сердец
 Element of the Saurians,Стихия Ящеров
 Element of the Wardbough,Стихия Вардбога
 Element of the Wurm,Стихия Червя
-Elemental Fury Glider,Планер стихийной ярости
+Elemental Fury Glider,Планёр стихийной ярости
 Elemental Lodestone,Элементальный магнетит
 Elemental Sword,Элементальный меч
 Elemental Water Sample,Образец элементальной воды

--- a/pn/pn_items_039.csv
+++ b/pn/pn_items_039.csv
@@ -158,15 +158,15 @@ Everburning Flame,Вечно горящее пламя
 Everburning Greaves,Вечно горящие наголенники
 Everburning Pistol,Вечно горящий пистолет
 Everburning Shoes,Вечно горящие туфли
-Evergreen,Вечнозеленый
-Evergreen Boots,Вечнозеленые ботинки
+Evergreen,Вечнозелёный
+Evergreen Boots,Вечнозелёные ботинки
 Evergreen Coat,Вечнозелёная куртка
 Evergreen Core,Вечнозелёное ядро
 Evergreen Dye,Краска «Вечнозелёный»
 Evergreen Fragment,Вечнозелёный фрагмент
 Evergreen Gloves,Вечнозелёные перчатки
-Evergreen Helm,Вечнозеленый шлем
-Evergreen Leggings,Вечнозеленые поножи
+Evergreen Helm,Вечнозелёный шлем
+Evergreen Leggings,Вечнозелёные поножи
 Evergreen Lodestone,Вечнозелёный магнетит
 Evergreen Shard,Вечнозелёный осколок
 Evergreen Shoulderguards,Наплечники «Вечнозелёный»
@@ -490,7 +490,7 @@ Fanged Dread Mask,Зубастая жуткая маска
 Fanged Greatsword,Клыкастый двуручный меч
 Fangfish,Клыкастая рыба
 Fantastic Fish Fillet,Фантастическое филе рыбы
-Far Mountain,Далекая гора
+Far Mountain,Далёкая гора
 Far Mountain Dye,Краска «Далёкая гора»
 Farmer's Rusty Axe,Ржавый топор фермера
 Farmer's Rusty Dagger,Ржавый кинжал фермера

--- a/pn/pn_items_040.csv
+++ b/pn/pn_items_040.csv
@@ -274,12 +274,12 @@ First Haven Gauntlets,Латные перчатки Первого Убежищ�
 First Haven Leather Gloves,Кожаные перчатки Первого Убежища
 First Night's Spark,Искра первой ночи
 First Spear's Icon,Икона Первого Копья
-Firstborn Boots,Сапоги перворожденного
+Firstborn Boots,Сапоги перворождённого
 Firstborn Coat,Куртка Перворождённого
 Firstborn Gloves,Перчатки перворождённого
 Firstborn Helm,Шлем перворождённого
 Firstborn Leggings,Поножи первенца
-Firstborn Shoulderguards,Наплечники перворожденного
+Firstborn Shoulderguards,Наплечники перворождённого
 Fish Bone Whistle,Свисток из рыбьей кости
 Fish Egg,Икра рыбы
 Fish Figurine,Фигурка рыбки

--- a/pn/pn_items_041.csv
+++ b/pn/pn_items_041.csv
@@ -5,7 +5,7 @@ Flask of Utility Primer,Флакон вспомогательного прайм
 Flask of Vabbian Red,Фляга ваббианского красного
 Flat Boatsman Hat,Плоская шляпа лодочника
 Flat Boatsman Hat Skin,Облик плоской шляпы лодочника
-Flatbread,Лепешка
+Flatbread,Лепёшка
 Flattened Ooze,Сплющенная слизь
 Flavorful Fish Fillet,Ароматное рыбное филе
 Flawed Guild Catapult Blueprint,Дефектный чертёж гильдейской катапульты
@@ -39,11 +39,11 @@ Floral Glider,Цветочный планер
 Flowerhead,Цветочная головка
 Flowing Scaled Cape,Струящийся чешуйчатый плащ
 Flowing Silk Backpack Skin,Облик рюкзака «Струящийся шёлк»
-Flowing Silk Glider,Планер «Струящийся шёлк»
+Flowing Silk Glider,Планёр «Струящийся шёлк»
 Flowing Silk Glider Skin,Облик планера «Струящийся шёлк»
 Fluff,Пух
 Fluff Dye,Краска «Пушок»
-Fluffy Clouds Glider,Планер «Пушистые облака»
+Fluffy Clouds Glider,Планёр «Пушистые облака»
 Fluffy Samoyed Jackal,Пушистый шакал-самоед
 Fluffy Samoyed Jackal Skin,Облик шакала «Пушистый самоед»
 Flush,Смыв
@@ -55,7 +55,7 @@ Flux Matrix,Матрица потока
 Fly-by-Night: Bronze,Ночной полёт: бронза
 Fly-by-Night: Gold,Ночной полёт: золото
 Fly-by-Night: Silver,Ночной полёт: серебро
-Flying Boar Glider,Планер «Летающий кабан»
+Flying Boar Glider,Планёр «Летающий кабан»
 Flying Circus: Bronze,Летучий цирк: бронза
 Flying Cow Token,Жетон летающей коровы
 Flying Dolyak: Bronze,Летающий дольяк: бронза

--- a/pn/pn_items_042.csv
+++ b/pn/pn_items_042.csv
@@ -30,7 +30,7 @@ Fox Fire Torch Skin,Облик факела «Лисий огонь»
 Fox Fire Warhorn,Боевой рог лисьего пламени
 Fox Fire Warhorn Skin,Облик боевого рога «Лисий огонь»
 Fox Fire Weapon Choice,Выбор оружия «Лисий огонь»
-Fox Spirit Glider,Планер «Дух лисы»
+Fox Spirit Glider,Планёр «Дух лисы»
 Foxfire Cluster,Скопление лисьего огня
 Foxglove,Наперстянка
 Fractal Adept's Chest,Сундук адепта фракталов
@@ -183,7 +183,7 @@ Frosted Sea Dye,Краска «Морозное море»
 Frostfang Vol. 1,«Frostfang». Том 1
 Frostfang Vol. 2,«Frostfang». Том 2
 Frostfang Vol. 3,«Frostfang». Том 3
-Frostfire Glider,Планер «Морозный огонь»
+Frostfire Glider,Планёр «Морозный огонь»
 Frostfire Outfit,Наряд «Морозный огонь»
 Frostforged Axe,Морозокованый топор
 Frostforged Axe Skin,Облик топора «Ледяная ковка»

--- a/pn/pn_items_043.csv
+++ b/pn/pn_items_043.csv
@@ -82,10 +82,10 @@ Genius Epaulets,Гениальные наплечники
 Genius Gloves,Перчатки гения
 Genius Helm,Шлем гения
 Genius Leggings,Поножи гения
-Gentle Garden Swing Glider,Планер «Садовые качели»
+Gentle Garden Swing Glider,Планёр «Садовые качели»
 Geode Cache,Тайник жеодов
 Geode Hoard,Склад жеод
-Geomancer Glider,Планер «Геомант»
+Geomancer Glider,Планёр «Геомант»
 Germinated Foxfire Cluster,Проросший кластер лисьего огня
 Geyser Batfin,Летучая мышь-фонтан
 Ghastly Grinning Shield,Зловещий оскал
@@ -129,7 +129,7 @@ Giant Catfish,Гигантский сом
 Giant Devourer Stinger,Жало гигантского пожирателя
 Giant Dusty Wintersday Gift,Гигантский пыльный подарок Зимнего дня
 Giant Eye,Гигантский глаз
-Giant Folding Fan Glider,Планер «Гигантский складной веер»
+Giant Folding Fan Glider,Планёр «Гигантский складной веер»
 Giant Gourami,Гигантский гурами
 Giant Jellyfish Stinger,Жало гигантской медузы
 Giant Mushroom Spore,Спора гигантского гриба
@@ -137,7 +137,7 @@ Giant Octopus,Гигантский осьминог
 Giant Paddlefish,Гигантский веслонос
 Giant Pearl,Гигантская жемчужина
 Giant Shark Tooth,Гигантский акулий зуб
-Giant Shuriken Glider,Планер «Гигантский сюрикен»
+Giant Shuriken Glider,Планёр «Гигантский сюрикен»
 Giant Trevally,Гигантский каранкс
 Giant Troll Tooth,Гигантский зуб тролля
 Giant Wolf Tooth,Гигантский волчий зуб
@@ -477,7 +477,7 @@ Glacial Focus,Ледниковый фокус
 Glacial Focus Skin,Облик ледникового фокуса
 Glacial Fragment,Ледниковый фрагмент
 Glacial Gauntlets Box,Коробка с ледниковыми латными перчатками
-Glacial Glider,Планер «Ледниковый»
+Glacial Glider,Планёр «Ледниковый»
 Glacial Greatsword,Ледниковый двуручный меч
 Glacial Greatsword Skin,Облик ледникового двуручного меча
 Glacial Hammer,Ледниковый молот

--- a/pn/pn_items_044.csv
+++ b/pn/pn_items_044.csv
@@ -44,7 +44,7 @@ Glazed Chocolate Raspberry Cookie,Глазированное шоколадно-
 Glazed Pumpkin Pie,Глазированный тыквенный пирог
 Gleam of Sentience,Отблеск разумности
 Gleaming Matrix,Мерцающая матрица
-Glide-r-Tron,Планер «Глайд-р-Трон»
+Glide-r-Tron,Планёр «Глайд-р-Трон»
 Glimmerfang,Мерцающий клык
 Glimmering Arches Grand Prix: Bronze,Гран-при Мерцающих арок: бронза
 Glimmering Resin Axe,Мерцающий смоляной топор

--- a/pn/pn_items_045.csv
+++ b/pn/pn_items_045.csv
@@ -80,17 +80,17 @@ Gourmet Chef's Tools,Инструменты повара-гурмана
 Graceful Bladed Left Wing Backpack,Изящный левый заплечный рюкзак «Клинок»
 Graceful Bladed Left Wing Backpack Skin,Облик рюкзака «Изящное левое крыло с клинком»
 Graceful Bladed Left Wing Backpack and Glider Combo,Комплект «Изящный клинковый левый крыльевой рюкзак и планер»
-Graceful Bladed Left Wing Glider,Планер «Левое лезвие грации»
-Graceful Bladed Left Wing Glider Skin,Планер «Изящное лезвийное левое крыло»
+Graceful Bladed Left Wing Glider,Планёр «Левое лезвие грации»
+Graceful Bladed Left Wing Glider Skin,Планёр «Изящное лезвийное левое крыло»
 Graceful Bladed Right Wing Backpack,Рюкзак «Грациозное правое крыло с лезвиями»
 Graceful Bladed Right Wing Backpack Skin,Облик рюкзака «Изящное правое крыло с лезвиями»
 Graceful Bladed Right Wing Backpack and Glider Combo,Изящный рюкзак-крыло «Правое крыло» и дельтаплан
-Graceful Bladed Right Wing Glider,Планер «Правое лезвие грации»
+Graceful Bladed Right Wing Glider,Планёр «Правое лезвие грации»
 Graceful Bladed Right Wing Glider Skin,Облик планера «Изящное правое лезвийное крыло»
 Graceful Bladed Wings Backpack,Рюкзак «Грациозные крылья с лезвиями»
 Graceful Bladed Wings Backpack Skin,Облик рюкзака «Изящные крылья с лезвиями»
 Graceful Bladed Wings Backpack and Glider Combo,Комплект «Изящные клинковые крылья»: рюкзак и планер
-Graceful Bladed Wings Glider,Планер «Крылья-лезвия грации»
+Graceful Bladed Wings Glider,Планёр «Крылья-лезвия грации»
 Graceful Bladed Wings Glider Skin,Облик планера «Изящные окрылённые крылья»
 Gradient Glasses (Down),Градиентные очки (вниз)
 Gradient Glasses (Down) Skin,Облик «Градиентные очки (вниз)»
@@ -144,7 +144,7 @@ Grasping Dead Pauldrons,Наплечники цепких мертвецов
 Grasping Dead Visage,Лик цепких мертвецов
 Grasping Gaze Shoulders,Наплечники хватающего взгляда
 Grasping Gaze Shoulders Box,Коробка с наплечниками «Цепкий взор»
-Grasping Phantom Glider,Планер «Хваткий фантом»
+Grasping Phantom Glider,Планёр «Хваткий фантом»
 Grass,Трава
 Grass Dye,Краска «Трава»
 Grave,Могила

--- a/pn/pn_items_046.csv
+++ b/pn/pn_items_046.csv
@@ -128,7 +128,7 @@ Handcrafted Bellower,Крикун ручной работы
 Handcrafted Bent Circuit,Гнутая цепь ручной работы
 Handcrafted Big Grin,Широкая улыбка ручной работы
 Handcrafted Blind Ed's Longbow,Длинный лук Слепого Эда ручной работы
-Handcrafted Boltcaster,Болтомет ручной работы
+Handcrafted Boltcaster,Болтомёт ручной работы
 Handcrafted Bombard,бомбарда ручной работы
 Handcrafted Boregun,бур ручной работы
 Handcrafted Cauterizer,каутеризатор ручной работы
@@ -193,7 +193,7 @@ Handcrafted Serrated Fate,Зазубренная судьба ручной ра�
 Handcrafted Skaaldsinger,Скальдпевец ручной работы
 Handcrafted Slate-Bound Star,Сланцесвязанная звезда ручной работы
 Handcrafted Smodur's Charge,Заряд Смодура ручной работы
-Handcrafted Sparrowcatcher,Ловец воробьев ручной работы
+Handcrafted Sparrowcatcher,Ловец воробьёв ручной работы
 Handcrafted Speakerpride,Гордость спикера ручной работы
 Handcrafted Spiritcatcher,Ловец духов ручной работы
 Handcrafted Stagsign,Знак оленя ручной работы

--- a/pn/pn_items_050.csv
+++ b/pn/pn_items_050.csv
@@ -363,7 +363,7 @@ Icedevil Hood,Капюшон ледяного дьявола
 Icedevil Mask,Маска ледяного дьявола
 Icefish,Ледяная рыба
 Iceflow,Ледяной поток
-Iceforged Reaver,Ледяной мародер
+Iceforged Reaver,Ледяной мародёр
 Icelord's Heavy Diadem,Тяжёлая диадема ледяного лорда
 Icelord's Light Diadem,Лёгкая диадема ледяного лорда
 Icelord's Medium Diadem,Средняя диадема ледяного лорда

--- a/pn/pn_items_051.csv
+++ b/pn/pn_items_051.csv
@@ -121,7 +121,7 @@ In Memoriam,В память
 In Memorium,В память
 In Need of a Friend,В поисках друга
 Inaccurate Caravanserai Map,Неточная карта караван-сарая
-Incandescent,Раскаленный
+Incandescent,Раскалённый
 Incandescent Dye,Краска «Раскалённая»
 Incarnate Flame,Воплощенное пламя
 Incarnate Gloves,Инкарнатные перчатки
@@ -184,7 +184,7 @@ Infernal,Адский
 Infernal Device,Адское устройство
 Infernal Dye,Краска «Адская»
 Infernal Envoy Backpack Skin,Облик рюкзака «Адский посланник»
-Infernal Envoy Glider,Планер «Адский посланник»
+Infernal Envoy Glider,Планёр «Адский посланник»
 Infernal Envoy Glider Skin,Облик планера «Адский посланник»
 Infernal Envoy Outfit,Наряд «Адский посланник»
 Infernal Envoy Staff,Адский посох посланника
@@ -195,7 +195,7 @@ Infernal Horror,Адский ужас
 Infernal Horror Springer Skin,Облик спрингера «Адский ужас»
 Infernal Roar,Адский рев
 Infernal Roar Warhorn Skin,Облик боевого рога «Адский рёв»
-Infinirarium Glider,Планер «Инфинирариум»
+Infinirarium Glider,Планёр «Инфинирариум»
 Infinite Arrow Cart Blueprint,Чертёж бесконечной стреломётной телеги
 Infinite Ballista Blueprint,Чертёж бесконечной баллисты
 Infinite Catapult Blueprint,Чертёж бесконечной катапульты

--- a/pn/pn_items_052.csv
+++ b/pn/pn_items_052.csv
@@ -33,7 +33,7 @@ Iron Torch Head,Железная головка факела
 Iron Trident Head,Железный наконечник трезубца
 Iron Warhorn Mouthpiece,Мундштук железного боевого рога
 Iron's Tailpipe Bandana,Бандана «Выхлопная труба Айрона»
-Ironclad Glider,Планер «Бронированный»
+Ironclad Glider,Планёр «Бронированный»
 Ironclad Outfit,Наряд «Железный доспех»
 Ironfist,Железный кулак
 Ironshell's Shell Fragment,Обломок панциря Айроншелла
@@ -168,7 +168,7 @@ Jade Tech Heavy Leggings,Тяжёлые поножи из нефритовой �
 Jade Tech Helm,Шлем джад-теха
 Jade Tech Jetpack Backpack,Рюкзак «Реактивный ранец нефритовой техники»
 Jade Tech Jetpack Backpack and Glider Combo,Набор: рюкзак и планер «Реактивный ранец нефритовой техники»
-Jade Tech Jetpack Glider,Планер «Реактивный ранец нефритовых технологий»
+Jade Tech Jetpack Glider,Планёр «Реактивный ранец нефритовых технологий»
 Jade Tech Light Boots,Лёгкие сапоги из джетеха
 Jade Tech Light Gloves,Лёгкие перчатки из джетеха
 Jade Tech Light Shoulderpads,Нефритовые технологичные лёгкие наплечники
@@ -204,7 +204,7 @@ Jade Tech Visor Skin,Облик забрала «Нефритовая техни
 Jade Tech Warhorn,Боевой рог «Нефритовая техника»
 Jade Tech Wings Backpack,Рюкзак «Крылья нефритовой техники»
 Jade Tech Wings Backpack and Glider Combo,Набор: рюкзак и планер «Крылья нефритовой техники»
-Jade Tech Wings Glider,Планер «Крылья нефритовых технологий»
+Jade Tech Wings Glider,Планёр «Крылья нефритовых технологий»
 Jade Technician Backpack,Рюкзак нефритового техника
 Jade-Spun Silk Thread,Нить из нефритового шёлка
 Jadeite Fossilized Phyllopteryx,Окаменелый нефритовый филлоптерикс

--- a/pn/pn_items_053.csv
+++ b/pn/pn_items_053.csv
@@ -467,7 +467,7 @@ Knight's Rascal Gloves,Перчатки плута рыцаря
 Knight's Rascal Mask,Маска плута рыцаря
 Knight's Rascal Pants,Штаны проказника рыцаря
 Knight's Rascal Shoulders,Плечи плута рыцаря
-Knight's Reinforced Scale Boots,Укрепленные чешуйчатые сапоги рыцаря
+Knight's Reinforced Scale Boots,Укреплённые чешуйчатые сапоги рыцаря
 Knight's Reinforced Scale Coat,Укреплённая чешуйчатая куртка рыцаря
 Knight's Reinforced Scale Gauntlets,Усиленные чешуйчатые перчатки рыцаря
 Knight's Reinforced Scale Helm,Усиленный чешуйчатый шлем рыцаря

--- a/pn/pn_items_054.csv
+++ b/pn/pn_items_054.csv
@@ -11,7 +11,7 @@ Known Track 02,Известный трек 02
 Known Track 03,Известный трек 03
 Known Track 04,Известный трек 04
 Known Track 05,Известная дорожка 05
-Koda Heavy Armor Box,Коробка с тяжёлой броней Коды
+Koda Heavy Armor Box,Коробка с тяжёлой бронёй Коды
 Koda Light Armor Box,Коробка лёгких доспехов Коды
 Koda's Blossom Petal,Лепесток цветка Коды
 Koda's Blossom Seed Pouch,Мешочек семян цветка Коды
@@ -346,7 +346,7 @@ Lahtenda Bog Hunter,Болотный охотник Лахтенды
 Lake Doric Cache,Тайник озера Дорик
 Lake Doric Mussels,Мидии из озера Дорик
 Lake Doric Portal Scroll,Свиток портала озера Дорик
-Lake Lord Cuckoo,Озерная кукушка
+Lake Lord Cuckoo,Озёрная кукушка
 Lambent Battlelord's Hood Helm,Шлем-капюшон мерцающего владыки битвы
 Lambent Battlelord's Hood Helm Skin,Облик шлема «Капюшон сияющего военачальника»
 Lambent Sconce,Мерцающий канделябр

--- a/pn/pn_items_055.csv
+++ b/pn/pn_items_055.csv
@@ -21,7 +21,7 @@ Lead,Свинец
 Lead Dye,Краска «Свинец»
 Leadfoot Village Container,Контейнер деревни Свинцовоног
 Leaf Fossil,Окаменелый лист
-Leaf Glider,Планер «Лиственный»
+Leaf Glider,Планёр «Лиственный»
 Leafy Sea Dragon,Морской дракон-тряпичник
 Leaning Grade Runestone Rubbing,Эстампаж рунного камня наклонного склона
 Leaping Lion Statue Token,Жетон статуи «Прыгающий лев»
@@ -493,7 +493,7 @@ Lightning Jar,Банка с молнией
 Lightning Kite,Воздушный змей молнии
 Lightning Wings Backpack,Рюкзак «Крылья молнии»
 Lightning Wings Backpack and Glider Combo,Набор: рюкзак и планер «Крылья молнии»
-Lightning Wings Glider,Планер «Крылья молний»
+Lightning Wings Glider,Планёр «Крылья молний»
 Lightning in a Bottle,Молния в бутылке
 Lightning-Blessed Zephyrite Gloves,"Перчатки зефирита, благословлённые молнией"
 Lightning-Touched Zephyrite Gloves,Тронутые молнией перчатки зефирита

--- a/pn/pn_items_056.csv
+++ b/pn/pn_items_056.csv
@@ -297,7 +297,7 @@ Love of Gardening,Любовь к садоводству
 Love of Revolution,Любовь к революции
 Love of Solitude,Любовь к одиночеству
 Lovely Dandelion,Прекрасный одуванчик
-Lovestruck Anlace,Влюбленный кинжал
+Lovestruck Anlace,Влюблённый кинжал
 Lovestruck Anlace Skin,Облик кинжала «Влюблённый»
 Lovestruck Axe,Влюблённый топор
 Lovestruck Axe Skin,Облик топора «Влюблённый»
@@ -312,7 +312,7 @@ Lovestruck Greatsword Skin,Облик двуручного меча «Влюбл
 Lovestruck Hammer,Влюблённый молот
 Lovestruck Hammer Skin,Облик молота «Влюблённый»
 Lovestruck Longbow,Влюблённый длинный лук
-Lovestruck Longbow Skin,Облик длинного лука «Влюбленный»
+Lovestruck Longbow Skin,Облик длинного лука «Влюблённый»
 Lovestruck Mace,Влюблённая булава
 Lovestruck Mace Skin,Шкура булавы Влюбленного
 Lovestruck Pistol,Влюблённый пистолет
@@ -322,11 +322,11 @@ Lovestruck Protector Skin,Облик «Влюблённый защитник»
 Lovestruck Rifle,Влюблённая винтовка
 Lovestruck Rifle Skin,Облик винтовки «Влюблённый»
 Lovestruck Scepter,Влюблённый скипетр
-Lovestruck Scepter Skin,Облик скипетра «Влюбленный»
+Lovestruck Scepter Skin,Облик скипетра «Влюблённый»
 Lovestruck Short Bow,Влюблённый короткий лук
-Lovestruck Short Bow Skin,Облик короткого лука «Влюбленный»
+Lovestruck Short Bow Skin,Облик короткого лука «Влюблённый»
 Lovestruck Staff,Влюблённый посох
-Lovestruck Staff Skin,Облик посоха «Влюбленный»
+Lovestruck Staff Skin,Облик посоха «Влюблённый»
 Lovestruck Sword,Влюблённый меч
 Lovestruck Sword Skin,Облик меча «Влюблённый»
 Lovestruck Weapon Box,Коробка с оружием Влюбленного
@@ -488,8 +488,8 @@ Luminous Medium Pauldrons,Светящиеся средние наплечник
 Luminous Partisan,Сияющая партизанская алебарда
 Luminous Pillar,Сияющий столб
 Luminous Prehistoric Siege Turtle,Сияющая доисторическая осадная черепаха
-Luminous Prowler,Сияющий мародер
-Luminous Raider,Сияющий налетчик
+Luminous Prowler,Сияющий мародёр
+Luminous Raider,Сияющий налётчик
 Luminous Ray,Сияющий скат
 Luminous Repeater,Сияющий револьвер
 Luminous Roller,Сияющий роллер

--- a/pn/pn_items_057.csv
+++ b/pn/pn_items_057.csv
@@ -54,7 +54,7 @@ Lunar Astrolabe Warhorn Skin,Облик боевого рога «Лунная �
 Lunar Backpack,Лунный рюкзак
 Lunar Backpack and Glider Combo,Лунный набор: рюкзак и планер
 Lunar Gift Box,Лунная подарочная коробка
-Lunar Glider,Планер «Лунный»
+Lunar Glider,Планёр «Лунный»
 Lunar Maned Skyscale,Лунный гривастый скайскейл
 Lunar Maned Skyscale Skin,Шкура лунного гривистого скайскейла
 Lunar New Year Firework,Фейерверк Лунного Нового года
@@ -134,7 +134,7 @@ Lyssa's Regalia,Регалии Лиссы
 Lyssa's Regalia Outfit,Наряд «Регалия Лиссы»
 Macabre Pistol,Зловещий пистолет
 Macaw Wings Backpack,Рюкзак «Крылья ары»
-Macaw Wings Glider,Планер «Крылья ара»
+Macaw Wings Glider,Планёр «Крылья ара»
 Macaw Wings Glider Combo,Комбо-планер «Крылья ары»
 Mace,Булава
 Mace Token,Жетон булавы
@@ -425,7 +425,7 @@ Magi's Krytan Warhammer,Военный молот крайтанского ма�
 Magi's Krytan Warhorn,Боевой рог мага из Крайты
 Magi's Luminescent Jerkin,Светящийся камзол мага
 Magi's Luminescent Vestments,Сияющие одеяния мага
-Magi's Marauder Mask,Маска мага-мародера
+Magi's Marauder Mask,Маска мага-мародёра
 Magi's Orichalcum Imbued Inscription,Пропитанная орихалковая гравировка мага
 Magi's Pearl Bludgeoner,Жемчужная булава мага
 Magi's Pearl Blunderbuss,Жемчужный мушкетон мага

--- a/pn/pn_items_061.csv
+++ b/pn/pn_items_061.csv
@@ -87,7 +87,7 @@ Miasma Research,Исследование миазмов
 Michotl Tribe's Herbs,Травы племени Мичотль
 Midday,Полдень
 Midday Dye,Краска «Полуденная»
-Middleweight Hatchling,Средневесный детеныш
+Middleweight Hatchling,Средневесный детёныш
 Midnight Blue,Полуночный синий
 Midnight Blue Dye,Краска «Полуночный синий»
 Midnight Bronze,Полуночная бронза
@@ -309,15 +309,15 @@ Mighty Soft Wood Torch of Smoldering,Мощный факел из мягкой �
 Mighty Soft Wood Warhorn,Мощный мягкодревесный боевой рог
 Mighty Soft Wood Warhorn of Debility,Мощный боевой рог из мягкой древесины немощи
 Mighty Soft Wood Warhorn of Ogre Slaying,Мощный боевой рог из мягкой древесины для убийства огров
-Mighty Sparrowcatcher,Мощный ловец воробьев
+Mighty Sparrowcatcher,Мощный ловец воробьёв
 Mighty Speargun,Мощное гарпунное ружьё
 Mighty Staff,Мощный посох
 Mighty Steam Speargun,Мощное паровое гарпунное ружьё
 Mighty Steam Speargun of Smoldering,Мощное паровое ружьё тления
 Mighty Studded Boots,Мощные кованые сапоги
 Mighty Studded Coat,Мощная стёганая куртка
-Mighty Studded Gloves,Мощные клепаные перчатки
-Mighty Studded Pants,Мощные клепаные штаны
+Mighty Studded Gloves,Мощные клёпаные перчатки
+Mighty Studded Pants,Мощные клёпаные штаны
 Mighty Supplejack,Мощный суппледжек
 Mighty Swindler Boots of Divinity,Мощные сапоги мошенника божественности
 Mighty Swindler Boots of the Lich,Мощные сапоги мошенника Лича
@@ -407,9 +407,9 @@ Mini Arsenite Assault Knight,Мини арсенитный штурмовой р
 Mini Astral Ward Livia,Мини Ливия Astral Ward
 Mini Augmented Steward of Galdra,Мини улучшенный стюард Галдры
 Mini Augmented Swiftwing,Мини усиленный быстрокрыл
-Mini Awakened Abomination,Мини Пробужденная мерзость
+Mini Awakened Abomination,Мини Пробуждённая мерзость
 Mini Awakened Archer,Мини Пробуждённый лучник
-Mini Awakened Canid,Мини Пробужденный псоглав
+Mini Awakened Canid,Мини Пробуждённый псоглав
 Mini Awakened Canid Champion,Мини Пробуждённый чемпион-канид
 Mini Awakened Death Seer,Мини Пробуждённый провидец смерти
 Mini Awakened Elite Archer,Мини Пробуждённый элитный лучник
@@ -463,8 +463,8 @@ Mini Cobalt Great Jungle Wurm Head,Мини-голова кобальтовог�
 Mini Comrade Molechev,Мини-товарищ Молечев
 Mini Consortium Pacifier,Мини-консорциумный успокоитель
 Mini Corrupted,Мини-порченый
-Mini Corrupted Trahearne,Мини «Оскверненный Траэрн»
-Mini Corrupted Wolverine Spirit,Мини-дух оскверненного росомахи
+Mini Corrupted Trahearne,Мини «Осквернённый Траэрн»
+Mini Corrupted Wolverine Spirit,Мини-дух осквернённого росомахи
 Mini Crecia Stoneglow,Мини Кресия Камнесвет
 Mini Cuckoo Hatchling Reward Chest,Сундук с наградой за мини-птенца кукушки
 Mini Dagda,Мини Дагда

--- a/pn/pn_items_062.csv
+++ b/pn/pn_items_062.csv
@@ -24,7 +24,7 @@ Mini Malice Swordshadow,Мини Малис Свордшэдоу
 Mini Marjory Delaqua,Мини Марджори Делаква
 Mini Master Sergeant Shadi,Мини Мастер-сержант Шади
 Mini Modniir Berserker,Мини Модниир-берсерк
-Mini Molten Firestorm,Мини Раскаленный огненный шторм
+Mini Molten Firestorm,Мини Раскалённый огненный шторм
 Mini Moose,Мини Лось
 Mini Mordant Crescent,Мини Mordant Crescent
 Mini Mordrem Husk,Мини Мордрем-шелуха
@@ -145,7 +145,7 @@ Mini Super Assassin,Мини-супер-ассасин
 Mini Super Banana,Мини-супер-банан
 Mini Super Bee Dog,Мини-супер-собака-пчела
 Mini Super Blue Ooze,Мини-суперсиний слизевик
-Mini Super Choya Miner,Мини-супер Шахтер Чойя
+Mini Super Choya Miner,Мини-супер Шахтёр Чойя
 Mini Super Frog,Мини-супер Лягушка
 Mini Super Goat,Мини-супер-козёл
 Mini Super Green Ooze,Мини-«Супер зелёная слизь»
@@ -195,13 +195,13 @@ Mini Toy Soldier,Мини-игрушечный солдатик
 Mini Trahearne,Мини Трахёрн
 Mini Tsuru Whitewing,Мини-Цуру Белокрылый
 Mini Turai Ossa,Мини Турай Осса
-Mini Turtle Hatchling Reward Chest,Мини-сундук с наградой за детеныша черепахи
+Mini Turtle Hatchling Reward Chest,Мини-сундук с наградой за детёныша черепахи
 Mini Twisted Horror,Мини-искажённый ужас
 Mini Twisted Mender,Мини-искажённый целитель
 Mini Twisted Nightmare,Мини-искажённый кошмар
 Mini Twisted Reaver,Мини-искривлённый жнец
-Mini Twisted Spirit,Мини Искаженный дух
-Mini Twisted Watchwork Moa,Мини-искривленный Часовой Моа
+Mini Twisted Spirit,Мини Искажённый дух
+Mini Twisted Watchwork Moa,Мини-искривлённый Часовой Моа
 Mini Tybalt,Мини-Тайбальт
 Mini Tybalt Leftpaw,Мини Тайбальт Леволап
 Mini Tybalt Reward Box,Мини-Наградная коробка Тибальта
@@ -233,7 +233,7 @@ Mini Watchknight,Мини Рыцарь-страж
 Mini Watchknight Mk II,Мини-страж-рыцарь Марк II
 Mini Water Djinn,Мини-водный Джинн
 Mini Weaver Folarin Oyekan,Мини-ткач Фоларин Ойекан
-Mini Whisper of Jormag,Мини Шепот Йормага
+Mini Whisper of Jormag,Мини Шёпот Йормага
 Mini Whispers Creator,Мини Творец Шепчущих
 Mini Whispers Keeper,Мини Хранитель Шепчущих
 Mini Whispers Lightbringer,Мини Светоносец Шепчущих
@@ -249,8 +249,8 @@ Mini White Springer Kit,Мини-белый детёныш спрингера
 Mini Wind Rider,Мини Ветрокрыл
 Mini Wintersday Cheer Freezie,Мини-Замороженная радость Зимнего дня
 Mini Wolfborn,Мини Волчий Род
-Mini Wolfborn Berserker,Мини-берсерк Волкорожденных
-Mini Wolfborn Hunter,Мини-охотник Волкорожденных
+Mini Wolfborn Berserker,Мини-берсерк Волкорождённых
+Mini Wolfborn Hunter,Мини-охотник Волкорождённых
 Mini Wolfborn Shaman,Мини-шаман Волкорождённых
 Mini Wrathbringer,Мини-Гневоприносящий
 Mini Wyvern,Мини Виверна
@@ -273,8 +273,8 @@ Mini Zojja,Мини Зоджа
 Mini Zommoros,Мини Зомморос
 Mini-moa Egg,Яйцо мини-моа
 Miniaturized Skiff Engine,Миниатюрный двигатель для скользящей лодки
-Mining Hammer,Шахтерский молот
-Mining Lantern,Шахтерский фонарь
+Mining Hammer,Шахтёрский молот
+Mining Lantern,Шахтёрский фонарь
 Mining Pick of Bounty,Кирка изобилия
 Mining Rig Operator's Seat,Сиденье оператора буровой установки
 Mining Suit Operations Manual,Руководство по эксплуатации шахтерского костюма
@@ -286,7 +286,7 @@ Minister Li's Magnificent Coffer,«Великолепный ларец мини�
 Minister's Hat,Шляпа министра
 Minor Blessing of Otter,Малое благословение выдры
 Minor Kodan Cache,Малый тайник кодана
-Minor Potion of Branded Slaying,Малое зелье убийства клейменых
+Minor Potion of Branded Slaying,Малое зелье убийства клеймёных
 Minor Potion of Centaur Slaying,Малое зелье убийства кентавров
 Minor Potion of Demon Slaying,Малое зелье убийства демонов
 Minor Potion of Destroyer Slaying,Малое зелье убийства разрушителей

--- a/pn/pn_items_063.csv
+++ b/pn/pn_items_063.csv
@@ -367,7 +367,7 @@ Mordrem Fang Extraction Device,Устройство извлечения клы�
 Mordrem Focus,Фокус Мордрема
 Mordrem Focus Skin,Облик фокуса Мордрема
 Mordrem Fragment,Фрагмент Мордрема
-Mordrem Glider,Планер «Мордрем»
+Mordrem Glider,Планёр «Мордрем»
 Mordrem Greatsword,Мордремский двуручный меч
 Mordrem Greatsword Skin,Облик мордремского двуручного меча
 Mordrem Hammer,Молот Мордрема
@@ -377,7 +377,7 @@ Mordrem Husk Bladder,Мочевой пузырь оболочки мордрем
 Mordrem Husk Eye,Глаз модремской оболочки
 Mordrem Husk Fang,Клык модремового стручка
 Mordrem Husk Kidney,Почка мордремовской оболочки
-Mordrem Husk Spleen,Селезенка мордрем-оболочки
+Mordrem Husk Spleen,Селезёнка мордрем-оболочки
 Mordrem Husk Tendon,Сухожилие модремута-шелухи
 Mordrem Kidney Extraction Device,Устройство извлечения почек модремов
 Mordrem Lodestone,Камень душ Мордремота

--- a/pn/pn_items_064.csv
+++ b/pn/pn_items_064.csv
@@ -304,7 +304,7 @@ Naegling,Нэглинг
 Naga Cache,Нага-сундук
 Naga Fang,Клык нага
 Naga Spirit Backpack Skin,Облик рюкзака «Дух нага»
-Naga Spirit Glider,Планер «Дух Наги»
+Naga Spirit Glider,Планёр «Дух Наги»
 Naga Spirit Glider Skin,Облик планера «Дух нага»
 Nakis and Zohaqan's Tree,Дерево Накиса и Зохакана
 Nakis's Bracelet,Браслет Накиса
@@ -393,7 +393,7 @@ Necrotic Essence Torch,Факел некротической эссенции
 Necrotic Essence Torch Skin,Облик факела «Некротическая эссенция»
 Necrotic Essence Warhorn,Боевой рог «Некротическая эссенция»
 Necrotic Essence Warhorn Skin,Облик боевого рога «Некротическая эссенция»
-Necrotic Glider,Планер «Некротический»
+Necrotic Glider,Планёр «Некротический»
 Necrotic Graft,Некротический трансплантат
 Nectar,Нектар
 Nectar Dye,Краска «Нектарный»
@@ -457,7 +457,7 @@ Nevermore Vol. 4,Никогдаболь. Том 4
 New Horizons Supply Drop Requisition,Реквизиция поставок «Новые горизонты»
 New Kaineng Axe,Новый кайненгский топор
 New Kaineng Axe Skin,Облик топора «Новый Кайнен»
-New Kaineng Cape Glider,Планер «Плащ Нового Кайненга»
+New Kaineng Cape Glider,Планёр «Плащ Нового Кайненга»
 New Kaineng City: Commander's Choice Chest,«Новый Каиненг: Сундук выбора командира»
 New Kaineng City: Hero's Choice Chest,Сундук выбора героя Нового Каиненга
 New Kaineng Dagger,Кинжал Нового Каиненга

--- a/pn/pn_items_065.csv
+++ b/pn/pn_items_065.csv
@@ -79,17 +79,17 @@ Nightmare Vine Worm Loot Box,Коробка с добычей червя-лоз�
 Nightmare Warhammer,Боевой молот Кошмара
 Nightmare Warhorn,Кошмарный боевой рог
 Nightmare's Legacy,Наследие Кошмара
-Nightshade Boots,Сапоги паслена
+Nightshade Boots,Сапоги паслёна
 Nightshade Coat,Куртка паслёна
 Nightshade Gloves,Перчатки паслёна
 Nightshade Helm,Шлем ночной тени
-Nightshade Leggings,Поножи паслена
+Nightshade Leggings,Поножи паслёна
 Nightshade Shoulderguards,Наплечники Ночной тени
 Nightsong,Ночная песнь
 Nightsong Dye,Краска «Песнь ночи»
 Nightspeaker Greatsword,Двуручный меч Ночного вещателя
 Nightspeaker Greatsword Skin,Облик двуручного меча «Ночной вещатель»
-Nightspeaker Wings Glider,Планер «Крылья Ночного вестника»
+Nightspeaker Wings Glider,Планёр «Крылья Ночного вестника»
 Nightwing,Ночное Крыло
 Nika Mini Reward Box,Мини-коробка с наградой Ники
 Nika Reward Box,Коробка с наградой Ники
@@ -424,11 +424,11 @@ Oiled Gossamer Pant Panel,Масляная паутинная панель шт�
 Oiled Gossamer Shoe Sole,Промасленная подошва из паучьего шёлка
 Oiled Gossamer Shoe Upper,Промасленный верх обуви из паутины
 Oiled Hardened Boot Sole,Промасленная кожаная подошва сапога
-Oiled Hardened Boot Upper,Промасленный верх закаленного сапога
+Oiled Hardened Boot Upper,Промасленный верх закалённого сапога
 Oiled Hardened Glove Lining,Масляная подкладка для закалённых перчаток
-Oiled Hardened Glove Panel,Масляная закаленная перчатка-панель
+Oiled Hardened Glove Panel,Масляная закалённая перчатка-панель
 Oiled Hardened Helmet Padding,Масляная прокладка закалённого шлема
-Oiled Hardened Helmet Strap,Масленый закаленный ремешок шлема
+Oiled Hardened Helmet Strap,Масленый закалённый ремешок шлема
 Oiled Hardened Longcoat Padding,Промасленная закалённая прокладка длинного плаща
 Oiled Hardened Longcoat Panel,Пропитанная маслом закалённая панель длиннополого пальто
 Oiled Hardened Shoulderguard Padding,Промасленная набивка закалённого наплечника

--- a/pn/pn_items_067.csv
+++ b/pn/pn_items_067.csv
@@ -348,7 +348,7 @@ Painter's Brilliance Dagger,Кинжал сияния художника
 Painter's Brilliance Dagger Skin,Облик кинжала «Блеск художника»
 Painter's Brilliance Focus,Фокус сияния художника
 Painter's Brilliance Focus Skin,Облик фокуса «Блеск художника»
-Painter's Brilliance Glider,Планер «Блеск художника»
+Painter's Brilliance Glider,Планёр «Блеск художника»
 Painter's Brilliance Greatsword,Двуручный меч сияния художника
 Painter's Brilliance Greatsword Skin,Облик двуручного меча «Блеск художника»
 Painter's Brilliance Hammer,Молот сияния художника

--- a/pn/pn_items_068.csv
+++ b/pn/pn_items_068.csv
@@ -148,13 +148,13 @@ Peerless Assaulter Greatbow,Большой лук непревзойденног
 Peerless Assaulter Torch,Факел непревзойденного штурмовика
 Peerless Defender Greatbow,Большой лук непревзойденного защитника
 Peerless Defender Torch,Факел непревзойденного защитника
-Peerless Greatbow,Непревзойденный большой лук
+Peerless Greatbow,Непревзойдённый большой лук
 Peerless Healer Greatbow,Большой лук непревзойденного целителя
-Peerless Healer Torch,Факел целителя «Непревзойденный»
+Peerless Healer Torch,Факел целителя «Непревзойдённый»
 Peerless Infusion,Непревзойденная инфузия
-Peerless Malicious Greatbow,Непревзойденный злобный большой лук
-Peerless Malicious Torch,Непревзойденный злобный факел
-Peerless Torch,Непревзойденный факел
+Peerless Malicious Greatbow,Непревзойдённый злобный большой лук
+Peerless Malicious Torch,Непревзойдённый злобный факел
+Peerless Torch,Непревзойдённый факел
 Peg Leg Screw,Винт деревянной ноги
 Peg-Leg Boots,Сапоги-протезы
 Peg-Leg Boots Skin,Облик сапог «Деревянная нога»
@@ -219,7 +219,7 @@ Penetrating Aureate Warhammer of Ogre Slaying,Пронзающий золочё�
 Penetrating Aureate Warhorn of Battle,Пронзающий золочёный боевой рог битвы
 Penetrating Aureate Warhorn of Earth,Пронзающий золочёный боевой рог земли
 Penetrating Aureate Warhorn of Ogre Slaying,Пронзающий золочёный боевой рог истребления огров
-Penetrating Black Earth Aquabreather of the Citadel,Проникающий черноземный аквадыхатель цитадели
+Penetrating Black Earth Aquabreather of the Citadel,Проникающий чернозёмный аквадыхатель цитадели
 Penetrating Boots,Пробивающие сапоги
 Penetrating Cabalist Boots,Проникающие сапоги кабалиста
 Penetrating Cabalist Coat,Проникающая куртка кабалиста

--- a/pn/pn_items_069.csv
+++ b/pn/pn_items_069.csv
@@ -25,7 +25,7 @@ Personal Gyrocopter Chair Glider Combo,Персональный гирокопт
 Personal Merchant Express,Персональный торговый экспресс
 Personal Trader Express,Персональный торговый экспресс
 Personalized Homemade Lucky Envelope,Персонализированный домашний счастливый конверт
-Personalized Trick-or-Treat Bag,Персонализированный мешок «Кошелек или жизнь»
+Personalized Trick-or-Treat Bag,Персонализированный мешок «Кошелёк или жизнь»
 Personalized Wintersday Gift,Персонализированный подарок Зимнего дня
 Perspective of the Ascalonian Wall,Вид на Аскалонскую стену
 Pet Dog Whistle: Basenji,Свисток для питомца: Басенджи
@@ -76,14 +76,14 @@ Phoenix Dagger,Кинжал Феникса
 Phoenix Dagger Skin,Облик кинжала «Феникс»
 Phoenix Focus,Фокус Феникса
 Phoenix Focus Skin,Облик фокуса «Феникс»
-Phoenix Glider,Планер «Феникс»
+Phoenix Glider,Планёр «Феникс»
 Phoenix Glove Skin,Облик перчаток феникса
 Phoenix Gloves,Перчатки Феникса
 Phoenix Greatsword,Двуручный меч Феникса
 Phoenix Greatsword Skin,Облик двуручного меча «Феникс»
 Phoenix Hammer,Молот Феникса
 Phoenix Hammer Skin,Раскраска «Феникс» (молот)
-Phoenix Kite Glider,Планер «Воздушный змей Феникса»
+Phoenix Kite Glider,Планёр «Воздушный змей Феникса»
 Phoenix Light Armor Skin,Облик лёгкой брони «Феникс»
 Phoenix Longbow,Длинный лук Феникса
 Phoenix Longbow Skin,Облик длинного лука «Феникс»
@@ -309,7 +309,7 @@ Pinnacle Wake,Вершина пробуждения
 Pinnacle Wake Skin,Облик пробуждения «Пик»
 Pinnacle Ward,Вершинный оберег
 Pinnacle Ward Skin,Облик нагрудника «Вершина»
-Pinweight Hatchling,Детеныш-легковес
+Pinweight Hatchling,Детёныш-легковес
 Piranha's Bite,Укус пираньи
 "Pirate ""Fork""",Пиратская «Вилка»
 Pirate Axe,Пиратский топор
@@ -328,7 +328,7 @@ Pirate Crescent,Пиратский полумесяц
 Pirate Crook,Пиратский посох
 Pirate Cutlass,Пиратская абордажная сабля
 Pirate Flask,Пиратская фляга
-Pirate Flintlock,Пиратский кремневый пистолет
+Pirate Flintlock,Пиратский кремнёвый пистолет
 Pirate Handblade,Пиратский ручной клинок
 Pirate Hard Tack,Пиратский сухарь
 Pirate Harpoon,Пиратский гарпун

--- a/pn/pn_items_070.csv
+++ b/pn/pn_items_070.csv
@@ -466,7 +466,7 @@ Prepare for the Worst,Приготовиться к худшему
 Presence of the Keep Improvement,Присутствие улучшения крепости
 Preserved Bat Wing,Консервированное крыло летучей мыши
 Preserved Lucky Four-Leaf Clover,Сохранившийся счастливый четырехлистный клевер
-Preserved Queen Bee,Сохраненная королева пчел
+Preserved Queen Bee,Сохраненная королева пчёл
 Preserved Red Cap,Сохранившаяся красная шапочка
 Press Button,Нажмите кнопку
 Pressed Friendship Flower,Сплющенный цветок дружбы

--- a/pn/pn_items_071.csv
+++ b/pn/pn_items_071.csv
@@ -306,7 +306,7 @@ Purchase for karma and snowflakes during Wintersday.,Купить за карм�
 Purchased and spent via the Black Lion Trading Company.,Приобретается и тратится через Black Lion Trading Company.
 Purchased in Bava Nisos.,Куплено в Бава Нисос.
 Purge Signet (Infused),Очищающий знак (насыщенный)
-Purified Branded Aether,Очищенный заклейменный эфир
+Purified Branded Aether,Очищенный заклеймённый эфир
 Purified Destroyer Aether,Очищенный эфир уничтожителя
 Purified Essence of Generosity,Очищенная сущность щедрости
 Purified Essence of Resolve,Очищенная сущность решимости
@@ -350,11 +350,11 @@ PvP Player Loot Box,Коробка с добычей игрока PvP
 PvP Prize Package,Набор призов PvP
 PvP Qualifier Prizes: 5th through 8th Place,Призы за квалификацию PvP: с 5-го по 8-е место
 PvP Qualifier Prizes: First and Second Place,Призы рейтинговых матчей PvP: первое и второе места
-PvP Qualifier Prizes: Third and Fourth Place,Призы за квалификацию в PvP: третье и четвертое место
+PvP Qualifier Prizes: Third and Fourth Place,Призы за квалификацию в PvP: третье и четвёртое место
 PvP Salvage Kit,Набор для разбора PvP
 PvP Tournament Voucher,Ваучер PvP-турнира
 Pyramid Card,Пирамидальная карта
-Pyre,Костер
+Pyre,Костёр
 Pyre Circlet Helm Skin,Облик шлема «Венец костра»
 Pyre Dye,Краска «Погребальный костер»
 Pyre Fierceshot Arrowhead,Наконечник стрелы Пира Огненного Выстрела
@@ -425,7 +425,7 @@ Quetzal Cache,Тайник кетцаля
 Quetzal Commander's Cache,Тайник командира кетцалей
 Quetzal Crest,Гребень Кетцаль
 Quetzal Harpoon,Гарпун Кетцаль
-Quetzal Speargun,Копьемет кетцаля
+Quetzal Speargun,Копьемёт кетцаля
 Quetzal Trident,Трезубец кетцаля
 Quiche of Darkness,Киш Тьмы
 Quiche of Darkness Vegetable Mix,Овощная смесь Киша Тьмы
@@ -475,7 +475,7 @@ Rabid Aureate Charm,Бешеный ауреатный оберег
 Rabid Aureate Dirk,Бешеный ауреатный кинжал
 Rabid Aureate Highlander Greatsword,Бешеный золотой двуручный меч горца
 Rabid Aureate Longbow,Бешеный ауратный длинный лук
-Rabid Aureate Mace,Бешеная золоченая булава
+Rabid Aureate Mace,Бешеная золочёная булава
 Rabid Aureate Musket,Бешеный ауреатовый мушкет
 Rabid Aureate Pistol,Бешеный золотой пистолет
 Rabid Aureate Rinblade,Бешеный золотой ринблейд

--- a/pn/pn_items_072.csv
+++ b/pn/pn_items_072.csv
@@ -126,11 +126,11 @@ Rabid Exalted Gloves,Бешеные перчатки возвышенных
 Rabid Exalted Mantle,Бешеная возвышенная мантия
 Rabid Exalted Masque,Бешеная возвышенная маска
 Rabid Exalted Pants,Бешеные возвышенные штаны
-Rabid Firstborn Boots,Бешеные сапоги перворожденного
+Rabid Firstborn Boots,Бешеные сапоги перворождённого
 Rabid Firstborn Coat,Бешеная куртка перворождённого
 Rabid Firstborn Gloves,Первородные перчатки бешенства
-Rabid Firstborn Helm,Шлем бешеного перворожденного
-Rabid Firstborn Leggings,Бешеные поножи перворожденного
+Rabid Firstborn Helm,Шлем бешеного перворождённого
+Rabid Firstborn Leggings,Бешеные поножи перворождённого
 Rabid Firstborn Shoulderguards,Бешеные наплечники первенца
 Rabid Glyphic Axe,Бешеный глифический топор
 Rabid Glyphic Brand,Бешеное глифическое клеймо
@@ -200,12 +200,12 @@ Rabid Mist Walker Coat,Бешеная куртка странника туман
 Rabid Mist Walker Gloves,Бешеные перчатки ходящего в тумане
 Rabid Mist Walker Leggings,Бешеные поножи хранителя туманов
 Rabid Mist Walker Shoulders,Бешеные плечи туманного странника
-Rabid Nightshade Boots,Бешеные сапоги паслена
+Rabid Nightshade Boots,Бешеные сапоги паслёна
 Rabid Nightshade Coat,Бешеная куртка паслёна
-Rabid Nightshade Gloves,Перчатки бешеного паслена
-Rabid Nightshade Helm,Бешеный шлем паслена
+Rabid Nightshade Gloves,Перчатки бешеного паслёна
+Rabid Nightshade Helm,Бешеный шлем паслёна
 Rabid Nightshade Leggings,Поножи бешеной белены
-Rabid Nightshade Shoulderguards,Наплечники «Бешеный паслен»
+Rabid Nightshade Shoulderguards,Наплечники «Бешеный паслён»
 Rabid Oaken Boots,Бешеные дубовые ботинки
 Rabid Oaken Coat,Бешеная дубовая куртка
 Rabid Oaken Gloves,Бешеные дубовые перчатки
@@ -300,7 +300,7 @@ Rabid Soft Wood Warhorn,Бешеный боевой рог из мягкой д�
 Rabid Spineguard,Защитник позвоночника бешенства
 Rabid Steam Speargun,Бешеный паровой гарпун
 Rabid Tempered Scale Chestplate of the Revenant,Бешеная закалённая чешуйчатая кираса ревенанта
-Rabid Tempered Scale Gauntlets of the Revenant,Бешеные перчатки из каленой чешуи ревенанта
+Rabid Tempered Scale Gauntlets of the Revenant,Бешеные перчатки из калёной чешуи ревенанта
 Rabid Tempered Scale Greaves of the Revenant,Бешеные закалённые наголенники чешуи ревенанта
 Rabid Tempered Scale Legs of the Revenant,Бешеные чешуйчатые поножи Отступника
 Rabid Tempered Scale Pauldrons of the Revenant,Бешеные наплечники из калёной чешуи ревенанта

--- a/pn/pn_items_073.csv
+++ b/pn/pn_items_073.csv
@@ -355,8 +355,8 @@ Rampager's Krait Warhammer,Боевой молот «Крайт» яростно
 Rampager's Krait Whelk,Крайт-улитка Буяна
 Rampager's Linen Insignia,Льняная инсигния Буяна
 Rampager's Marauder Mask of Balthazar,Маска грабителя Бальтазара Буяна
-Rampager's Marauder Mask of Infiltration,Маска прорывающего вражеские ряды мародера
-Rampager's Marauder Mask of Rata Sum,Маска мародера Рата Сума
+Rampager's Marauder Mask of Infiltration,Маска прорывающего вражеские ряды мародёра
+Rampager's Marauder Mask of Rata Sum,Маска мародёра Рата Сума
 Rampager's Masquerade Boots,Маскарадные сапоги Буяна
 Rampager's Masquerade Gloves,Маскарадные перчатки Буяна
 Rampager's Masquerade Leggings,Поножи «Маскарад ярости»

--- a/pn/pn_items_074.csv
+++ b/pn/pn_items_074.csv
@@ -341,7 +341,7 @@ Ravaging Cabalist Hood of Balthazar,Разорительный капюшон к
 Ravaging Cabalist Hood of Divinity,Опустошающий капюшон каббалиста божественности
 Ravaging Cabalist Hood of Grenth,Опустошающий капюшон кабалиста Грента
 Ravaging Cabalist Hood of Rata Sum,Опустошающий капюшон каббалиста Рата Сум
-Ravaging Cabalist Hood of Scavenging,Опустошающий капюшон каббалиста мародерства
+Ravaging Cabalist Hood of Scavenging,Опустошающий капюшон каббалиста мародёрства
 Ravaging Cabalist Hood of the Afflicted,Опустошающый кабалистский капюшон страждущего
 Ravaging Cabalist Hood of the Citadel,Опустошающий капюшон кабалиста Цитадели
 Ravaging Cabalist Hood of the Eagle,Опустошающий капюшон каббалиста орла
@@ -395,7 +395,7 @@ Ravaging Dredge Trident,«Опустошающый трезубец» дредн
 Ravaging Embroidered Cotton Insignia,Опустошающая вышитая хлопковая инсигния
 Ravaging Embroidered Wool Insignia,Опустошающая вышитая шерстяная инсигния
 Ravaging Evergreen Boots,Опустошающие вечнозелёные сапоги
-Ravaging Evergreen Coat,Опустошающая вечнозеленая куртка
+Ravaging Evergreen Coat,Опустошающая вечнозелёная куртка
 Ravaging Evergreen Gloves,Опустошающие вечнозелёные наплечники
 Ravaging Evergreen Helm,Опустошающий вечнозеленый шлем
 Ravaging Evergreen Leggings,Опустошающие вечнозелёные поножи

--- a/pn/pn_items_075.csv
+++ b/pn/pn_items_075.csv
@@ -147,7 +147,7 @@ Ravaging Magician Mask,Опустошающая маска мага
 Ravaging Magician Mask of Hoelbrak,Опустошающая маска мага Хоэлбрака
 Ravaging Magician Mask of Rata Sum,Опустошающая маска мага Рата Сум
 Ravaging Magician Mask of the Traveler,Опустошающая маска мага путешественника
-Ravaging Marauder Mask of Infiltration,Опустошающая маска мародера проникновения
+Ravaging Marauder Mask of Infiltration,Опустошающая маска мародёра проникновения
 Ravaging Masquerade Boots,Опустошающие ботинки маскарада
 Ravaging Masquerade Gloves,Опустошающые перчатки маскарада
 Ravaging Masquerade Leggings,Опустошающие маскарадные поножи
@@ -181,7 +181,7 @@ Ravaging Privateer Coat of Strength,Опустошающая куртка кап
 Ravaging Privateer Gloves of Divinity,Опустошающие перчатки капера божественности
 Ravaging Privateer Gloves of Infiltration,Опустошающие перчатки капера проникновения
 Ravaging Privateer Gloves of Mercy,Опустошающие перчатки капера милосердия
-Ravaging Privateer Gloves of Scavenging,Опустошающие перчатки капера мародерства
+Ravaging Privateer Gloves of Scavenging,Опустошающие перчатки капера мародёрства
 Ravaging Privateer Gloves of Vampirism,Опустошающие перчатки капера вампиризма
 Ravaging Privateer Gloves of the Dolyak,Опустошающие перчатки капера доллака
 Ravaging Privateer Hat of Divinity,Опустошающая шляпа капера Божественности
@@ -212,14 +212,14 @@ Ravaging Reinforced Scale Boots of Vampirism,Опустошающие усиле
 Ravaging Reinforced Scale Boots of the Eagle,Опустошающые усиленные чешуйчатые сапоги орла
 Ravaging Reinforced Scale Boots of the Lich,Опустошающые усиленные чешуйчатые сапоги лича
 Ravaging Reinforced Scale Coat of Hoelbrak,Опустошающая усиленная чешуйчатая куртка Хоэлбрака
-Ravaging Reinforced Scale Coat of Mercy,Опустошающая укрепленная чешуйчатая куртка милосердия
+Ravaging Reinforced Scale Coat of Mercy,Опустошающая укреплённая чешуйчатая куртка милосердия
 Ravaging Reinforced Scale Coat of Rage,Опустошающая укреплённая чешуйчатая куртка ярости
-Ravaging Reinforced Scale Coat of Strength,Опустошающая укрепленная чешуйчатая куртка силы
+Ravaging Reinforced Scale Coat of Strength,Опустошающая укреплённая чешуйчатая куртка силы
 Ravaging Reinforced Scale Coat of the Afflicted,Опустошающая усиленная чешуйчатая куртка одержимого
 Ravaging Reinforced Scale Coat of the Eagle,Опустошающая усиленная чешуйчатая куртка Орла
 Ravaging Reinforced Scale Gauntlets of Divinity,Опустошающые усиленные чешуйчатые рукавицы божественности
 Ravaging Reinforced Scale Gauntlets of Infiltration,Опустошающые усиленные чешуйчатые перчатки проникновения
-Ravaging Reinforced Scale Gauntlets of the Centaur,Опустошающие укрепленные чешуйчатые перчатки кентавра
+Ravaging Reinforced Scale Gauntlets of the Centaur,Опустошающие укреплённые чешуйчатые перчатки кентавра
 Ravaging Reinforced Scale Gauntlets of the Citadel,Опустошающые чешуйчатые рукавицы Цитадели из усиленной стали
 Ravaging Reinforced Scale Gauntlets of the Dolyak,Опустошающые усиленные чешуйчатые перчатки из дояка
 Ravaging Reinforced Scale Helm of Divinity,Опустошающий усиленный чешуйчатый шлем божественности
@@ -232,7 +232,7 @@ Ravaging Reinforced Scale Helm of the Flock,Опустошающий усиле�
 Ravaging Reinforced Scale Helm of the Grove,Опустошающий укреплённый чешуйчатый шлем рощи
 Ravaging Reinforced Scale Helm of the Traveler,Опустошающий укреплённый чешуйчатый шлем путешественника
 Ravaging Reinforced Scale Legs of Divinity,Опустошающые усиленные чешуйчатые поножи божественности
-Ravaging Reinforced Scale Legs of Hoelbrak,Опустошающые усиленные чешуйчатые поножи Хельбрейка
+Ravaging Reinforced Scale Legs of Hoelbrak,Опустошающые усиленные чешуйчатые поножи Хёльбрейка
 Ravaging Reinforced Scale Legs of Lyssa,Опустошающие укреплённые чешуйчатые штаны Лиссы
 Ravaging Reinforced Scale Legs of the Citadel,Опустошающые усиленные чешуйчатые поножи цитадели
 Ravaging Reinforced Scale Legs of the Dolyak,Опустошающие усиленные чешуйчатые поножи дойяка
@@ -427,10 +427,10 @@ Ravaging Steel Rifle,Опустошающая стальная винтовка
 Ravaging Steel Shield,Опустошающий стальной щит
 Ravaging Steel Spear,Опустошающее стальное копьё
 Ravaging Steel Sword,Опустошающий стальной меч
-Ravaging Studded Boots,Опустошающие клепаные сапоги
+Ravaging Studded Boots,Опустошающие клёпаные сапоги
 Ravaging Studded Coat,Опустошающая шипованная куртка
-Ravaging Studded Gloves,Опустошающие клепаные перчатки
-Ravaging Studded Pants,Опустошающие клепаные штаны
+Ravaging Studded Gloves,Опустошающие клёпаные перчатки
+Ravaging Studded Pants,Опустошающие клёпаные штаны
 Ravaging Student Circlet,Опустошающий ученический венец
 Ravaging Student Coat,Опустошающая студенческая куртка
 Ravaging Student Gloves,Опустошающие студенческие перчатки

--- a/pn/pn_items_076.csv
+++ b/pn/pn_items_076.csv
@@ -63,7 +63,7 @@ Raven Tonic,Вороний тоник
 Raven Vest Skin,Облик жилета «Ворон»
 Raven's Gift,«Дар Ворона»
 Raven's Power,Сила Ворона
-Raven's Spirit Glider,Планер «Дух Ворона»
+Raven's Spirit Glider,Планёр «Дух Ворона»
 Raven-Blessed Visage,"Лик, благословлённый Вороном"
 Raven-Blessed Visage Box,"Коробка с ликом, благословлённым Вороном"
 Ravengift,Вороний Дар
@@ -244,25 +244,25 @@ Recipe: Ars Goetia,Рецепт: арс Гоетия
 Recipe: Ascalon Ghost Potion,Рецепт: зелье «Призрак Аскалона»
 Recipe: Ascalonian Herbs,Рецепт: аскалонские травы
 Recipe: Ascended Axe,Рецепт: рецепт: Вознесённый топор
-Recipe: Ascended Dagger,Рецепт: вознесенный кинжал
+Recipe: Ascended Dagger,Рецепт: вознесённый кинжал
 Recipe: Ascended Focus,Рецепт: вознесённый фокус
 Recipe: Ascended Greatsword,Рецепт: вознесённый двуручный меч
 Recipe: Ascended Hammer,Рецепт: вознесённый молот
 Recipe: Ascended Harpoon Gun,Рецепт: вознесённый гарпунный пистолет
 Recipe: Ascended Heavy Boots,Рецепт: вознесённые тяжёлые сапоги
-Recipe: Ascended Heavy Coat,Рецепт: вознесенная тяжёлая куртка
+Recipe: Ascended Heavy Coat,Рецепт: вознесённая тяжёлая куртка
 Recipe: Ascended Heavy Gloves,Рецепт: вознесённые тяжёлые перчатки
-Recipe: Ascended Heavy Helm,Рецепт: вознесенный тяжёлый шлем
+Recipe: Ascended Heavy Helm,Рецепт: вознесённый тяжёлый шлем
 Recipe: Ascended Heavy Leggings,Рецепт: рецепт «Вознесенные тяжёлые поножи»
 Recipe: Ascended Heavy Shoulders,Рецепт: вознесённые тяжёлые наплечники
-Recipe: Ascended Inscription,Рецепт: вознесенная гравировка
-Recipe: Ascended Insignia,Рецепт: рецепт «Вознесенная инсигния»
+Recipe: Ascended Inscription,Рецепт: вознесённая гравировка
+Recipe: Ascended Insignia,Рецепт: рецепт «Вознесённая инсигния»
 Recipe: Ascended Light Boots,Рецепт: вознесённые лёгкие ботинки
 Recipe: Ascended Light Coat,Рецепт: вознесённая лёгкая куртка
 Recipe: Ascended Light Gloves,Рецепт: вознесённые лёгкие перчатки
 Recipe: Ascended Light Helm,Рецепт: вознесённый лёгкий шлем
 Recipe: Ascended Light Leggings,Рецепт: вознесённые светлые поножи
-Recipe: Ascended Light Shoulders,Рецепт: вознесенные лёгкие наплечники
+Recipe: Ascended Light Shoulders,Рецепт: вознесённые лёгкие наплечники
 Recipe: Ascended Longbow,Рецепт: вознесённый длинный лук
 Recipe: Ascended Mace,Рецепт: вознесённая булава
 Recipe: Ascended Medium Boots,Рецепт: вознесённые средние сапоги
@@ -270,15 +270,15 @@ Recipe: Ascended Medium Coat,Рецепт: вознесённая средняя
 Recipe: Ascended Medium Gloves,Рецепт: вознесённые средние перчатки
 Recipe: Ascended Medium Helm,Рецепт: вознесённый средний шлем
 Recipe: Ascended Medium Leggings,Рецепт: вознесённые средние поножи
-Recipe: Ascended Medium Shoulders,Рецепт: вознесенные средние наплечники
+Recipe: Ascended Medium Shoulders,Рецепт: вознесённые средние наплечники
 Recipe: Ascended Pistol,Рецепт: вознесённый пистолет
 Recipe: Ascended Rifle,Рецепт: вознесённая винтовка
-Recipe: Ascended Scepter,Рецепт: вознесенный скипетр
+Recipe: Ascended Scepter,Рецепт: вознесённый скипетр
 Recipe: Ascended Shield,Рецепт: щит вознесения
 Recipe: Ascended Short Bow,Рецепт: вознесённый короткий лук
 Recipe: Ascended Spear,Рецепт: вознесённое копьё
 Recipe: Ascended Staff,Рецепт: вознесённый посох
-Recipe: Ascended Sword,Рецепт: вознесенный меч
+Recipe: Ascended Sword,Рецепт: вознесённый меч
 Recipe: Ascended Torch,Рецепт: вознесённый факел
 Recipe: Ascended Trident,Рецепт: вознесённый трезубец
 Recipe: Ascended Warhorn,Рецепт: вознесённый боевой рог
@@ -454,7 +454,7 @@ Recipe: Box of Assassin's Draconic Armor (Exotic),Рецепт: комплект
 Recipe: Box of Assassin's Gladiator Armor (Rare),Рецепт: коробка с доспехами гладиатора убийцы (Редкий)
 Recipe: Box of Assassin's Reinforced Scale Armor,Рецепт: коробка чешуйчатой брони убийцы
 Recipe: Box of Assassin's Reinforced Scale Armor (Master),Рецепт: коробка усиленной чешуйчатой брони убийцы (Мастер)
-Recipe: Box of Berserker's Barbaric Armor,Рецепт: коробка с варварской броней берсерка
+Recipe: Box of Berserker's Barbaric Armor,Рецепт: коробка с варварской бронёй берсерка
 Recipe: Box of Berserker's Barbaric Armor (Master),Рецепт: коробка варварской брони берсерка (Мастер)
 Recipe: Box of Berserker's Barbaric Armor (Rare),Рецепт: коробка берсеркской варварской брони (редкая)
 Recipe: Box of Berserker's Draconic Armor (Exotic),Рецепт: короб брони берсерка из драконьей стали (экзотика)
@@ -464,7 +464,7 @@ Recipe: Box of Berserker's Reinforced Scale Armor (Master),Рецепт: кор�
 Recipe: Box of Carrion Barbaric Armor,Рецепт: коробка брони падальщика
 Recipe: Box of Carrion Barbaric Armor (Master),Рецепт: короб варварской брони из падали (Мастер)
 Recipe: Box of Carrion Barbaric Armor (Rare),Рецепт: коробка падальщичьих варварских доспехов (Редкое)
-Recipe: Box of Carrion Draconic Armor (Exotic),Рецепт: коробка с драконьей броней падали (Экзотический)
+Recipe: Box of Carrion Draconic Armor (Exotic),Рецепт: коробка с драконьей бронёй падали (Экзотический)
 Recipe: Box of Carrion Gladiator Armor (Rare),Рецепт: коробка доспехов гладиатора из падали (Редкое)
 Recipe: Box of Carrion Reinforced Scale Armor,Рецепт: коробка армированной чешуйчатой брони трупоеда
 Recipe: Box of Carrion Reinforced Scale Armor (Master),Рецепт: коробка усиленной чешуйчатой брони из падали (Мастер)
@@ -494,7 +494,7 @@ Recipe: Box of Hunter's Gladiator Armor (Rare),Рецепт: коробка до
 Recipe: Box of Hunter's Scale Armor,Рецепт: набор чешуйчатой брони охотника
 Recipe: Box of Hunter's Scale Armor (Master),Рецепт: коробка чешуйчатой брони охотника (Мастер)
 Recipe: Box of Hunter's Splint Armor,Рецепт: коробка боевого расколотого доспеха
-Recipe: Box of Knight's Barbaric Armor,Рецепт: коробка с варварской броней рыцаря
+Recipe: Box of Knight's Barbaric Armor,Рецепт: коробка с варварской бронёй рыцаря
 Recipe: Box of Knight's Barbaric Armor (Master),Рецепт: коробка рыцарской варварской брони (Мастер)
 Recipe: Box of Knight's Barbaric Armor (Rare),Рецепт: коробка рыцарской варварской брони (редкой)
 Recipe: Box of Knight's Draconic Armor (Exotic),Рецепт: коробка драконьей брони рыцаря (Экзотика)

--- a/pn/pn_items_077.csv
+++ b/pn/pn_items_077.csv
@@ -4,14 +4,14 @@ Recipe: Box of Knight's Reinforced Scale Armor (Master),Рецепт: короб
 Recipe: Box of Malign Chain Armor,Рецепт: коробка пагубной кольчужной брони
 Recipe: Box of Malign Chain Armor (Master),Рецепт: коробка пагубней кольчужной брони (Мастер)
 Recipe: Box of Mighty Chain Armor,Рецепт: коробка прочной кольчужной брони
-Recipe: Box of Mighty Chain Armor (Master),Рецепт: коробка с могучей кольчужной броней (мастер)
+Recipe: Box of Mighty Chain Armor (Master),Рецепт: коробка с могучей кольчужной бронёй (мастер)
 Recipe: Box of Nomad's Draconic Armor,Рецепт: короб драконической брони странника
 Recipe: Box of Precise Chain Armor,Рецепт: коробка точной кольчужной брони
 Recipe: Box of Precise Chain Armor (Master),Рецепт: коробка точной кольчужной брони (мастер)
 Recipe: Box of Rampager's Barbaric Armor,Рецепт: коробка варварской брони разбойника
 Recipe: Box of Rampager's Barbaric Armor (Master),Рецепт: коробка брони варвара бесчинства (Мастер)
-Recipe: Box of Rampager's Barbaric Armor (Rare),Рецепт: коробка с варварской броней головореза (редкая)
-Recipe: Box of Rampager's Draconic Armor (Exotic),Рецепт: коробка с драконьей броней разбойника (экзотика)
+Recipe: Box of Rampager's Barbaric Armor (Rare),Рецепт: коробка с варварской бронёй головореза (редкая)
+Recipe: Box of Rampager's Draconic Armor (Exotic),Рецепт: коробка с драконьей бронёй разбойника (экзотика)
 Recipe: Box of Rampager's Gladiator Armor (Rare),Рецепт: коробка с доспехами гладиатора-грабителя (редкое)
 Recipe: Box of Rampager's Reinforced Scale Armor,Рецепт: коробка усиленной чешуйчатой брони берсерка
 Recipe: Box of Rampager's Reinforced Scale Armor (Master),Рецепт: коробка усиленной чешуйчатой брони разбойника (Мастер)
@@ -21,7 +21,7 @@ Recipe: Box of Ravaging Scale Armor (Master),Рецепт: коробка чеш
 Recipe: Box of Ravaging Splint Armor,Рецепт: коробка разорительной шинированной брони
 Recipe: Box of Rejuvenating Gladiator Armor (Rare),Рецепт: коробка восстанавливающей гладиаторской брони (редкое)
 Recipe: Box of Rejuvenating Scale Armor,Рецепт: коробка восстанавливающей чешуйчатой брони
-Recipe: Box of Rejuvenating Scale Armor (Master),Рецепт: коробка с омолаживающей чешуйчатой броней (Мастер)
+Recipe: Box of Rejuvenating Scale Armor (Master),Рецепт: коробка с омолаживающей чешуйчатой бронёй (Мастер)
 Recipe: Box of Rejuvenating Splint Armor,Рецепт: коробка восстанавливающей шинной брони
 Recipe: Box of Resilient Chain Armor,Рецепт: коробка прочной кольчужной брони
 Recipe: Box of Resilient Chain Armor (Master),Рецепт: коробка прочной кольчужной брони (мастер)
@@ -29,7 +29,7 @@ Recipe: Box of Simple Mighty Chain Armor,Рецепт: коробка прост
 Recipe: Box of Strong Gladiator Armor (Rare),Рецепт: коробка прочных доспехов гладиатора (Редкое)
 Recipe: Box of Strong Scale Armor,Рецепт: коробка прочной чешуйчатой брони
 Recipe: Box of Strong Scale Armor (Master),Рецепт: короб крепкой чешуйчатой брони (Мастер)
-Recipe: Box of Strong Splint Armor,Рецепт: коробка с прочной пластинчатой броней
+Recipe: Box of Strong Splint Armor,Рецепт: коробка с прочной пластинчатой бронёй
 Recipe: Box of Valkyrie Barbaric Armor,Рецепт: коробка варварской брони Валькирии
 Recipe: Box of Valkyrie Barbaric Armor (Master),Рецепт: коробка варварской брони Валькирии (Мастер)
 Recipe: Box of Valkyrie Barbaric Armor (Rare),Рецепт: коробка валькирийской варварской брони (редкая)
@@ -42,7 +42,7 @@ Recipe: Box of Vigorous Scale Armor,Рецепт: коробка добротн�
 Recipe: Box of Vigorous Scale Armor (Master),Рецепт: коробка бодрящей чешуйчатой брони (Мастер)
 Recipe: Box of Vigorous Splint Armor,Рецепт: коробка бодрой лубковой брони
 Recipe: Box of Vital Chain Armor,Рецепт: коробка с жизненной кольчугой
-Recipe: Box of Vital Chain Armor (Master),Рецепт: коробка с цепной броней доблести (Мастер)
+Recipe: Box of Vital Chain Armor (Master),Рецепт: коробка с цепной бронёй доблести (Мастер)
 Recipe: Box of Zealot's Draconic Armor,Рецепт: коробка драконьих доспехов фанатика
 Recipe: Brandspark Amulet,Рецепт: амулет Искры бренда
 Recipe: Brandspark Earring,Рецепт: серьга из искрогранита
@@ -312,12 +312,12 @@ Recipe: Corrupted Cudgel,Рецепт: порочная дубина
 Recipe: Corrupted Greatbow,Рецепт: осквернённый большой лук
 Recipe: Corrupted Harbinger,Рецепт: порочный предвестник
 Recipe: Corrupted Harpoon Gun,Рецепт: осквернённое гарпунное ружьё
-Recipe: Corrupted Jar,Рецепт: оскверненная банка
+Recipe: Corrupted Jar,Рецепт: осквернённая банка
 Recipe: Corrupted Revolver,Рецепт: осквернённый револьвер
 Recipe: Corrupted Scepter,Рецепт: осквернённый скипетр
 Recipe: Corrupted Shard,Рецепт: осквернённый осколок
 Recipe: Corrupted Short Bow,Рецепт: осквернённый короткий лук
-Recipe: Corrupted Skeggox,Рецепт: оскверненный скеггокс
+Recipe: Corrupted Skeggox,Рецепт: осквернённый скеггокс
 Recipe: Corrupted Sledgehammer,Рецепт: осквернённая кувалда
 Recipe: Corrupted Spear,Рецепт: осквернённое копьё
 Recipe: Corrupted Trident,Рецепт: осквернённый трезубец

--- a/pn/pn_items_078.csv
+++ b/pn/pn_items_078.csv
@@ -87,7 +87,7 @@ Recipe: Feast of Chickpea Fritters,Рецепт: пиршество из ола�
 Recipe: Feast of Chickpea Salad,Рецепт: пиршество из салата с нутом
 Recipe: Feast of Citrus Clove Meat,Рецепт: пиршество из пряного мясного блюда с гвоздикой
 Recipe: Feast of Citrus Poultry with Almonds,Рецепт: пиршество из цитрусовой птицы с миндалём
-Recipe: Feast of Clam Cakes,Рецепт: пиршество из моллюсковых лепешек
+Recipe: Feast of Clam Cakes,Рецепт: пиршество из моллюсковых лепёшек
 Recipe: Feast of Coleslaw,Рецепт: пиршество из кольслоу
 Recipe: Feast of Coriander Crusted Meat,Рецепт: пиршество из мяса в кориандровой корочке
 Recipe: Feast of Coriander Crusted Meat Dinner,Рецепт: пиршество из со мясом в корочке из кориандра
@@ -96,7 +96,7 @@ Recipe: Feast of Dill Meatball Dinners,Рецепт: пиршество из м�
 Recipe: Feast of Dilled Poultry Piccata,Рецепт: пиршество из птицы с укропом пикката
 Recipe: Feast of Divinity Stuffed Mushrooms,Рецепт: праздничные фаршированные грибы божественности
 Recipe: Feast of Eggplant Fritters,Рецепт: пиршество из баклажановыми оладьями
-Recipe: Feast of Eggplant Sautee,Рецепт: пиршество из тушеных баклажанов
+Recipe: Feast of Eggplant Sautee,Рецепт: пиршество из тушёных баклажанов
 Recipe: Feast of Eggplant Stirfry,Рецепт: пиршество из «Жаркое из баклажанов»
 Recipe: Feast of Eztlitl Stuffed Mushrooms,Рецепт: пиршество из фаршированных грибов Эцтлитля
 Recipe: Feast of Fancy Truffle Burgers,Рецепт: пиршество из изысканных трюфельных бургеров
@@ -177,7 +177,7 @@ Recipe: Ferratus's Visage,Рецепт: лик Ферратуса
 Recipe: Ferratus's Visor,Рецепт: забрало Ферратуса
 Recipe: Ferratus's Warfists,Рецепт: боевые рукавицы Ферратуса
 Recipe: Ferratus's Wristguards,Рецепт: наручи Ферратуса
-Recipe: Festive Fall Tent,Рецепт: праздничный осенний шатер
+Recipe: Festive Fall Tent,Рецепт: праздничный осенний шатёр
 Recipe: Fiery Dragon Slayer Axe,Рецепт: огненный топор «Драконоборец»
 Recipe: Fiery Dragon Slayer Dagger,Рецепт: огненный кинжал «Драконоборец»
 Recipe: Fiery Dragon Slayer Focus,Рецепт: огненный фокус «Драконоборец»
@@ -240,7 +240,7 @@ Recipe: Fried Banana Chips,Рецепт: жареные банановые чи�
 Recipe: Fried Oyster Sandwich,Рецепт: жареный бутерброд с устрицами
 Recipe: Friendship,Рецепт: дружба
 Recipe: Frigate,Рецепт: фрегат
-Recipe: Front Line Stew,Рецепт: передовая похлебка
+Recipe: Front Line Stew,Рецепт: передовая похлёбка
 Recipe: Furious Maintenance Oil,Рецепт: яростное смазочное масло
 Recipe: Furious Sharpening Stone,Рецепт: яростный точильный камень
 Recipe: Furious Tuning Crystal,Рецепт: яростный кристалл настройки
@@ -374,7 +374,7 @@ Recipe: Godskull Crosier,Рецепт: посох «Божественный ч�
 Recipe: Godskull Crusher,Рецепт: дробитель черепа бога
 Recipe: Godskull Edge,Рецепт: клинок черепа бога
 Recipe: Godskull Effigy,Рецепт: черепобожье чучело
-Recipe: Godskull Flintlock,Рецепт: кремневый пистолет «Череп бога»
+Recipe: Godskull Flintlock,Рецепт: кремнёвый пистолет «Череп бога»
 Recipe: Godskull Harpoon Gun,Рецепт: гарпунное ружьё «Череп бога»
 Recipe: Godskull Impaler,Рецепт: пронзатель Божественного Черепа
 Recipe: Godskull Kris,Рецепт: кинжал «Череп бога»

--- a/pn/pn_items_081.csv
+++ b/pn/pn_items_081.csv
@@ -157,7 +157,7 @@ Recipe: Rune of Melandru,Рецепт: руна Меландру
 Recipe: Rune of Mercy,Рецепт: руна милосердия
 Recipe: Rune of Rage,Рецепт: руна ярости
 Recipe: Rune of Rata Sum,Рецепт: руна Рата Сум
-Recipe: Rune of Scavenging,Рецепт: руна мародерства
+Recipe: Rune of Scavenging,Рецепт: руна мародёрства
 Recipe: Rune of Snowfall,Рецепт: руна снегопада
 Recipe: Rune of Strength,Рецепт: руна силы
 Recipe: Rune of Vampirism,Рецепт: руны вампиризма
@@ -238,7 +238,7 @@ Recipe: Satchel of Carrion Masquerade Armor (Rare),Рецепт: сумка ма
 Recipe: Satchel of Carrion Noble Armor (Rare),Рецепт: сумка благородной брони падальщика (редкий)
 Recipe: Satchel of Carrion Prowler Armor,Рецепт: набор доспехов стервятника-падальщика
 Recipe: Satchel of Carrion Prowler Armor (Master),Рецепт: сумка брони хищника из дерьма (Мастер)
-Recipe: Satchel of Carrion Rascal Armor,Рецепт: сумка с броней пройдохи (Падаль)
+Recipe: Satchel of Carrion Rascal Armor,Рецепт: сумка с бронёй пройдохи (Падаль)
 Recipe: Satchel of Carrion Rascal Armor (Master),Рецепт: сумка из брони Стервятника рана (Мастер)
 Recipe: Satchel of Carrion Winged Armor,Рецепт: сумка доспехов Крылатого из падали
 Recipe: Satchel of Carrion Winged Armor (Master),Рецепт: сумка брони крылатого стервятника (Мастер)
@@ -372,7 +372,7 @@ Recipe: Satchel of Strong Student Armor (Master),Рецепт: сумка про
 Recipe: Satchel of Valkyrie Emblazoned Armor (Exotic),Рецепт: сумка гербовой брони валькирии (экзотический)
 Recipe: Satchel of Valkyrie Exalted Armor (Exotic),Рецепт: сумка возвышенной брони валькирии (экзотический)
 Recipe: Satchel of Valkyrie Feathered Armor,Рецепт: сумка валькирийных перьевых доспехов
-Recipe: Satchel of Valkyrie Feathered Armor (Master),Рецепт: сумка валькирийского оперенного доспеха (Мастер)
+Recipe: Satchel of Valkyrie Feathered Armor (Master),Рецепт: сумка валькирийского оперённого доспеха (Мастер)
 Recipe: Satchel of Valkyrie Masquerade Armor (Rare),Рецепт: сумка маскарадной брони валькирии (редкий)
 Recipe: Satchel of Valkyrie Noble Armor (Rare),Рецепт: сумка благородной брони валькирии (редкий)
 Recipe: Satchel of Valkyrie Prowler Armor,Рецепт: сумка доспехов валькирии-бродяги
@@ -395,7 +395,7 @@ Recipe: Satchel of Vital Embroidered Armor,Рецепт: сумка жизнен
 Recipe: Satchel of Vital Embroidered Armor (Master),Рецепт: сумка жизненной расшитой брони (мастерский)
 Recipe: Satchel of Vital Seeker Armor,Рецепт: сумка жизненной искательской брони
 Recipe: Satchel of Vital Seeker Armor (Master),Рецепт: сумка жизненной искательской брони (мастерский)
-Recipe: Satchel of Zealot's Emblazoned Armor,Рецепт: сумка с гербовой броней фанатика
+Recipe: Satchel of Zealot's Emblazoned Armor,Рецепт: сумка с гербовой бронёй фанатика
 Recipe: Satchel of Zealot's Exalted Armor,Рецепт: сумка ревностной возвышенной брони
 Recipe: Save the Queen,Рецепт: спасти королеву
 Recipe: Scavenger Protocol: Cloth,Рецепт: протокол сборщика: Ткань

--- a/pn/pn_items_084.csv
+++ b/pn/pn_items_084.csv
@@ -419,7 +419,7 @@ Recipe: Zojja's Wand,Рецепт: жезл Зойи
 Recipe: Zojja's Warfists,Рецепт: боевые рукавицы Зойи
 Recipe: Zojja's Warhammer,Рецепт: боевой молот Зойи
 Recipe: Zojja's Wristguards,Рецепт: наручи Зойи
-Recipes of the Dwarven Armor Trader,Рецепты торговца дварфийской броней
+Recipes of the Dwarven Armor Trader,Рецепты торговца дварфийской бронёй
 Recipes of the Dwarven Cloth Trader,Рецепты дварфийского торговца тканями
 Recipes of the Dwarven Leather Trader,Рецепты дворфского кожевенного торговца
 Reclaimed Axe,Восстановленный топор

--- a/pn/pn_items_085.csv
+++ b/pn/pn_items_085.csv
@@ -51,9 +51,9 @@ Refitted Aureate Highlander Greatsword,Переделанный златоцве
 Refitted Aureate Longbow,Переоборудованный золочёный длинный лук
 Refitted Aureate Mace,Переделанная золочёная булава
 Refitted Aureate Musket,Модернизированный золотой мушкет
-Refitted Aureate Pistol,Переделанный золоченый пистолет
+Refitted Aureate Pistol,Переделанный золочёный пистолет
 Refitted Aureate Rinblade,Переделанный позолоченный ринблейд
-Refitted Aureate Sconce,Переделанный золоченый светильник
+Refitted Aureate Sconce,Переделанный золочёный светильник
 Refitted Aureate Short Bow,Переделанный золотой короткий лук
 Refitted Aureate Staff,Переделанный позолоченный посох
 Refitted Aureate Targe,Модернизированный золотистый тарг

--- a/pn/pn_items_086.csv
+++ b/pn/pn_items_086.csv
@@ -427,7 +427,7 @@ Roadrunner,Бегун
 Roadrunner Raptor Skin,Облик раптора «Подорожник»
 Roar,Рык
 Roar of the Lion's Champion,Рёв чемпиона льва
-Roaring Dragon Glider,Планер «Ревущий дракон»
+Roaring Dragon Glider,Планёр «Ревущий дракон»
 Roasted Aloe Seed,Жареное семя алоэ
 Roasted Artichoke,Жареный артишок
 Roasted Meat,Жареное мясо

--- a/pn/pn_items_088.csv
+++ b/pn/pn_items_088.csv
@@ -30,13 +30,13 @@ Sample Results,Результаты образцов
 Sample of Hylek Poison,Образец яда хилеков
 Sample of Kryptis Corruption,Образец порчи криптис
 Sample of Kryptis Possession,Образец одержимости криптис
-Sanctified Axe,Освященный топор
+Sanctified Axe,Освящённый топор
 Sanctified Axe Skin,Облик топора «Освящённый»
 Sanctified Boots,Освященные сапоги
 Sanctified Boots Skin,Облик сапог «Освящённый»
-Sanctified Cape,Освященный плащ
+Sanctified Cape,Освящённый плащ
 Sanctified Cape Skin,Облик плаща «Освящённый»
-Sanctified Coat,Освященная куртка
+Sanctified Coat,Освящённая куртка
 Sanctified Coat Skin,Облик куртки «Освящённый»
 Sanctified Dagger,Освящённый кинжал
 Sanctified Dagger Skin,Облик кинжала «Освящённый»
@@ -49,19 +49,19 @@ Sanctified Greatsword,Освящённый двуручный меч
 Sanctified Greatsword Skin,Облик двуручного меча «Освящённый»
 Sanctified Hammer,Освящённый молот
 Sanctified Hammer Skin,Облик молота «Освящённый»
-Sanctified Helm,Освященный шлем
+Sanctified Helm,Освящённый шлем
 Sanctified Helm Skin,Облик шлема «Освящённый»
 Sanctified Leggings,Освященные поножи
 Sanctified Leggings Skin,Облик поножей «Освящённый»
-Sanctified Longbow,Освященный длинный лук
+Sanctified Longbow,Освящённый длинный лук
 Sanctified Longbow Skin,Облик длинного лука «Освящённый»
 Sanctified Mace,Освящённая булава
 Sanctified Mace Skin,Облик булавы «Освящённый»
 Sanctified Pistol,Освящённый пистолет
 Sanctified Pistol Skin,Облик пистолета «Освящённый»
-Sanctified Rifle,Освященная винтовка
+Sanctified Rifle,Освящённая винтовка
 Sanctified Rifle Skin,Облик винтовки «Освящённый»
-Sanctified Scepter,Освященный скипетр
+Sanctified Scepter,Освящённый скипетр
 Sanctified Scepter Skin,Облик скипетра «Освящённый»
 Sanctified Shield,Освящённый щит
 Sanctified Shield Skin,Облик щита «Освящённый»

--- a/pn/pn_items_089.csv
+++ b/pn/pn_items_089.csv
@@ -87,7 +87,7 @@ Season 3 Expedition Contract,Контракт на экспедицию сезо
 Season 4 Expedition Contract,Контракт на экспедицию 4-го сезона
 Season 4 Material Chest,Сундук материалов сезона 4
 Seasoned Focus Casing,Закалённый корпус фокуса
-Seasoned Focus Core,Закаленное ядро фокуса
+Seasoned Focus Core,Закалённое ядро фокуса
 Seasoned Harpoon,Выдержанный гарпун
 Seasoned Longbow Stave,Выдержанное древко длинного лука
 Seasoned Pistol Frame,Выдержанная оправа пистолета
@@ -452,7 +452,7 @@ Sentinel's Soft Wood Warhorn,Мягкий деревянный боевой ро
 Sentinel's Soft Wood Warhorn of the Geomancer,Мягкий деревянный боевой рог-стража геоманта
 Sentinel's Steam Speargun,Паровой гарпун стража
 Sentinel's Steam Speargun of Agony,Паровой гарпун стража Агонии
-Sentinel's Steam Speargun of Hobbling,Парализующее паровое копье стража.
+Sentinel's Steam Speargun of Hobbling,Парализующее паровое копьё стража.
 Sentry Turret,Турель часового
 Separatist Dagger,Кинжал сепаратистов
 Separatist Fighter Loot Box,Коробка с добычей сепаратиста
@@ -493,7 +493,7 @@ Seraph Short Bow,Короткий лук Серафимов
 Seraph Shoulderpads,Наплечники Серафимов
 Seraph Shoulders,Оплечье Серафимов
 Seraph Spear,Копьё Серафимов
-Seraph Speargun,Копьемет Серафимов
+Seraph Speargun,Копьемёт Серафимов
 Seraph Spicy Ration,Острый паёк Серафима
 Seraph Staff,Посох Серафимов
 Seraph Standard Ration,Стандартный паёк Серафимов

--- a/pn/pn_items_090.csv
+++ b/pn/pn_items_090.csv
@@ -7,7 +7,7 @@ Seraph Warhorn,Боевой рог Серафимов
 Seraph Weapon Recipe Book,Книга рецептов серафимского оружия
 Seraph Wings Backpack,Рюкзак крыльев серафима
 Seraph Wings Backpack and Glider Combo,Комплект «Крылья Серафимов»: рюкзак и планер
-Seraph Wings Glider,Планер «Крылья Серафима»
+Seraph Wings Glider,Планёр «Крылья Серафима»
 Seraph's Landing Mace,Булава Приземления Серафимов
 Seraph-Issue Axe,Серафимская боевая секира
 Seraph-Issue Breastplate,Нагрудник образца Серафимов
@@ -160,7 +160,7 @@ Settler's Iron Sword of Agony,"Железный меч поселенца, пр�
 Settler's Iron Sword of the Hydromancer,Железный меч поселенца Гидроманта
 Settler's Jewel,Самоцвет поселенца
 Settler's Keepsake,Реликвия поселенца
-Settler's Marauder Mask of Hoelbrak,Маска мародёра поселенца из Хельбрака
+Settler's Marauder Mask of Hoelbrak,Маска мародёра поселенца из Хёльбрака
 Settler's Orichalcum Imbued Inscription,Пропитанная орихалковая гравировка поселенца
 Settler's Pearl Bludgeoner,Жемчужный дубинобоец поселенца
 Settler's Pearl Blunderbuss,Перловый мушкетон поселенца

--- a/pn/pn_items_091.csv
+++ b/pn/pn_items_091.csv
@@ -137,7 +137,7 @@ Shaman's Exalted Mantle,Возвышенная мантия шамана
 Shaman's Exalted Masque,Возвышенная маска шамана
 Shaman's Exalted Pants,Штаны шамана
 Shaman's Intricate Gossamer Insignia,Искусно сотканная инсигния шамана
-Shaman's Marauder Mask of Hoelbrak,Маска шамана-мародёра из Хельбрака
+Shaman's Marauder Mask of Hoelbrak,Маска шамана-мародёра из Хёльбрака
 Shaman's Marauder Mask of Lyssa,Маска шамана-мародёра Лиссы
 Shaman's Marauder Mask of Scavenging,Маска шамана-мародёра с бонусом к поиску
 Shaman's Norn Axe,Шаманский норнский топор
@@ -172,7 +172,7 @@ Shaman's Norn Greatsword of Energy,Двуручный меч норна-шама
 Shaman's Norn Greatsword of Water,Двуручный меч из воды норна-шамана
 Shaman's Norn Mace,Шаманская норнская булава
 Shaman's Norn Mace of Air,Булава воздуха норна-шамана
-Shaman's Norn Mace of Corruption,Шестопер норна шамана скверны
+Shaman's Norn Mace of Corruption,Шестопёр норна шамана скверны
 Shaman's Norn Mace of Energy,Норнийский посох шамана энергии
 Shaman's Norn Mace of Water,Булава воды норна-шамана
 Shaman's Norn Pistol,Шаманский норнский пистолет
@@ -294,7 +294,7 @@ Shaman's Reclaimed Greatsword,Двуручный меч шамана
 Shaman's Reclaimed Greatsword of Earth,"Двуручный меч земли, возвращённый шаманом"
 Shaman's Reclaimed Hammer,Восстановленный молот шамана
 Shaman's Reclaimed Hammer of Earth,Восстановленный молот земли шамана
-Shaman's Reclaimed Longbow,Освобожденный длинный лук шамана
+Shaman's Reclaimed Longbow,Освобождённый длинный лук шамана
 Shaman's Reclaimed Longbow of Earth,"Длинный лук шамана, возвращённый земле"
 Shaman's Reclaimed Mace,Восстановленный шест шамана
 Shaman's Reclaimed Mace of Earth,Восстановленный шест земли шамана

--- a/pn/pn_items_092.csv
+++ b/pn/pn_items_092.csv
@@ -50,8 +50,8 @@ Sharptail Short Bow,Короткий лук острохвоста
 Shattered Axe,Раздробленный топор
 Shattered Bloodstone Circlet,Венец из осколков кровавого камня
 Shattered Bloodstone Circlet Skin,Облик диадемы из разбитого кровавого камня
-Shattered Bloodstone Glider,Планер «Разбитый кровавый камень»
-Shattered Cathedral Glider,Планер «Разрушенный собор»
+Shattered Bloodstone Glider,Планёр «Разбитый кровавый камень»
+Shattered Cathedral Glider,Планёр «Разрушенный собор»
 Shattered Chest Lid,Разбитая крышка сундука
 Shattered Dagger,Разбитый кинжал
 Shattered Dye,Краска «Разбитая»
@@ -74,7 +74,7 @@ Shattered Short Bow,Разбитый короткий лук
 Shattered Staff,Разбитый посох
 Shattered Stone Backpack and Glider Combo,Комбо рюкзака и планера из разбитого камня
 Shattered Stone Wings Backpack Skin,Облик рюкзака «Крылья из расколотого камня»
-Shattered Stone Wings Glider,Планер «Разбитые каменные крылья»
+Shattered Stone Wings Glider,Планёр «Разбитые каменные крылья»
 Shattered Stone Wings Glider Skin,Облик планера «Крылья из расколотого камня»
 Shattered Sword,Разбитый меч
 Shattered Torch,Разбитый факел
@@ -110,7 +110,7 @@ Sheepskin Gloves,Перчатки из овчины
 Sheepskin Leggings,Овчинные поножи
 Sheepskin Mantle,Накидка из овчины
 Sheepskin Shoes,Туфли из овчины
-Sheet Music Glider,Планер «Ноты»
+Sheet Music Glider,Планёр «Ноты»
 Sheet of Ambrite,Лист амбрита
 Sheet of Aurillium,Лист ауриллия
 Sheet of Charged Ambrite,Лист заряженного амбрита
@@ -188,7 +188,7 @@ Shimmering Aurora Dagger,Мерцающий кинжал Авроры
 Shimmering Aurora Dagger Skin,Облик кинжала «Мерцающая аврора»
 Shimmering Aurora Focus,Мерцающий фокус Авроры
 Shimmering Aurora Focus Skin,Облик фокуса «Мерцающая аврора»
-Shimmering Aurora Glider,Планер «Мерцающее сияние»
+Shimmering Aurora Glider,Планёр «Мерцающее сияние»
 Shimmering Aurora Greatsword,Мерцающий двуручный меч Авроры
 Shimmering Aurora Greatsword Skin,Облик двуручного меча «Мерцающая аврора»
 Shimmering Aurora Hammer,Мерцающий молот Авроры
@@ -235,9 +235,9 @@ Shining Aureate Highlander Greatsword,Сияющий ауреатный горс
 Shining Aureate Longbow,Сияющий золочёный длинный лук
 Shining Aureate Mace,Сияющая золотая булава
 Shining Aureate Musket,Сияющий золочёный мушкет
-Shining Aureate Pistol,Сияющий золоченый пистолет
-Shining Aureate Rinblade,Сияющий золоченый ринблейд
-Shining Aureate Sconce,Сияющий золоченый канделябр
+Shining Aureate Pistol,Сияющий золочёный пистолет
+Shining Aureate Rinblade,Сияющий золочёный ринблейд
+Shining Aureate Sconce,Сияющий золочёный канделябр
 Shining Aureate Short Bow,Сияющий короткий лук из золочёного металла
 Shining Aureate Staff,Сияющий позолоченный посох
 Shining Aureate Targe,Сияющая золочёная тарга
@@ -391,7 +391,7 @@ Shredded Rag,Рваная тряпка
 Shrengra's Warhorn,Боевой рог Шренгры
 Shrimpling,Креветочка
 Shrine Guardian Backpack Skin,Облик рюкзака хранителя святилищ
-Shrine Guardian Glider,Планер «Страж святилища»
+Shrine Guardian Glider,Планёр «Страж святилища»
 Shrine Guardian Glider Skin,Облик планера хранителя святилищ
 Shrine Guardian Jackal Skin,Облик шакала хранителя святилищ
 Shrine Guardian Outfit,Костюм стража святилища

--- a/pn/pn_items_093.csv
+++ b/pn/pn_items_093.csv
@@ -360,7 +360,7 @@ Skyscale Shield,Щит скайскейля
 Skyscale Shield Skin,Облик щита скайскейла
 Skyscale Short Bow,Короткий лук небесного скакуна
 Skyscale Short Bow Skin,Облик короткого лука скайскейла
-Skyscale Squadron Glider,Планер «Эскадрилья скайскейлов»
+Skyscale Squadron Glider,Планёр «Эскадрилья скайскейлов»
 Skyscale Staff,Посох скайскейла
 Skyscale Staff Skin,Облик посоха скайскейла
 Skyscale Sword,Меч скайскейльда
@@ -374,7 +374,7 @@ Skyscale Warhorn,Боевой рог скайскейла
 Skyscale Warhorn Skin,Облик боевого рога скайскейла
 Skyscale Weapon Box,Коробка с оружием скайскейла
 Skysteel Chair,Стул из Небесной Стали
-Skysteel Glider,Планер «Небесная сталь»
+Skysteel Glider,Планёр «Небесная сталь»
 Skysteel Greatsword,Двуручный меч из Небесной Стали
 Skysteel Greatsword Skin,Облик двуручного меча из небесной стали
 Skysteel Package,Скайстиловый набор
@@ -410,7 +410,7 @@ Sleek Dunerunner,Гладкий бегун дюн
 Sleeveless Wetsuit Bottoms,Низ гидрокостюма без рукавов
 Sleeveless Wetsuit Top,Верх гидрокостюма без рукавов
 Slender Fairy Wings Backpack Skin,Облик рюкзака «Тонкие крылья феи»
-Slender Fairy Wings Glider,Планер «Тонкие крылья феи»
+Slender Fairy Wings Glider,Планёр «Тонкие крылья феи»
 Slender Fairy Wings Glider Skin,Облик планера «Тонкие крылья феи»
 Slice of Allspice Cake,Кусок пирога с душистым перцем
 Slice of Allspice Cake with Ice Cream,Кусочек пирога с душистым перцем и мороженым

--- a/pn/pn_items_094.csv
+++ b/pn/pn_items_094.csv
@@ -172,7 +172,7 @@ Snowflake Copper Amulet,Снежинка: медный амулет
 Snowflake Copper Earring,Снежинка: медная серьга
 Snowflake Copper Ring,Снежинка: медное кольцо
 Snowflake Eel,Снежинковый угорь
-Snowflake Glider,Планер «Снежинка»
+Snowflake Glider,Планёр «Снежинка»
 Snowflake Gobbler Pack,Набор снежинки-пожирателя
 Snowflake Gobbler's Blessing,Благословение Снежинкоеда
 Snowflake Gold Amulet,Снежинка: золотой амулет
@@ -317,7 +317,7 @@ Soldier's Armageddon Leggings,«Походные поножи солдата»
 Soldier's Armageddon Leggings of Infiltration,«Походные поножи солдата проникновения»
 Soldier's Armageddon Pauldrons,«Наплечники Армагеддона солдата»
 Soldier's Armageddon Pauldrons of Infiltration,Наплечники Армагеддона солдата проникновения
-Soldier's Aureate Charm,Золоченый оберег солдата
+Soldier's Aureate Charm,Золочёный оберег солдата
 Soldier's Aureate Dirk,«Солдатский ауреат-кинжал»
 Soldier's Aureate Highlander Greatsword,Золочёный двуручный меч горца солдата
 Soldier's Aureate Longbow,Солдатский ауреатный длинный лук
@@ -329,8 +329,8 @@ Soldier's Aureate Sconce,«Золотой настенный светильни�
 Soldier's Aureate Short Bow,Солдатский светлый короткий лук
 Soldier's Aureate Spear,Копьё солдата из ауреата
 Soldier's Aureate Speargun,«Золотое копьемёт солдата»
-Soldier's Aureate Staff,Золоченый посох солдата
-Soldier's Aureate Targe,Солдатский золоченый тарч
+Soldier's Aureate Staff,Золочёный посох солдата
+Soldier's Aureate Targe,Солдатский золочёный тарч
 Soldier's Aureate Trident,Золотой трезубец солдата
 Soldier's Aureate Virge,«Золотой жезл солдата»
 Soldier's Aureate Warhammer,Боевой молот «Солдата» из ауреата

--- a/pn/pn_items_095.csv
+++ b/pn/pn_items_095.csv
@@ -139,19 +139,19 @@ Soldier's Stag Hounskull,Солдатский олений хундсгугел�
 Soldier's Stag Mail,Оленья кольчуга Солдата
 Soldier's Stag Spaulders,Оленьи наплечники солдата
 Soldier's Steam Speargun,Паровое гарпунное ружьё солдата
-Soldier's Tempered Scale Chestplate of the Guardian,Закаленная чешуйчатая кираса стража солдата
+Soldier's Tempered Scale Chestplate of the Guardian,Закалённая чешуйчатая кираса стража солдата
 Soldier's Tempered Scale Chestplate of the Revenant,Закалённая чешуйчатая кираса ревенанта солдата
 Soldier's Tempered Scale Chestplate of the Warrior,Закалённая чешуйчатая кираса Воина с солдатским клеймом
 Soldier's Tempered Scale Gauntlets of the Guardian,Закалённые чешуйчатые перчатки Стража (Солдат)
-Soldier's Tempered Scale Gauntlets of the Revenant,Перчатки из каленой чешуи ревенанта солдата
-Soldier's Tempered Scale Gauntlets of the Warrior,Наручи солдата из закаленной чешуи воина
+Soldier's Tempered Scale Gauntlets of the Revenant,Перчатки из калёной чешуи ревенанта солдата
+Soldier's Tempered Scale Gauntlets of the Warrior,Наручи солдата из закалённой чешуи воина
 Soldier's Tempered Scale Greaves of the Guardian,Закалённые чешуйчатые наголенники солдата стража
 Soldier's Tempered Scale Greaves of the Revenant,Закалённые наголенники чешуи ревенанта солдата
 Soldier's Tempered Scale Greaves of the Warrior,«Солдата» Закалённые чешуйчатые наголенники Воина
-Soldier's Tempered Scale Legs of the Guardian,Солдатские поножи из закаленной чешуи Стража
+Soldier's Tempered Scale Legs of the Guardian,Солдатские поножи из закалённой чешуи Стража
 Soldier's Tempered Scale Legs of the Revenant,Чешуйчатые поножи Отступника солдата
-Soldier's Tempered Scale Legs of the Warrior,Солдатские закаленные чешуйчатые поножи воина
-Soldier's Tempered Scale Pauldrons of the Guardian,Солдатские закаленные чешуйчатые наплечники стража
+Soldier's Tempered Scale Legs of the Warrior,Солдатские закалённые чешуйчатые поножи воина
+Soldier's Tempered Scale Pauldrons of the Guardian,Солдатские закалённые чешуйчатые наплечники стража
 Soldier's Tempered Scale Pauldrons of the Revenant,Наплечники из калёной чешуи ревенанта солдата
 Soldier's Tempered Scale Pauldrons of the Warrior,Наплечники из закалённой чешуи солдата воина
 Soldier's Tribal Bow,Племенной лук солдата
@@ -251,7 +251,7 @@ Soo-Won's Wing Skin,Облик «Крыло Су-Вон»
 Soo-Won's Wisdom,Мудрость Су-Вон
 Soo-Won's Wisdom Skin,Облик «Мудрость Су-Вон»
 Soot-Covered Ring,Закопчённое кольцо
-Sorcerer's Cape Glider,Планер «Плащ чародея»
+Sorcerer's Cape Glider,Планёр «Плащ чародея»
 Sorcerer's Cape Skin,Облик плаща чародея
 Sorcerer's Coat,Куртка чародея
 Sorcerer's Epaulets,Наплечники чародея
@@ -281,7 +281,7 @@ Soros's Wand,Жезл Сороса
 Soros's Warhammer,Боевой молот Сороса
 Soros's Weapon Chest,Сундук с оружием Сороса
 Sorrow's Claw,Коготь Скорби
-Sorrow's Embrace Armor Box,Коробка с броней «Объятия Скорби»
+Sorrow's Embrace Armor Box,Коробка с бронёй «Объятия Скорби»
 Sorrow's Embrace Token Loot Box,Коробка с жетонами Объятий Скорби
 Sorrow's Embrace Weapons Box,Коробка с оружием из Объятий Скорби
 Sorrowful Treasure,Печальное сокровище
@@ -291,7 +291,7 @@ Soul Conductor,Проводник душ
 Soul Eater Siege Turtle,Пожиратель душ (осадная черепаха)
 Soul Eater Siege Turtle Skin,Облик осадной черепахи «Пожиратель душ»
 Soul Pastry,Пирожное души
-Soul River Glider,Планер «Река душ»
+Soul River Glider,Планёр «Река душ»
 Soul River Hound,Гончая реки душ
 Soul River Hound Hammer Skin,Облик молота «Гончая Реки Душ»
 Soul of Koda,Душа Коды
@@ -375,23 +375,23 @@ Sparkfly Wings,Крылья светлячков
 Sparking Jade Shard,Искрящийся осколок нефрита
 Sparking Petrified Wood,Искрящаяся окаменелая древесина
 Sparkling Tinsel Ornament,Сверкающее мишурное украшение
-Sparkling Wrapped Axe,Сверкающий обернутый топор
+Sparkling Wrapped Axe,Сверкающий обёрнутый топор
 Sparkling Wrapped Dagger,Искрящийся обёрнутый кинжал
 Sparkling Wrapped Focus,Сверкающий обёрнутый фокус
 Sparkling Wrapped Greatsword,Сверкающий упакованный двуручный меч
 Sparkling Wrapped Hammer,Сверкающий обёрнутый молот
 Sparkling Wrapped Longbow,Сверкающий упакованный длинный лук
 Sparkling Wrapped Mace,Сверкающая обёрнутая булава
-Sparkling Wrapped Pistol,Сверкающий обернутый пистолет
+Sparkling Wrapped Pistol,Сверкающий обёрнутый пистолет
 Sparkling Wrapped Rifle,Сверкающая упакованная винтовка
 Sparkling Wrapped Scepter,Искрящийся обмотанный скипетр
 Sparkling Wrapped Shield,Сверкающий обёрнутый щит
-Sparkling Wrapped Short Bow,Сверкающий обернутый короткий лук
+Sparkling Wrapped Short Bow,Сверкающий обёрнутый короткий лук
 Sparkling Wrapped Staff,Сверкающий упакованный посох
-Sparkling Wrapped Sword,Сверкающий обернутый меч
-Sparkling Wrapped Torch,Сверкающий обернутый факел
+Sparkling Wrapped Sword,Сверкающий обёрнутый меч
+Sparkling Wrapped Torch,Сверкающий обёрнутый факел
 Sparkling Wrapped Warhorn,Сверкающий обмотанный боевой рог
-Sparrowcatcher,Ловец воробьев
+Sparrowcatcher,Ловец воробьёв
 Sparse Drizzlewood Coast Tree Token,Редкий жетон дерева Drizzlewood Coast
 Speak with Snargle Goldclaw.,Поговорите с Снарглом Золотым Когтем.
 Speaker Supply,Запас динамиков
@@ -405,7 +405,7 @@ Spear of Accuracy,Копьё точности
 Spear of Force,Копьё Силы
 Spear of Smoldering,Копьё Тлеющего Пламени
 Spear of Venom,Копьё Яда
-Speargun,Копьемет
+Speargun,Копьемёт
 Speargun of the Dragon's Deep,Гарпун драконьей глубины
 Spearmarshal's Plea,Мольба копьёмаршала
 Spearmint,Мята
@@ -459,7 +459,7 @@ Spectral Dagger,Призрачный кинжал
 Spectral Dagger Skin,Облик призрачного кинжала
 Spectral Focus,Спектральный фокус
 Spectral Focus Skin,Облик призрачного фокуса
-Spectral Glider,Планер «Призрачный»
+Spectral Glider,Планёр «Призрачный»
 Spectral Greatsword,Призрачный двуручный меч
 Spectral Greatsword Skin,Облик призрачного двуручного меча
 Spectral Hammer Skin,Облик призрачного молота

--- a/pn/pn_items_096.csv
+++ b/pn/pn_items_096.csv
@@ -3,7 +3,7 @@ Spellfire Torch Skin,Внешний вид: факел «Огненное зак
 Spellforged Backpack,Зачарованный рюкзак
 Spellforged Backpack and Glider Combo,Связанный заклинанием рюкзак и дельтаплан
 Spellforged Outfit,Костюм заклинателя
-Spellweaver Glider,Планер «Заклинатель»
+Spellweaver Glider,Планёр «Заклинатель»
 Spero,Сперо
 Spicier Flank Steak,Пряный стейк из пашины
 Spicy Cheeseburger,Пряный чизбургер
@@ -268,7 +268,7 @@ Stained Glass Shard,Осколок витража
 Stained Glass Wings Backpack,Рюкзак «Витражные крылья»
 Stained Glass Wings Backpack Skin,Облик рюкзака «Крылья из витража»
 Stained Glass Wings Backpack and Glider Combo,Комбо-набор «Крылья из витража: рюкзак и планер»
-Stained Glass Wings Glider,Планер «Витражные крылья»
+Stained Glass Wings Glider,Планёр «Витражные крылья»
 Stained Tent Canvas,Запачканный холст палатки
 Stalker Boots,Сапоги сталкера
 Stalker Coat,Куртка сталкера
@@ -343,7 +343,7 @@ Stargazer,Звездочет
 Stargazer Pendant,Кулон звездочета
 Starlight Wings Backpack,Рюкзак «Крылья звёздного света»
 Starlight Wings Backpack and Glider Combo,Комбо-набор «Крылья звёздного света: рюкзак и планер»
-Starlight Wings Glider,Планер «Звёздные крылья»
+Starlight Wings Glider,Планёр «Звёздные крылья»
 Starlit Sky Feathered Raptor,Оперенный раптор звёздного неба
 Starlit Weald Cache,Тайник «Звёздная роща»
 Starlit Weald Renown Token,Жетон почёта Звёздной Рощи
@@ -394,8 +394,8 @@ Stately Mantle Skin,Облик «Величественная накидка»
 Stately Shoes Skin,Облик «Величественная обувь»
 Static Assault Knight Power Core,Ядро силы «Статический штурмовой рыцарь»
 Static Conduit,Статический проводник
-Static Tempered Spinal Blades,Статические Закаленные Спинные Клинки
-Static Tempered Spinal Blades (Infused),Статические Закаленные Спинные Клинки (Насыщенные)
+Static Tempered Spinal Blades,Статические Закалённые Спинные Клинки
+Static Tempered Spinal Blades (Infused),Статические Закалённые Спинные Клинки (Насыщенные)
 Statue Token,Жетон статуи
 Statue of Grenth Coffer,Сундук статуи Грента
 Statue of Joko Smiting Abaddon,"Статуя Джоко, разящего Аббадона"

--- a/pn/pn_items_097.csv
+++ b/pn/pn_items_097.csv
@@ -144,7 +144,7 @@ Stellar Cleaver,Звёздный тесак
 Stellar Disk,Звёздный диск
 Stellar Dragon Wings Backpack,Рюкзак «Крылья звёздного дракона»
 Stellar Dragon Wings Backpack and Glider Combo,Комбо-набор «Крылья звёздного дракона: рюкзак и планер»
-Stellar Dragon Wings Glider,Планер «Крылья звёздного дракона»
+Stellar Dragon Wings Glider,Планёр «Крылья звёздного дракона»
 Stellar Harbinger,Звёздный предвестник
 Stellar Khopesh,Звёздный хопеш
 Stellar Knobkerrie,Звёздная дубинка

--- a/pn/pn_items_098.csv
+++ b/pn/pn_items_098.csv
@@ -131,7 +131,7 @@ Strong Dredge Trident,Прочный трезубец дреджей
 Strong Echo of Drizzlewood Coast,Сильное эхо Побережья Морось-леса
 Strong Echo of Forging Steel,Сильное эхо Кузницы стали
 Strong Echo of Raven Sanctum,Сильное эхо Святилища Ворона
-Strong Echo of Whispers,Сильное эхо Шепотов
+Strong Echo of Whispers,Сильное эхо Шёпотов
 Strong Echo of the Shiverpeaks,Сильное эхо Дрожащих вершин
 Strong Embroidered Cotton Insignia,Вышитая хлопковая инсигния прочного
 Strong Embroidered Wool Insignia,Вышитая шерстяная инсигния прочного
@@ -364,7 +364,7 @@ Strong Privateer Hat of the Dolyak,Прочная пиратская шляпа 
 Strong Privateer Hat of the Lich,Прочная шляпа флибустьера Лича
 Strong Privateer Pants of Divinity,Прочные штаны пирата божественности
 Strong Privateer Pants of Infiltration,Прочные штаны капера скрытности
-Strong Privateer Pants of Scavenging,Прочные каперские штаны мародерства
+Strong Privateer Pants of Scavenging,Прочные каперские штаны мародёрства
 Strong Privateer Pants of the Eagle,Прочные штаны капера орла
 Strong Privateer Pants of the Flock,Прочные каперские штаны Стаи
 Strong Privateer Shoulders of Rata Sum,Прочные наплечники капера Рата Сума
@@ -383,7 +383,7 @@ Strong Reinforced Scale Boots of the Dolyak,Прочные сапоги из ч�
 Strong Reinforced Scale Boots of the Eagle,Прочные усиленные чешуйчатые сапоги орла
 Strong Reinforced Scale Boots of the Flame Legion,Прочные усиленные чешуйчатые сапоги Flame Legion
 Strong Reinforced Scale Boots of the Pack,Прочные сапоги из усиленной чешуи Стаи
-Strong Reinforced Scale Coat of Divinity,Прочная укрепленная чешуйчатая куртка божественности
+Strong Reinforced Scale Coat of Divinity,Прочная укреплённая чешуйчатая куртка божественности
 Strong Reinforced Scale Coat of Grenth,Прочная усиленная чешуйчатая куртка Грента
 Strong Reinforced Scale Coat of Hoelbrak,Прочная усиленная чешуйчатая куртка Хоэлбрака
 Strong Reinforced Scale Coat of Lyssa,Прочная усиленная чешуйчатая куртка Лиссы

--- a/pn/pn_items_099.csv
+++ b/pn/pn_items_099.csv
@@ -59,10 +59,10 @@ Strong Steel Rifle,Прочная стальная винтовка
 Strong Steel Shield,Прочный стальной щит
 Strong Steel Spear,Прочное стальное копьё
 Strong Steel Sword,Прочный стальной меч
-Strong Studded Boots,Прочные клепаные сапоги
+Strong Studded Boots,Прочные клёпаные сапоги
 Strong Studded Coat,Прочная клепаная куртка
 Strong Studded Gloves,Прочные перчатки с шипами
-Strong Studded Pants,Прочные клепаные штаны
+Strong Studded Pants,Прочные клёпаные штаны
 Strong Student Circlet,Прочный ученический венец
 Strong Student Coat,Прочная студенческая куртка
 Strong Student Gloves,Прочные студенческие перчатки
@@ -136,7 +136,7 @@ Strong Wraps,Прочные обмотки
 Studded Boots,Клёпаные сапоги
 Studded Coat,Куртка с шипами
 Studded Gloves,Перчатки с шипами
-Studded Helm,Клепаный шлем
+Studded Helm,Клёпаный шлем
 Studded Leather Bracers,Штромованные Кожаные Наручи
 Studded Leather Leggings,Штромованные Кожаные Поножи
 Studded Leather Mask,Шипованная кожаная маска
@@ -146,7 +146,7 @@ Studded Plate Armor,Клёпаный латный доспех
 Studded Plate Gauntlets,Шипованные латные перчатки
 Studded Plate Greaves,Шипованные пластинчатые наголенники
 Studded Plate Helm,Шлем с клепаной пластиной
-Studded Plate Leggings,Клепаные пластинчатые поножи
+Studded Plate Leggings,Клёпаные пластинчатые поножи
 Studded Plate Pauldrons,Наплечники из клепаных пластин
 Studded Shoulders,Плечи с шипами
 Student Circlet,Диадема ученика
@@ -328,7 +328,7 @@ Sun-Blessed Vision,Благословенное солнцем зрение
 Sun-Blessed Zephyrite Axe,Благословенный солнцем топор зефирита
 Sun-Blessed Zephyrite Dagger,Благословенный солнцем кинжал зефирита
 Sun-Blessed Zephyrite Focus,Благословенный солнцем фокус зефирита
-Sun-Blessed Zephyrite Gloves,"Перчатки зефирита, благословленные солнцем"
+Sun-Blessed Zephyrite Gloves,"Перчатки зефирита, благословлённые солнцем"
 Sun-Blessed Zephyrite Greatsword,Благословенный солнцем двуручный меч зефирита
 Sun-Blessed Zephyrite Hammer,Благословенный солнцем молот зефирита
 Sun-Blessed Zephyrite Longbow,Благословенный солнцем длинный лук зефирита
@@ -370,12 +370,12 @@ Sunfire Lava,Солнечная лава
 Sunfire Lava Dye,Краска «Солнечный огонь лавы»
 Sunfish,рыба-солнце
 Sunken Beacon,Потоплый маяк
-Sunken Carver,Потопленный резчик
+Sunken Carver,Потоплённый резчик
 Sunken Harbinger,Потоплённый предвестник
 Sunken Pirate Treasure,Затонувшее пиратское сокровище
 Sunken Pistol,Погружённый пистолет
 Sunken Rations,Погребенные припасы
-Sunken Reaver,Потопленный Разбойник
+Sunken Reaver,Потоплённый Разбойник
 Sunken Shell,Потонувшая раковина
 Sunken Wheel,Потонувшее Колесо
 Sunless Medallion,Беззвёздный медальон
@@ -402,7 +402,7 @@ Sunshine Shorts,Шорты солнечного света
 Sunshine Shorts Skin,Облик шорт «Солнечный свет»
 Sunspear Armor Box,Коробка с доспехами Копья Солнца
 Sunspear Bounty Medal,Медаль за выполнение заданий Солнеспира
-Sunspear Glider,Планер «Копьё Солнца»
+Sunspear Glider,Планёр «Копьё Солнца»
 Sunspear Order Emblem,Эмблема «Орден Солнечного копья»
 Sunspear Paragon Support,Поддержка Парогона Солнечного Копья
 Sunspear Redemption Wish,Желание об искуплении Санспира
@@ -423,14 +423,14 @@ Super Adventure Bonus: Gold,Супер приключенческий бонус
 Super Adventure Bonus: Silver,Супер приключение: бонус серебро
 Super Adventure Box Chair,Кресло «Супер-приключение»
 Super Adventure Box o' Fun,Коробка веселья супер-приключений
-Super Adventure Glider,Планер «Супер-приключение»
+Super Adventure Glider,Планёр «Супер-приключение»
 Super Adventure Logging Bear,Медведь-лесоруб супер-приключений
 Super Adventure Weapon Box,Супер приключенческая коробка с оружием
 Super Assassin Backpack,Рюкзак супер-убийцы
 Super Axe,Супер-топор
 Super Axe Skin,Супер топор
 Super Backpack Cover,Супер обложка для рюкзака
-Super Cloud Glider,Планер «Супер-облако»
+Super Cloud Glider,Планёр «Супер-облако»
 Super Dagger,Супер-кинжал
 Super Dagger Skin,Супер кинжал (внешний вид)
 Super Explosive Finisher,Добивание «Супервзрыв»

--- a/pn/pn_items_100.csv
+++ b/pn/pn_items_100.csv
@@ -417,7 +417,7 @@ Sword of the Dragon's Deep,Меч драконьей глубины
 Swordfish,Меч-рыба
 Swordshame,Позор меча
 Sworn Zaishen Helm Skin,Облик шлема присяжного зайшена
-Sylph Wings Glider,Планер «Крылья сильфа»
+Sylph Wings Glider,Планёр «Крылья сильфа»
 Sylvan Seedstool,Сильванский семенной табурет
 Sylvari Blade,Клинок сильвари
 Sylvari Bow,Лук сильвари

--- a/pn/pn_items_101.csv
+++ b/pn/pn_items_101.csv
@@ -45,9 +45,9 @@ Taimi's Coffer of Holding,Сундук хранения Тайми
 Taimi's Dye Kit,Набор красок Тайми
 Taimi's Outfit,Наряд Тайми
 Taimi's Reunion,Воссоединение Тайми
-Tainted Bloodstone Censer,Оскверненная гематитовая кадильница
-Tainted Glyphic Maul,Оскверненный глифический молот
-Tainted Glyphic Trispear,Оскверненная глифическая трезубец
+Tainted Bloodstone Censer,Осквернённая гематитовая кадильница
+Tainted Glyphic Maul,Осквернённый глифический молот
+Tainted Glyphic Trispear,Осквернённая глифическая трезубец
 Taker of Blood,Забирающий кровь
 Tale of Adventure,Сказание о приключениях
 Tale of Back Home,Рассказ о доме
@@ -77,9 +77,9 @@ Tangled Depths: Hero's Choice Chest,Сундук выбора героя «Гл�
 Tangled Net,Спутанная сеть
 Tanglewood Wings Backpack,Рюкзак «Крылья Тэнглвуда»
 Tanglewood Wings Backpack and Glider Combo,Комбо-набор «Крылья Тэнглвуда: рюкзак и планер»
-Tanglewood Wings Glider,Планер «Крылья Тэнглвуда»
+Tanglewood Wings Glider,Планёр «Крылья Тэнглвуда»
 Tapestry Shred,Лоскут гобелена
-Tar,Деготь
+Tar,Дёготь
 Tar Dye,Краска «Дёготь»
 Tar Elemental Core,Ядро смоляного элементаля
 Tar Flakes,Смоляные хлопья
@@ -126,8 +126,8 @@ Tasty Bat Wing,Вкусное летучее крыло
 Tasty Carrot,Вкусная морковка
 Tasty Chak Legs,Вкусные чак-штаны
 Tasty Devourer Carapace,Вкусный панцирь пожирателя
-Tasty Dried Bark,Вкусная сушеная кора
-Tasty Dried Carapace,Вкусный сушеный панцирь
+Tasty Dried Bark,Вкусная сушёная кора
+Tasty Dried Carapace,Вкусный сушёный панцирь
 Tasty Dried Cat's Paw,Вкусные сушеные кошачьи лапки
 Tasty Dried Eel,Вкусный сушёный угорь
 Tasty Dried Flower,Вкусные сушеные цветы
@@ -381,7 +381,7 @@ The Anthem of Victory,Гимн Победы
 The Anthem of Whimsy,Гимн Причуды
 The Anthem of the Fallen,Гимн Павших
 The Art of Forging: Nightsword Blade Edition,Искусство ковки: издание клинка Ночного меча
-The Ascension Glider,Планер «Вознесение»
+The Ascension Glider,Планёр «Вознесение»
 The Axe of Destiny,Топор Судьбы
 The Bard Experiment,Эксперимент барда
 The Battle of Sorrow's Furnace,Битва за Печь Скорби

--- a/pn/pn_items_102.csv
+++ b/pn/pn_items_102.csv
@@ -92,7 +92,7 @@ Thick Trouser Padding,Толстая подкладка штанов
 Thick Trouser Panel,Толстая панель штанов
 Thief's Cache,Тайник вора
 Thief's Dreambound Chest,Знак вора: Грудь грёз
-Thimble of Instant World Experience,Наперсток мгновенного мирового опыта
+Thimble of Instant World Experience,Напёрсток мгновенного мирового опыта
 Thin Boot Sole,Тонкая подошва сапога
 Thin Boot Upper,Тонкий верх сапога
 Thin Glove Lining,Тонкая подкладка перчатки
@@ -122,7 +122,7 @@ Thornthrower,Метатель шипов
 Thorny Prison Key,Ключ от колючей тюрьмы
 Thorny Seed Pouch,Мешочек колючих семян
 Thoughtless Potion,Зелье бездумности
-Thousand Seas Gourd Glider,Планер «Тыква Тысячи Морей»
+Thousand Seas Gourd Glider,Планёр «Тыква Тысячи Морей»
 Thousand Seas Pavilion Pass,Пропуск в павильон Тысячи морей
 Thousand Seas Pavilion Pass (2 weeks),Пропуск в павильон Тысячи морей (2 недели)
 Threat Assessment Manual,Руководство по оценке угрозы
@@ -236,7 +236,7 @@ Timekeeper Dagger,Кинжал хранителя времени
 Timekeeper Dagger Skin,Облик кинжала «Хранитель времени»
 Timekeeper Focus,Фокус хранителя времени
 Timekeeper Focus Skin,Облик фокуса «Хранитель времени»
-Timekeeper Glider,Планер «Хранитель времени»
+Timekeeper Glider,Планёр «Хранитель времени»
 Timekeeper Greatsword,Двуручный меч Хранителя времени
 Timekeeper Greatsword Skin,Облик двуручного меча «Хранитель времени»
 Timekeeper Hammer,Молот хранителя времени

--- a/pn/pn_items_103.csv
+++ b/pn/pn_items_103.csv
@@ -143,7 +143,7 @@ Tournament of Legends: Magic or Might,Турнир легенд: магия ил
 Tournament of Legends: Mastery or Fortune,Турнир легенд: мастерство или удача
 Tournament of Legends: Precursor Choice Box,Коробка выбора предтечи «Турнир легенд»
 Tournament of Legends: Second Place,Турнир легенд: Второе место
-Tournament of Legends: Third Place and Fourth Place,Турнир легенд: третье место и четвертое место
+Tournament of Legends: Third Place and Fourth Place,Турнир легенд: третье место и четвёртое место
 Tower Shard,Башенный осколок
 Toxal Bog Stew,Токсальское болотное рагу
 Toxic Armguard,Токсичный наруч
@@ -455,7 +455,7 @@ Track 33: Qadim,Трек 33: Кадим
 Track 33: Refuge for Outcasts,Трек 33: Приют для изгоев
 Track 33: Smodur the Unflinching,Трек 33: Смодур Непоколебимый
 Track 33: Undead of Elona,Трек 33: Нежить Элоны
-Track 33: United Legions,Трек 33: Объединенные легионы
+Track 33: United Legions,Трек 33: Объединённые легионы
 Track 34: An Old Forgotten Place,Трек 34: Старое забытое место
 Track 34: Dirge of the Father King,Трек 34: Плач Короля-Отца
 Track 34: Fort Assault,Трек 34: Штурм крепости

--- a/pn/pn_items_104.csv
+++ b/pn/pn_items_104.csv
@@ -3,7 +3,7 @@ Track 40: Become Like Water,Трек 40: Стань как вода
 Track 40: Sunrise of Astorea,Трек 40: Восход Астореи
 Track 40: The Crystal Dragon Pt. 3,"Трек 40: Хрустальный дракон, часть 3"
 Track 40: The End of War,Трек 40: Конец войны
-Track 40: United Legions II,Трек 40: Объединенные легионы II
+Track 40: United Legions II,Трек 40: Объединённые легионы II
 Track 41: Blighted Battleground,Трек 41: Заражённое поле боя
 Track 41: Champion of Jormag,Трек 41: Чемпион Йормага
 Track 41: Kestrel's Watch,Трек 41: Пустельгин дозор
@@ -253,7 +253,7 @@ Tribal Bow Skin,Облик племенного лука
 Tribal Bulwark,Племенной оплот
 Tribal Dagger,Племенной кинжал
 Tribal Dagger Skin,Облик племенного кинжала
-Tribal Flintlock,Племенной кремневый пистолет
+Tribal Flintlock,Племенной кремнёвый пистолет
 Tribal Focus,Племенной фокус
 Tribal Focus Skin,Облик племенного фокуса
 Tribal Greatsword,Племенной двуручный меч

--- a/pn/pn_items_105.csv
+++ b/pn/pn_items_105.csv
@@ -1,7 +1,7 @@
 english,translate
 Turtle Siege Enhancer 2,Усилитель осады черепахи 2
 Tusked Defender,Защитник с клыками
-Twilight Arbor Armor Box,Коробка с броней Сумеречной беседки
+Twilight Arbor Armor Box,Коробка с бронёй Сумеречной беседки
 Twilight Arbor Token Loot Box,Коробка с жетоном Сумеречной беседки
 Twilight Arbor Weapons Box,Коробка с оружием «Сумеречная беседка»
 Twilight Striker,Сумеречный ударник
@@ -15,9 +15,9 @@ Twin Sands,Двойные Пески
 Twin Talons,Парные когти
 Twinspur Pistol,Пистолет Двойного Шипа
 Twinspur Rifle,Винтовка Двойного Шипа
-Twisted Essence of Generosity,Искривленная Эссенция Щедрости
-Twisted Essence of Resolve,Искривленная Эссенция Решимости
-Twisted Essence of Trust,Искривленная Эссенция Доверия
+Twisted Essence of Generosity,Искривлённая Эссенция Щедрости
+Twisted Essence of Resolve,Искривлённая Эссенция Решимости
+Twisted Essence of Trust,Искривлённая Эссенция Доверия
 Twisted Tendril,Скрученный усик
 Twisted Watchwork Portal Device,Искривлённое часовое портальное устройство
 Twisted Watchwork Scrap,Обрезок искажённого часового механизма
@@ -44,7 +44,7 @@ Tyrian Fishing Reward,Тирийская награда за рыбалку
 Tyrian Regions Reward Cache,Тайник с наградой регионов Тирии
 Tyrian Saltwater Fishing License,Лицензия на ловлю солёной рыбы в Тирии
 Tyrian Saltwater Fishing Reward,Награда за ловлю солёной рыбы в Тирии
-Ugly Wool Glider,Планер «Уродливый шерстяной»
+Ugly Wool Glider,Планёр «Уродливый шерстяной»
 Ugly Wool Hat,Уродливая шерстяная шапка
 Ugly Wool Mittens,Некрасивые шерстяные рукавицы
 Ugly Wool Sock,Уродливый шерстяной носок
@@ -64,7 +64,7 @@ Umber Dye,Краска «Умбра»
 Umbral Demon,Теневой демон
 Umbral Demon Skimmer Skin,Облик скиммера «Теневой демон»
 Umbral Serpent Backpack Skin,Облик рюкзака «Теневой змей»
-Umbral Serpent Glider,Планер «Теневой змей»
+Umbral Serpent Glider,Планёр «Теневой змей»
 Umbral Serpent Glider Skin,Облик планера «Теневой змей»
 "Unauthorized ""Mad King Says"" Players Guide",Неофициальное руководство игрока «Безумный король говорит»
 Unbound,Несвязанный
@@ -74,7 +74,7 @@ Unbound Magic Gatherer,Сборщик несвязанной магии
 Unbound Magic Harvesting Blast,Взрыв сбора урожая несвязанной магии
 Unbound Magic Logging Pulse,Импульс рубки леса несвязанной магии
 Unbound Magic Mining Beam,Луч добычи несвязанной магии
-Unbound Mining Pick,Несвязанная кирка шахтера
+Unbound Mining Pick,Несвязанная кирка шахтёра
 Unbreakable Choir Bell,Неразрушимый колокольчик хора
 Unbreakable Garden Trowel,Неразрушимый садовый совок
 Unbreakable Gathering Tools Container,Контейнер с неразрушимыми инструментами для сбора
@@ -131,7 +131,7 @@ Underworld Shadow,Тень Подземного мира
 Undying Shackles Cape,Плащ Неугасимых Оков
 Undying Shackles Cape Skin,Облик накидки «Неумирающие оковы»
 Undying Shackles Cape and Glider Combo,Набор «Неумирающие оковы»: плащ и планер
-Undying Shackles Glider,Планер «Бессмертные оковы»
+Undying Shackles Glider,Планёр «Бессмертные оковы»
 Unethical Test Results,Неэтичные результаты тестов
 Unfinished Azure Dragon Slayer Axe,Незавершённый топор убийцы лазурного дракона
 Unfinished Azure Dragon Slayer Dagger,Незавершённый кинжал убийцы лазурного дракона
@@ -216,7 +216,7 @@ Unlock Weaponsmithing Station,Разблокировать оружейный с
 Unlocked Rift Essence Coffer,Открытый сундук с эссенцией разлома
 Unopened Crystal Shard Kite,Неоткрытый воздушный змей из осколка кристалла
 Unopened Endless Bottle of Batwing Brew,Неоткрытая бесконечная бутылка отвара из летучих мышей
-Unopened Endless Branded Tonic,Неоткрытый бесконечный клейменый тоник
+Unopened Endless Branded Tonic,Неоткрытый бесконечный клеймёный тоник
 Unopened Endless Choya Piñata Tonic,Неоткрытый бесконечный тоник пиньяты чойи
 Unopened Endless Desert Mystery Tonic,Нераспечатанный таинственный тоник Бескрайней пустыни
 Unopened Endless Mystery Tonic,Неоткрытый бесконечный тоник тайны
@@ -448,8 +448,8 @@ Valkyrie Bearkin War Helm,Боевой шлем медвежат Валькир�
 Valkyrie Bronze Dagger of Accuracy,Бронзовый кинжал точности Валькирии
 Valkyrie Bronze Dagger of Force,Бронзовый кинжал силы Валькирии
 Valkyrie Bronze Spear of Force,Бронзовое копьё силы Валькирии
-Valkyrie Corrupted Artifact,Искаженный артефакт Валькирии
-Valkyrie Corrupted Avenger,Оскверненный мститель Валькирии
+Valkyrie Corrupted Artifact,Искажённый артефакт Валькирии
+Valkyrie Corrupted Avenger,Осквернённый мститель Валькирии
 Valkyrie Corrupted Blade,Испорченный клинок Валькирии
 Valkyrie Corrupted Blaster,Искажённый бластер Валькирии
 Valkyrie Corrupted Branch,Испорченная ветвь Валькирии
@@ -465,7 +465,7 @@ Valkyrie Corrupted Short Bow,Испорченный короткий лук Ва
 Valkyrie Corrupted Skeggox,Испорченный скеггокс Валькирии
 Valkyrie Corrupted Sledgehammer,Искажённый кузнечный молот Валькирии
 Valkyrie Corrupted Spear,Испорченное копьё Валькирии
-Valkyrie Corrupted Trident,Оскверненный трезубец Валькирии
+Valkyrie Corrupted Trident,Осквернённый трезубец Валькирии
 Valkyrie Corrupted Wartorch,Искажённый факел войны Валькирии
 Valkyrie Darksteel Axe,Топор из тёмной стали Валькирии
 Valkyrie Darksteel Dagger,Кинжал Валькирии из тёмной стали

--- a/pn/pn_items_106.csv
+++ b/pn/pn_items_106.csv
@@ -181,8 +181,8 @@ Valkyrie Rascal Shoulders of the Thief,Плечи плута вора Вальк
 Valkyrie Ring of Beryl,Кольцо берилла Валькирии
 Valkyrie Silk Insignia,Шёлковая инсигния Валькирии
 Valkyrie Subterfuge Hood of the Thief,Капюшон обмана вора Валькирии
-Valkyrie Tempered Scale Chestplate,Кираса из каленой чешуи Валькирии
-Valkyrie Tempered Scale Gauntlets,Закаленные чешуйчатые перчатки Валькирии
+Valkyrie Tempered Scale Chestplate,Кираса из калёной чешуи Валькирии
+Valkyrie Tempered Scale Gauntlets,Закалённые чешуйчатые перчатки Валькирии
 Valkyrie Tempered Scale Greaves,Наголенники Валькирии из закалённой чешуи
 Valkyrie Tempered Scale Helm,Шлем Валькирии из закалённой чешуи
 Valkyrie Tempered Scale Legs,Штаны Валькирии из закалённой чешуи
@@ -340,7 +340,7 @@ Venombite Warhorn,Боевой рог Ядовитого Укуса
 Venombite Warhorn Skin,Облик боевого рога «Ядовитый укус»
 Venombite Weapon Box,Коробка с оружием «Ядовитый укус»
 Venombite Weapon Choice,Выбор оружия Ядовитого Укуса
-Venombite Wings Glider,Планер «Крылья ядовитого укуса»
+Venombite Wings Glider,Планёр «Крылья ядовитого укуса»
 Venomfish,Ядовитая рыба
 Venomous Feathered Raptor,Ядовитый пернатый раптор
 Venomous Greathorn,Ядовитый большерог

--- a/pn/pn_items_107.csv
+++ b/pn/pn_items_107.csv
@@ -1,5 +1,5 @@
 english,translate
-Vermilion Wings Glider,Планер «Киноварные крылья»
+Vermilion Wings Glider,Планёр «Киноварные крылья»
 Veronica Dye,Краска «Вероника»
 Very Lucky Rabbit's Foot,Лапка очень удачливого кролика
 Very Shiny Thing,Очень блестящая штука
@@ -12,7 +12,7 @@ Veteran Ascalonian Ghost Loot Box,Коробка с добычей ветера�
 Veteran Bane's Teeth Loot Box,Коробка с трофеями зубов ветерана Бейна
 Veteran Banjo the Brown Bear Loot Box,Коробка с добычей ветерана Банджо Бурого Медведя
 Veteran Blu the Brown Shark Loot Box,"Коробка с добычей ветерана Блю, бурой акулы"
-Veteran Branded Minion Loot Box,Коробка с добычей порождения клейменого ветерана
+Veteran Branded Minion Loot Box,Коробка с добычей порождения клеймёного ветерана
 Veteran Cave Troll Loot Box,Коробка с добычей ветерана пещерного тролля
 Veteran Chak Cache,Тайник ветеранов чаков
 Veteran Chest of the Mists,Ветеранский сундук Туманных земель
@@ -107,7 +107,7 @@ Vibrant Companions Mount Adoption Select License,Яркая лицензия н�
 Vibrant Dye Kit,Набор ярких красок
 Vibrant Mountain Griffon Egg,Яйцо яркого горного грифона
 Vibrant Wings Backpack Skin,Рюкзак «Яркие крылья»
-Vibrant Wings Glider,Планер «Яркие крылья»
+Vibrant Wings Glider,Планёр «Яркие крылья»
 Vibrant Wings Glider Skin,Глайдер кожи «Яркие крылья»
 Vicious Claw,Жестокий коготь
 Vicious Fang,Злобный клык
@@ -411,7 +411,7 @@ Vine-Covered Chain Pauldrons,"Наплечники в цепях, покрыты
 Vine-Covered Crate,"Ящик, увитый лозой"
 Vine-Covered Mantle,"Накидка, покрытая лозой"
 Vine-Covered Pauldrons,"Наплечники, покрытые лозой"
-Vine-Touched Destroyer Glider,"Планер «Разрушитель, тронутый лозой»"
+Vine-Touched Destroyer Glider,"Планёр «Разрушитель, тронутый лозой»"
 Vine-Touched Destroyer Glider Combo,Набор «Тронутый лозой разрушитель»: планер
 Vined Cache,Увитый лозой тайник
 Vinelord Edgebloom Axe,Топор Цветочного лорда

--- a/pn/pn_items_108.csv
+++ b/pn/pn_items_108.csv
@@ -264,7 +264,7 @@ Void Corrupted Warhorn,"Боевой рог, развращенный Бездн
 Void Corrupted Warhorn Skin,Облик боевого рога «Порча Бездны»
 Void's Coffer,Сундук Пустоты
 Void's Magnificent Coffer,Великолепный сундук Пустоты
-Void-Corrupted Orb,Искаженная пустотой сфера
+Void-Corrupted Orb,Искажённая пустотой сфера
 Void-Corrupted Orb (Infused),Порочная сфера Бездны (Улучшенная)
 Voided WvW Tournament Claim Ticket,Аннулированный талон турнира WvW
 Voidflame Assassin Dagger,Кинжал убийцы Безднопламени
@@ -288,7 +288,7 @@ Volcanic Backpack and Glider Combo,Набор «Вулканический»: р
 Volcanic Blackfish,Вулканический чёрнорыб
 Volcanic Challenge Mote,Частица вулканического испытания
 Volcanic Earth Elemental Core,Ядро вулканического земляного элементаля
-Volcanic Glider,Планер «Вулканический»
+Volcanic Glider,Планёр «Вулканический»
 Volcanic Ray,Вулканический скат
 Volcanic Rock,Вулканический камень
 Volcanic Scale,Вулканическая чешуя

--- a/pn/pn_items_109.csv
+++ b/pn/pn_items_109.csv
@@ -121,7 +121,7 @@ Watchknight Action Figure,Фигурка часового стража
 Watchknight Greaves,Наголенники часового
 Watchknight Statue,Статуя часового рыцаря
 Watchknight's Harvesting Sickle,Серп жатвы часового
-Watchknight's Logging Axe,Шахтерский топор Стража
+Watchknight's Logging Axe,Шахтёрский топор Стража
 Watchknight's Mining Pick,Шахтерская кирка Стража
 Watchwork Axe,Часовой топор
 Watchwork Chest,Часовой сундук
@@ -167,7 +167,7 @@ Water Dragon Pauldrons,Наплечники водяного дракона
 Water Dragon Pauldrons Skin,Облик наплечников водяного дракона
 Water Dragon Spear,Копьё водяного дракона
 Water Dragon Spear Skin,Облик копья водяного дракона
-Water Dragon Wings Glider,Планер «Крылья водяного дракона»
+Water Dragon Wings Glider,Планёр «Крылья водяного дракона»
 Water Fight Balloon Bucket,Ведро с шарами для водной битвы
 Water Filter,Водяной фильтр
 Water Scepter,Водяной скипетр
@@ -228,8 +228,8 @@ Weaponized Elder Wood Plank,Боевая доска из древней древ
 Weaponized Mithril Ingot,Боевой мифриловый слиток
 Weaponsmith Starter Kit,Набор начинающего оружейника
 Weaponsmith's Notes,Записки оружейника
-Weathered Favor of the Bazaar,Потертая благосклонность базара
-Weathered Favor of the Pavilion,Потертая милость павильона
+Weathered Favor of the Bazaar,Потёртая благосклонность базара
+Weathered Favor of the Pavilion,Потёртая милость павильона
 Weathered Peg Leg,Обветренная деревянная нога
 Weathered Prayer Beads,Потертые чётки
 Weatherwrack,Погодный удар
@@ -280,7 +280,7 @@ Weighted Axe Blade,Утяжелённое лезвие топора
 Weighted Axe Haft,Утяжелённое древко топора
 Weighted Dagger Blade,Утяжелённый клинок кинжала
 Weighted Daysword Blade,Утяжелённый клинок дневного меча
-Weighted Golem Cube,Утяжеленный куб голема
+Weighted Golem Cube,Утяжелённый куб голема
 Weighted Hammer Head,Утяжелённый боёк молота
 Weighted Harpoon,Утяжелённый гарпун
 Weighted Mace Head,Утяжелённый боёк булавы
@@ -290,7 +290,7 @@ Weighted Rifle Barrel,Утяжелённый ствол винтовки
 Weighted Shield Boss,Утяжелённый умбон щита
 Weighted Spearhead,Утяжелённый наконечник копья
 Weighted Staff Head,Утяжелённое навершие посоха
-Weighted Sword Blade,Утяжеленный клинок меча
+Weighted Sword Blade,Утяжелённый клинок меча
 Weighted Torch Head,Утяжелённое навершие факела
 Weighted Trident Head,Утяжелённое навершие трезубца
 Weighted Warhorn Mouthpiece,Утяжелённый мундштук боевого рога
@@ -301,14 +301,14 @@ Well-Cut Jib,Хорошо скроенный кливер
 Welterweight Hatchling,Детёныш полусреднего веса
 West Tarir Commendation,Благодарность Западного Тарира
 Weyandt's Greed,Жадность Вейандта
-Whale Spirit Glider,Планер «Дух кита»
+Whale Spirit Glider,Планёр «Дух кита»
 What's Happening?,Что происходит?
 Wheat,Пшеница
 Wheat Dye,Краска «Пшеничная»
 Wheel of the Lion's Champion,Колесо Львиного чемпиона
 Wheelock Rifle,Колесцовая винтовка
 Whetstone,Точильный камень
-Whisper,Шепот
+Whisper,Шёпот
 Whisper Dye,Краска «Шёпот»
 Whisper Model K Pistol,Пистолет модели «Шёпот» K
 Whisper Model KX Pistol,Пистолет модели «Шёпот» KX
@@ -342,11 +342,11 @@ Whisper's Secret Scepter,Тайный скипетр Шёпота
 Whisper's Secret Shield,Тайный щит Шёпота
 Whisper's Secret Short Bow,Тайный короткий лук Шёпота
 Whisper's Secret Shoulderguards,Наплечники тайны Шёпота
-Whisper's Secret Spear,Тайное копьё Шепота
+Whisper's Secret Spear,Тайное копьё Шёпота
 Whisper's Secret Speargun,Тайное гарпунное ружьё Шёпота
 Whisper's Secret Staff,Тайный посох Шёпота
 Whisper's Secret Sword,Тайный меч Шёпота
-Whisper's Secret Tassets,Тайные набедренники Шепота
+Whisper's Secret Tassets,Тайные набедренники Шёпота
 Whisper's Secret Torch,Тайный факел Шёпота
 Whisper's Secret Trident,Тайный трезубец Шёпота
 Whisper's Secret Warhorn,Тайный боевой рог Шёпота
@@ -392,7 +392,7 @@ White Mantle Crest,Герб Белой Мантии
 White Mantle Elite Guard Mask Box,Коробка маски элитного стража Белой Мантии
 White Mantle Gavel,Молот Белой Мантии
 White Mantle Gladius,Гладиус Белой Мантии
-White Mantle Glider,Планер «Белая Мантия»
+White Mantle Glider,Планёр «Белая Мантия»
 White Mantle Greatbow,Большой лук Белой Мантии
 White Mantle Icon,Икона Белой Мантии
 White Mantle Outfit,Костюм Белой Мантии
@@ -461,7 +461,7 @@ Wide-Rim Glasses Skin,Облик очков с широкой оправой
 Wielded by the Ministry of Purity's chief enforcer.,Используется главным блюстителем Ministry of Purity.
 Wild Magic Backpack,Рюкзак дикой магии
 Wild Magic Backpack Glider Combo,Комбо-набор «Дикая магия»: рюкзак и планер
-Wild Magic Glider,Планер «Дикая магия»
+Wild Magic Glider,Планёр «Дикая магия»
 Wild Trihorn,Дикий трехрог
 Wild Trihorn Raptor Skin,Облик дикого трёхрогого раптора
 Wildfire Talisman,Талисман лесного пожара

--- a/pn/pn_items_110.csv
+++ b/pn/pn_items_110.csv
@@ -14,7 +14,7 @@ Winged Headpiece Skin,Облик крылатого головного убор�
 Winged Lantern,Крылатый фонарь
 Winged Mantle,Крылатое оплечье
 Winged Pants,Крылатые штаны
-Winged Reverie Skiff,Крылатый скиф грез
+Winged Reverie Skiff,Крылатый скиф грёз
 Winged Reverie Skiff Skin,Облик лодки «Крылатая греза»
 Winged Tunic,Крылатая туника
 Wings of Dwayna,Крылья Двайны
@@ -63,9 +63,9 @@ Wintergreen Custom Candy Cane Hammer,Кастомный молот-ледене�
 Wintergreen Dagger,Кинжал «Зимняя зелень»
 Wintergreen Dye,Краска «Зимняя зелень»
 Wintergreen Focus,Фокус «Зимняя зелень»
-Wintergreen Greatsword,Зимнезеленый двуручный меч
+Wintergreen Greatsword,Зимнезелёный двуручный меч
 Wintergreen Hammer,Зимнезелёный молот
-Wintergreen Longbow,Зимнезеленый длинный лук
+Wintergreen Longbow,Зимнезелёный длинный лук
 Wintergreen Mace,Булава «Винтергрин»
 Wintergreen Pistol,Пистолет из грушанки
 Wintergreen Rifle,Винтовка «Зимняя зелень»
@@ -74,8 +74,8 @@ Wintergreen Shield,Щит «Винтергрин»
 Wintergreen Short Bow,Короткий лук зимней зелени
 Wintergreen Staff,Посох зимней зелени
 Wintergreen Sword,Зимнезелёный меч
-Wintergreen Torch,Зимнезеленый факел
-Wintergreen Warhorn,Зимнезеленый боевой рог
+Wintergreen Torch,Зимнезелёный факел
+Wintergreen Warhorn,Зимнезелёный боевой рог
 Wintermint,Зимняя мята
 Wintermint Dye,Краска «Зимняя мята»
 Wintersbark,Зимокора
@@ -151,7 +151,7 @@ Wish for Progress,Пожелание прогресса
 Wish for Unity,Желание единства
 Wissper Inssani Elegy Mosaic,Мозаика элегии Висспера Инссани
 Wisteria,Глициния
-Witch Cauldron Chair,Кресло «Котел ведьмы»
+Witch Cauldron Chair,Кресло «Котёл ведьмы»
 Witch Doctor's Clutches,Хватка знахаря
 Witch Doctor's Coat,Куртка знахаря
 Witch Doctor's Leggings,Поножи знахаря
@@ -161,8 +161,8 @@ Witch's Coat,Куртка ведьмы
 Witch's Gloves,Перчатки Ведьмы
 Witherbreeches,Увядшие Штаны
 Wizard Lightning Finisher,Добивание «Молния волшебника»
-Wizard's Ascended Armor Chest,Сундук вознесенной брони волшебника
-Wizard's Ascended Weapon Chest,Сундук вознесенного оружия волшебника
+Wizard's Ascended Armor Chest,Сундук вознесённой брони волшебника
+Wizard's Ascended Weapon Chest,Сундук вознесённого оружия волшебника
 Wizard's Box of Crafting Materials,Коробка материалов для крафта волшебника
 Wizard's Hat,Шляпа волшебника
 Wizard's Hat Skin,«Облик шляпы волшебника»
@@ -217,7 +217,7 @@ Wolf's Loyalty,Верность Волка
 Wolf-Tooth Trophy,Трофей «Волчий зуб»
 Wolfborn Axe,Волкорождённый топор
 Wolfborn Boots,Сапоги волчьего рождения
-Wolfborn Bracers,Наручи волкорожденного
+Wolfborn Bracers,Наручи волкорождённого
 Wolfborn Dagger,Волкорождённый кинжал
 Wolfborn Focus,Волкорождённый фокус
 Wolfborn Greatsword,Волкорождённый двуручный меч
@@ -293,7 +293,7 @@ Worm Rancher's Gauntlets,Перчатки червячного фермера
 Worm Rancher's Gloves,Рукавицы червячного фермера
 Worm Rancher's Studded Gloves,Перчатки с шипами червячного фермера
 Worm Rancher's Torch,Факел червячного фермера
-Worn Bone,Потертая кость
+Worn Bone,Потёртая кость
 Worn Bone Dye,Краска «Потёртая кость»
 Worn Chain Coat,Потёртая кольчужная куртка
 Worn Chain Gauntlets,Потёртые кольчужные перчатки
@@ -328,9 +328,9 @@ Wrangler Shoulders,Наплечники вранглера
 Wrangler's Bag,Сумка пастуха
 Wrapped Axe,Обмотанный топор
 Wrapped Dagger,Обмотанный кинжал
-Wrapped Focus,Обернутый фокус
+Wrapped Focus,Обёрнутый фокус
 Wrapped Gift,Завёрнутый подарок
-Wrapped Greatsword,Обернутый двуручный меч
+Wrapped Greatsword,Обёрнутый двуручный меч
 Wrapped Hammer,Обмотанный молот
 Wrapped Longbow,Обмотанный длинный лук
 Wrapped Mace,Обмотанная булава
@@ -341,7 +341,7 @@ Wrapped Shield,Обёрнутый щит
 Wrapped Short Bow,Обёрнутый короткий лук
 Wrapped Staff,Обёрнутый посох
 Wrapped Sword,Обёрнутый меч
-Wrapped Torch,Обернутый факел
+Wrapped Torch,Обёрнутый факел
 Wrapped Warhorn,Свернутый боевой рог
 Wrappings of the Lich,Обмотки лича
 Wrath,Гнев
@@ -383,7 +383,7 @@ Writ of Studied Accuracy,Грамота изученной точности
 Writ of Studied Malice,Грамота изученной злобы
 Writ of Studied Speed,Грамота изученной скорости
 Writ of Studied Strength,Грамота изученной силы
-Wupwup Armor Chest,Сундук с броней Вупвуп
+Wupwup Armor Chest,Сундук с бронёй Вупвуп
 Wupwup Artifact,Артефакт Вупвуп
 Wupwup Bastion,Бастион Вупвуп
 Wupwup Blade,Клинок Вупвуп

--- a/pn/pn_items_111.csv
+++ b/pn/pn_items_111.csv
@@ -192,7 +192,7 @@ Zephyrite Lightning Helm,Шлем молнии зефиритов
 Zephyrite Longbow,Зефиритский длинный лук
 Zephyrite Mace,Зефиритская булава
 Zephyrite Paraglider,Зефиритский параплан
-Zephyrite Paraglider Glider,Планер «Параплан зефиритов»
+Zephyrite Paraglider Glider,Планёр «Параплан зефиритов»
 Zephyrite Pistol,Зефиритский пистолет
 Zephyrite Rescue Pack,Спасательный набор зефиритов
 Zephyrite Rescue Recording,Спасательная запись зефиритов

--- a/pn/pn_names_001.csv
+++ b/pn/pn_names_001.csv
@@ -185,13 +185,13 @@ Alliance Investigation,Расследование альянса
 Allie,Алли
 Alligator,Аллигатор
 Allyn,Аллин
-Alma Arrowshot,Алма Стреломет
+Alma Arrowshot,Алма Стреломёт
 Almarr,Алмарр
 Almorra Soulkeeper,Альморра Душехран
 "Alphard, Serpent of the Waves","Альфард, Змей Волн"
 Alpine Bull Minotaur,Альпийский бык-минотавр
 Alpine Ewe,Альпийская овца
-Alpine Skelk Hatchling,Детеныш альпийского скелка
+Alpine Skelk Hatchling,Детёныш альпийского скелка
 Alta Maneshifter,Альта Оборотень
 Alteria Cogchaser,Альтерия Когчейзер
 Althair,Альтаир
@@ -243,7 +243,7 @@ Andrick Stonebleed,Андрик Камнеточец
 Androel,Андроэль
 Anette Eymundrdottir,Анетт Эймундрдоттир
 Angella,Ангелла
-Angry Crab,Разъяренный краб
+Angry Crab,Разъярённый краб
 Angry Wasp,Разъярённая оса
 Anhinga,Змеешейка
 Anise,Анис

--- a/pn/pn_names_002.csv
+++ b/pn/pn_names_002.csv
@@ -1,16 +1,16 @@
 english,translate
 Awaiting Your Arrival,Ожидаем вашего прибытия
-Awakened Abomination,Пробужденная мерзость
+Awakened Abomination,Пробуждённая мерзость
 Awakened Canid,Пробуждённый псоглав
 Awakened Caster,Пробуждённый заклинатель
 Awakened Citizen,Пробуждённый горожанин
 Awakened Earthstalker,Пробуждённый землекоп
 Awakened Exile,Пробуждённый изгнанник
-Awakened General,Генерал пробужденных
+Awakened General,Генерал пробуждённых
 Awakened Inquest,Пробуждённый член Инквеста
 Awakened Inquest Enforcer,Пробуждённый силовик Инквеста
 Awakened Inquest Technician,Пробуждённый техник Инквеста
-Awakened Insect Swarm,Рой пробужденных насекомых
+Awakened Insect Swarm,Рой пробуждённых насекомых
 Awakened Invader,Пробуждённый захватчик
 Awakened Mounts Pack,Набор пробуждённых скакунов
 Awakened Nightwalker,Пробуждённый ночной охотник
@@ -44,7 +44,7 @@ Azuki,Азуки
 Azula Quenchsteel,Азула Гасящая Сталь
 Azzam,Аззам
 Baby,Малыш
-Baby Siege Turtle,Детеныш осадной черепахи
+Baby Siege Turtle,Детёныш осадной черепахи
 Bachlag,Бахлаг
 Badazar,Бадазар
 Badazar's Champion,Чемпион Бадазара
@@ -387,29 +387,29 @@ Bram Dawnrazer,Брэм Зареруш
 Bramble Begone,"Прочь, ежевика!"
 Bran,Бран
 Branching Path,Разветвленный путь
-Brand Thrall,Клейменный раб
+Brand Thrall,Клеймённый раб
 Branded Ambushers,Клеймёные засадники
-Branded Aurene,Клейменная Аурин
-Branded Awakened Mummy,Клейменная ожившая мумия
-Branded Cavalier,Клейменный кавалерист
-Branded Citizen,Клейменный горожанин
+Branded Aurene,Клеймённая Аурин
+Branded Awakened Mummy,Клеймённая ожившая мумия
+Branded Cavalier,Клеймённый кавалерист
+Branded Citizen,Клеймённый горожанин
 Branded Crystal Shield,Клеймёный кристальный щит
 Branded Crystals,Кристаллы клейма
-Branded Devourer,Клейменный пожиратель
-Branded Devourer Hatchling,Клейменный детёныш пожирателя
-Branded Exploder,Клейменный подрывник
+Branded Devourer,Клеймённый пожиратель
+Branded Devourer Hatchling,Клеймённый детёныш пожирателя
+Branded Exploder,Клеймённый подрывник
 Branded Forgotten Priest,Клеймёный забытый жрец
-Branded Free Awakened,Клейменный свободный пробуждённый
-Branded Grub,Клейменная личинка
+Branded Free Awakened,Клеймённый свободный пробуждённый
+Branded Grub,Клеймённая личинка
 Branded Josso Essher,Клеймёный Джоссо Эшер
 Branded Mender,Клеймёный врачеватель
 Branded Mine,Шахта Клейма
 Branded Mounts Pack,Клеймёный набор скакунов
-Branded Ogre,Клейменный огр
-Branded Priest,Клейменный жрец
-Branded Priestess,Клейменная жрица
-Branded Ravager,Клейменный опустошитель
-Branded Sapper,Клейменный сапёр
+Branded Ogre,Клеймённый огр
+Branded Priest,Клеймённый жрец
+Branded Priestess,Клеймённая жрица
+Branded Ravager,Клеймённый опустошитель
+Branded Sapper,Клеймённый сапёр
 Brandstone Elemental,Элементаль клейменного камня
 Brandubh,Брандуб
 Brandulf,Брандульф

--- a/pn/pn_names_003.csv
+++ b/pn/pn_names_003.csv
@@ -1,7 +1,7 @@
 english,translate
 Buoy,Буй
 Burian,Буриан
-Buried Virtue,Погребенная Добродетель
+Buried Virtue,Погребённая Добродетель
 Burncore,Ядрожог
 Burnfast,Скорожог
 Burnham Wurmgut,Бернхэм Кишкодер
@@ -179,7 +179,7 @@ Castaway Harper,Изгой Харпер
 Castaway Hellensdottir,Изгой Хелленсдоттир
 Castaway Jared,Изгой Джаред
 Castaway Jessie,Изгой Джесси
-Castaway Jolly Jim,Изгой Веселый Джим
+Castaway Jolly Jim,Изгой Весёлый Джим
 Castaway Kae,Изгой Кае
 Castaway Karin,Изгой Карин
 Castaway Kash,Изгой Каш
@@ -284,9 +284,9 @@ Champion Baron Sokranos,Чемпион: Барон Сокранос
 Champion Blighted Husk,Чемпион: Пораженная шелуха
 Champion Bloodstone Elemental,Чемпион элементаль кровавого камня
 Champion Bramble Main Stalk,Чемпион: Ежевичный стебель
-Champion Branded Devourer,Клейменный чемпион-пожиратель
-Champion Branded Devourer Queen,Чемпион: Клейменная королева пожирателей
-Champion Branded Earth Elemental,Чемпион: Клейменный элементаль земли
+Champion Branded Devourer,Клеймённый чемпион-пожиратель
+Champion Branded Devourer Queen,Чемпион: Клеймённая королева пожирателей
+Champion Branded Earth Elemental,Чемпион: Клеймённый элементаль земли
 Champion Brewmaster Asef,Чемпион: Пивовар Асеф
 Champion Calimus Pyretooth,Чемпион: Калимус Огнезуб
 Champion Cave Spider,Чемпион пещерный паук
@@ -314,8 +314,8 @@ Champion Dominion Marksman,Чемпион: Меткий стрелок Доми�
 Champion Dominion Spy,Чемпион: Шпион Доминиона
 Champion Elasa the Elemental,Чемпион: Эласа Элементаль
 Champion Emperor Mattake,Чемпион: Император Маттаке
-Champion Enraged Jotun,Чемпион: Разъяренный йотун
-Champion Enraged Spider,Чемпион: Разъяренный паук
+Champion Enraged Jotun,Чемпион: Разъярённый йотун
+Champion Enraged Spider,Чемпион: Разъярённый паук
 Champion Fallen Leopard Shaman,Чемпион: Падший шаман леопардов
 Champion Family-Sized Candy Corn Elemental,Чемпион: Семейный элементаль конфетной кукурузы
 Champion Fire Elemental,Чемпион: Элементаль огня
@@ -385,7 +385,7 @@ Champion Reclaimed Wraith,Чемпион: Восстановленный при�
 Champion Recovery Squad Golem,Чемпион: Голем поискового отряда
 Champion Repurposed Jade Tracker,Чемпион: Перепрофилированный нефритовый следопыт
 Champion Risen Baron,Чемпион: Восставший барон
-Champion Risen Despoiler,Чемпион: Восставший мародер
+Champion Risen Despoiler,Чемпион: Восставший мародёр
 Champion Risen Farmer,Чемпион: Восставший фермер
 Champion Risen Giant,Чемпион Восставший великан
 Champion Risen Noble,Чемпион: Восставший дворянин

--- a/pn/pn_names_004.csv
+++ b/pn/pn_names_004.csv
@@ -1,7 +1,7 @@
 english,translate
 CHOP K1T-B,РУБ-К1Т-Б
 CHOP K1T-C,РУБ-К1Т-В
-Chopper Pilot,Пилот вертолета
+Chopper Pilot,Пилот вертолёта
 Chorister,Хорист
 Chott,Чотт
 Choya Piñata,Чойя-пиньята
@@ -156,8 +156,8 @@ Corrupted First Mate Dolus,Осквернённый старпом Долус
 Corrupted Jade,Осквернённый нефрит
 Corrupted Sabiti,Осквернённый Сабити
 Corrupted Scholar,Осквернённый учёный
-Corrupted Shard,Оскверненный осколок
-Corrupted Wolverine Spirit,Дух оскверненного росомахи
+Corrupted Shard,Осквернённый осколок
+Corrupted Wolverine Spirit,Дух осквернённого росомахи
 Corsair Archivist,Архивариус корсаров
 Corsair Buccaneer,Корсар-буканьер
 Corsair Guard,Страж корсаров
@@ -343,7 +343,7 @@ Cunning Melody,Хитрая мелодия
 Curator,Куратор
 Curator Ruras,Куратор Рурас
 Curious Remedy,Любопытное снадобье
-Cursed Flintlock,Проклятый кремневый пистоль
+Cursed Flintlock,Проклятый кремнёвый пистоль
 Custodian Minu,Смотритель Мину
 Customer,Клиент
 Cutspecter,Призракорез
@@ -487,7 +487,7 @@ Deputy Tarff,Заместитель Тарфф
 Deputy Urtt,Заместитель Уртт
 Derby Fan,Фанатка дерби
 Derketo,Деркето
-Desert Cheetah Cub,Детеныш пустынного гепарда
+Desert Cheetah Cub,Детёныш пустынного гепарда
 Desert Devourer,Пустынный пожиратель
 Desert Devourer Hatchling,Выводок пустынного пожирателя
 Desert Fox,Пустынная лиса

--- a/pn/pn_names_005.csv
+++ b/pn/pn_names_005.csv
@@ -55,21 +55,21 @@ Disguised Agent,Замаскированный агент
 Disheartened Refugee,Разочарованный беженец
 Dishwasher,Посудомойщик
 Disoriented Hylek,Дезориентированный хилек
-Displaced Agent,Перемещенный агент
-Displaced Beetle,Перемещенный жук
-Displaced Boar,Перемещенный кабан
-Displaced Forest Spider,Перемещенный лесной паук
-Displaced Hawkeye Griffon,Перемещенный грифон-ястреб
-Displaced Instigator,Перемещенный подстрекатель
-Displaced Polar Bear,Перемещенный белый медведь
-Displaced Researcher,Перемещенный исследователь
-Displaced Rock Dog,Перемещенный каменный пес
-Displaced Snow Leopard,Перемещенный снежный барс
-Displaced Spirit,Перемещенный дух
-Displaced Tar Elemental,Перемещенный элементаль смолы
+Displaced Agent,Перемещённый агент
+Displaced Beetle,Перемещённый жук
+Displaced Boar,Перемещённый кабан
+Displaced Forest Spider,Перемещённый лесной паук
+Displaced Hawkeye Griffon,Перемещённый грифон-ястреб
+Displaced Instigator,Перемещённый подстрекатель
+Displaced Polar Bear,Перемещённый белый медведь
+Displaced Researcher,Перемещённый исследователь
+Displaced Rock Dog,Перемещённый каменный пес
+Displaced Snow Leopard,Перемещённый снежный барс
+Displaced Spirit,Перемещённый дух
+Displaced Tar Elemental,Перемещённый элементаль смолы
 Distant Memory,Далекое воспоминание
-Distorted Facet of Darkness,Искаженная грань Тьмы
-Distorted Facet of Strength,Искаженная грань Силы
+Distorted Facet of Darkness,Искажённая грань Тьмы
+Distorted Facet of Strength,Искажённая грань Силы
 Distraught Ghost,Обезумевший призрак
 Distressed Mech,Повреждённый мех
 Distressed Scavenger,Обеспокоенный падальщик
@@ -346,8 +346,8 @@ Elite Branded Siege Devourer,Элитный клейменный осадный 
 Elite Canthan Spirit Tahkayun,Элитный кантанский дух Такаян
 Elite Chak Bracer,Элитный чак-браслет
 Elite Charr Tank,Элитный танк чарр
-Elite Corrupted Naga Wavecaller,Элитный оскверненный нага-волнотворец
-Elite Corrupted Sylvari,Элитный оскверненный сильвари
+Elite Corrupted Naga Wavecaller,Элитный осквернённый нага-волнотворец
+Elite Corrupted Sylvari,Элитный осквернённый сильвари
 Elite Coursing Jade Spark,Элитная бегущая нефритовая искра
 Elite Coztic Shadowleaper,Элитный козтик-прыгун теней
 Elite Crazed Harathi Lancer,Элитный обезумевший харати-копейщик
@@ -442,7 +442,7 @@ Elite Nightmare Court Knight,Элитный рыцарь Кошмарного д
 Elite Nightmare Hypnoss,Элитный кошмарный гипнотизер
 Elite Nightmare Vine,Элитная кошмарная лоза
 Elite Oni,Элитный они
-Elite Orrian Spectral Flamecaster,Элитный оррианский призрачный огнеметчик
+Elite Orrian Spectral Flamecaster,Элитный оррианский призрачный огнемётчик
 Elite Orrian Spectral Ghostblade,Элитный оррианский призрачный клинок
 Elite Orrian Spectral Guard,Элитный оррианский призрачный страж
 Elite Orrian Spectral Juggernaut,Элитный оррианский призрачный джаггернаут

--- a/pn/pn_names_006.csv
+++ b/pn/pn_names_006.csv
@@ -75,9 +75,9 @@ Engineer Rawscowl,Инженер Роускаул
 Engineer Verutum,Инженер Верутум
 Engineer Vexus Snarlgear,Инженер Вексус Рычащая Шестерня
 Enoki,Эноки
-Enraged Ettin,Разъяренный эттин
-Enraged Quaggan,Разъяренный квагган
-Enraged Water Sprite,Разъяренный водный дух
+Enraged Ettin,Разъярённый эттин
+Enraged Quaggan,Разъярённый квагган
+Enraged Water Sprite,Разъярённый водный дух
 Ensign Wilton,Прапорщик Уилтон
 Enslaved Charr,Порабощенный чарр
 Enthralled Ooze,Очарованная слизь
@@ -210,7 +210,7 @@ Fafnarin the Heartslayer,Фафнарин Сердцеед
 Fafnir,Фафнир
 Fahd,Фахд
 Fahranur,Фахранур
-Fahrar Cub,Детеныш фахрара
+Fahrar Cub,Детёныш фахрара
 Fahrtak Shatterfiend,Фартак-осквернитель
 Faint Ghostnight,Фэйнт Ночепризрак
 Faithbreaker,Веролом
@@ -350,7 +350,7 @@ Fixx,Фикс
 Fjotli,Фьотли
 Flakk,Флакк
 Flame Acolyte,Аколит Пламени
-Flame Cub,Детеныш Пламени
+Flame Cub,Детёныш Пламени
 Flame Legion Acolyte,Аколит Легиона Пламени
 Flame Legion Ammo Runner,Снабженец Легиона Пламени
 Flame Legion Egg Thief,Похититель яиц Легиона Пламени
@@ -455,7 +455,7 @@ Frayne,Фрейн
 Frazzela,Фраззела
 Freddie,Фредди
 Fredric,Фредрик
-Free Awakened,Свободные Пробужденные
+Free Awakened,Свободные Пробуждённые
 Free Awakened Caster,Свободный заклинатель Пробуждённых
 Free Awakened Soldier,Свободный солдат Пробуждённых
 Free Kryptis Essence,Свободная эссенция криптис
@@ -495,7 +495,7 @@ Frost Spirit,Ледяной дух
 Frostfang,Ледяной Клык
 Frozen Jade Researcher,Замороженный исследователь нефрита
 Frozen Teeth,Ледяные зубья
-Frozen Tide,Замерзший прилив
+Frozen Tide,Замёрзший прилив
 Frozenwind,Фрозенвинд
 Frozz,Фрозз
 Frustrated Daxi,Разочарованный Дакси

--- a/pn/pn_names_007.csv
+++ b/pn/pn_names_007.csv
@@ -8,8 +8,8 @@ Fulgent Fence,Сияющее ограждение
 Fulla,Фулла
 Fulmyna Blaststone,Фулмина Взрывокамень
 Fumalna Sootbristle,Фумальна Сажещетин
-Fuming Ash Legion Soldier,Разъяренный солдат Пепельного легиона
-Fuming Blood Legion Soldier,Разъяренный солдат Кровавого легиона
+Fuming Ash Legion Soldier,Разъярённый солдат Пепельного легиона
+Fuming Blood Legion Soldier,Разъярённый солдат Кровавого легиона
 Fural Rageseeker,Фурал Искатель Ярости
 Furore Hauntsmash,Furore Hauntsmash
 Fursarai,Фурсараи

--- a/pn/pn_names_008.csv
+++ b/pn/pn_names_008.csv
@@ -71,7 +71,7 @@ Hoelbrak Emissary,Эмиссар Хоэльбрака
 Holfi Driftslayer,Холфи Убийца Дрифтов
 Holla Copperwield,Холла Коппервилд
 Hollowed Bomber,Полый бомбардир
-Holo Branded Devourer Hatchling,"Голографический вылупившийся пожиратель, заклейменный кристаллами"
+Holo Branded Devourer Hatchling,"Голографический вылупившийся пожиратель, заклеймённый кристаллами"
 Holo Eye of Zhaitan,Голографический Глаз Зайтана
 Holo Knut Whitebear,Голографический Кнут Белый Медведь
 Hologram of Kudu,Голограмма Куду
@@ -164,7 +164,7 @@ Hypnotized Spectator,Загипнотизированный зритель
 Hywel,Хивел
 Iberu,Иберу
 Ibli,Ибли
-Ice Drake Hatchling,Детеныш ледяного дрейка
+Ice Drake Hatchling,Детёныш ледяного дрейка
 Ice Elemental,Ледяной элементаль
 Ice Shark,Ледяная акула
 Ice Troll,Ледяной тролль
@@ -327,7 +327,7 @@ Iowerth,Иоверт
 Ipos Hookgill,Ипос Крюкожабр
 Iqmin,Икмин
 Iraf,Ираф
-Irate Bull,Разъяренный бык
+Irate Bull,Разъярённый бык
 Iris,Ирис
 Irja,Ирья
 Iroh,Айро
@@ -350,7 +350,7 @@ Irondock Engineer's Apprentice,Ученик инженера Железного 
 Ironsnout,Железнорыл
 Irontooth,Железнозуб
 Irradiated Inquest,Облучённый член Инквеста
-Irradiated Rat,Облученная крыса
+Irradiated Rat,Облучённая крыса
 Irritable Crab,Раздражительный краб
 Irritable Villager,Раздражительный селянин
 Irukka,Ирукка
@@ -392,7 +392,7 @@ Jacaranda,Жакаранда
 Jacaranda Seedling,Саженец джакаранды
 Jacinta Longclaw,Джасинта Длинный Коготь
 Jack,Джек
-Jack (Warclaw Cub (grey)),Джек (Детеныш боевого когтя (серый))
+Jack (Warclaw Cub (grey)),Джек (Детёныш боевого когтя (серый))
 Jack-Jack,Джек-Джек
 Jackal,Шакал
 Jackalope,Джекалоп

--- a/pn/pn_names_009.csv
+++ b/pn/pn_names_009.csv
@@ -10,7 +10,7 @@ Joko,Джоко
 Joko Projection,Проекция Джоко
 Jokull,Джокулл
 Jolecia,Джолесия
-Jolly Donny,Веселый Донни
+Jolly Donny,Весёлый Донни
 Jonez,Джонез
 Jonkor,Джонкор
 Jonna,Джонна
@@ -49,7 +49,7 @@ Jumba,Джумба
 Jun Brightclaw,Джун Яркий Коготь
 Jungle Boar,Лесной кабан
 Jungle Larva,Лесная личинка
-Jungle Raptor Hatchling,Детеныш лесного раптора
+Jungle Raptor Hatchling,Детёныш лесного раптора
 Jungle Tendril,Лесной усик
 Junia Twistgear,Джуния Твистгир
 Junior Scientist,Младший учёный
@@ -63,7 +63,7 @@ Justiciar Araya,Юстициарий Арая
 Justin,Джастин
 Juudow,Джудоу
 Juvenile Blue Jellyfish,Юная синяя медуза
-Juvenile Red Jellyfish,Детеныш красной медузы
+Juvenile Red Jellyfish,Детёныш красной медузы
 Juwon Ral,Джувон Рал
 Jyrna Flayspirit,Джирна Флейспирит
 Kaana,Каана
@@ -280,7 +280,7 @@ Kobe,Кобе
 Koda,Кода
 Kodan,Кодан
 Kodan Claw,Когтистый кодан
-Kodan Cub,Детеныш кодана
+Kodan Cub,Детёныш кодана
 Kodan Grandpaw,Дедушка кодан
 Kodan Guard,Страж кодана
 Kodan Horn,Рог кодана
@@ -322,7 +322,7 @@ Krait,Крайт
 Krait Damoss,Крайт Дамосс
 Krait Keymaster,Крайт-ключник
 Krait Orb Carrier,Крайт — носитель сферы
-Krait Raider,Крайт-налетчик
+Krait Raider,Крайт-налётчик
 Krait Slave,Крайт-раб
 Krait Slave Guard,Крайт — охранник рабов
 Krait Slavemaster,Крайт-рабовладелец

--- a/pn/pn_names_011.csv
+++ b/pn/pn_names_011.csv
@@ -72,7 +72,7 @@ Marri Strongshot,Марри Меткий Выстрел
 Marriner,Марринер
 Mars,Марс
 Marsh Mosquito,Болотный комар
-Marsh Spider Hatchling,Детеныш болотного паука
+Marsh Spider Hatchling,Детёныш болотного паука
 Marshal,Маршал
 Marten Bollinger,Мартен Боллинджер
 Martingale,Мартингейл
@@ -143,7 +143,7 @@ Meek Ettin,Робкий эттин
 Meeloomopp,Милумопп
 Meerkat,Сурикат
 Mega Chainsaw the Skeleton,Мега-Бензопила Скелет
-Mega Foostivoo the Merry,Мега-Фустиву Веселый
+Mega Foostivoo the Merry,Мега-Фустиву Весёлый
 Mega Maraca Choya Pinata,Мега-Чойя с маракасами
 Mega Princess Doll,Мега-Кукла Принцесса
 Megalith,Мегалит
@@ -241,7 +241,7 @@ Miner Brenne,Шахтёр Бренне
 Miner Kelgg,Шахтёр Келгг
 Mini,Мини
 Mini Jungle Boar,Мини-лесной кабан
-Mini White Kitten,Мини-белый котенок
+Mini White Kitten,Мини-белый котёнок
 Miniature Waypoint,Миниатюрная путевая точка
 Minion,Миньон
 Minister,Министр
@@ -327,7 +327,7 @@ Modniir Defender,Модниир-защитник
 Modniir Engineer,Модниир-инженер
 Modniir Executioner,Модниир-палач
 Modniir High Sage,Верховный мудрец модниир
-Modniir Raider,Модниир-налетчик
+Modniir Raider,Модниир-налётчик
 Modniir Ulgoth,Модниир Улгот
 Mog,Мог
 Mogi,Моги
@@ -442,7 +442,7 @@ Mura,Мура
 Murakai's Steward,Стюард Муракая
 Murellow,Мурелло
 Murellow Matriarch,Матриарх мурелло
-Murellow Whelp,Детеныш мурелло
+Murellow Whelp,Детёныш мурелло
 Murielle,Мюриэль
 Murkhaunt,Мракоброд
 Murphy,Мерфи

--- a/pn/pn_names_012.csv
+++ b/pn/pn_names_012.csv
@@ -49,7 +49,7 @@ New Kaineng,Новый Кайненг
 New Year Rewards,Новогодние награды
 New Year Weapons,Новогоднее оружие
 Newborn Siege Turtle,Новорожденная осадная черепаха
-Newborn Siege Turtle Hatchling,Детеныш осадной черепахи
+Newborn Siege Turtle Hatchling,Детёныш осадной черепахи
 Newly Awakened,Недавно пробуждённый
 Newly Awakened Trainee,Недавно пробуждённый ученик
 Newton,Ньютон
@@ -491,7 +491,7 @@ PK 632z-M,ПК 632z-M
 Plagan Swordrend,Плаган Мечерез
 Plague Rot,Гниение чумы
 Plains Wurm,Равни́нный червь
-Plains Wurm Hatchling,Детеныш степного червя
+Plains Wurm Hatchling,Детёныш степного червя
 Plains Wurm Queen,Королева степных червей
 Plasma,Плазма
 Plebeian,Плебей

--- a/pn/pn_names_013.csv
+++ b/pn/pn_names_013.csv
@@ -296,7 +296,7 @@ Ralena Stormbringer,Ралена Громовержец
 Rally Point,Точка сбора
 Ralote Foebreaker,Ралотэ Сокрушитель Врагов
 Rama,Рама
-Rampaging Earth Elemental,Разъяренный элементаль земли
+Rampaging Earth Elemental,Разъярённый элементаль земли
 Ramses,Рамзес
 Ranch Hand,Работник ранчо
 Ranch Hand Joe,Работник ранчо Джо
@@ -382,13 +382,13 @@ Red Team Coordinator,Координатор красной команды
 Redeye,Красный Глаз
 Redfoot,Красноног
 Rednax,Реднакс
-Reef Hatchling,Детеныш рифового ската
+Reef Hatchling,Детёныш рифового ската
 Reeva,Рива
 Refugee,Беженец
 Refugee Bjorn,Беженец Бьорн
 Refugee Blacksmith,Беженец-кузнец
 Refugee Camp Director,Директор лагеря беженцев
-Refugee Cub,Беженец-детеныш
+Refugee Cub,Беженец-детёныш
 Refugee Eydis,Беженец Эйдис
 Refugee Farmer,Беженец-фермер
 Refugee Lennart,Беженец Леннарт

--- a/pn/pn_names_014.csv
+++ b/pn/pn_names_014.csv
@@ -44,7 +44,7 @@ Risen Charr Pirate,Восставший чарр-пират
 Risen Chicken,Восставшая курица
 Risen Corpse,Восставший труп
 Risen Defiler,Восставший осквернитель
-Risen Despoiler,Восставший мародер
+Risen Despoiler,Восставший мародёр
 Risen Eagle,Восставший орёл
 Risen Farmer,Восставший фермер
 Risen Fisher,Восставший рыбак
@@ -233,10 +233,10 @@ Sanctum,Святилище
 Sand Cyclone,Песчаный циклон
 Sand Eel,Песчаный угорь
 Sand Elver,Песчаный угорь
-Sand Lion Cub,Детеныш песчаного льва
+Sand Lion Cub,Детёныш песчаного льва
 Sand Lioness,Песчаная львица
 Sand Shark,Песчаная акула
-Sand Shark Pup,Детеныш песчаной акулы
+Sand Shark Pup,Детёныш песчаной акулы
 Sand Wurm,Песчаный червь
 Sandtooth,Песчаный Зуб
 Sandy,Сэнди

--- a/pn/pn_names_015.csv
+++ b/pn/pn_names_015.csv
@@ -84,7 +84,7 @@ Shrieksy,Шрикси
 Shrill Sunderbark,Визгливая Кора
 Shrimpy,Креветка
 Shrine Guardian Ears,Уши стража святилища
-Shrine Guardian Infant,Детеныш стража святилища
+Shrine Guardian Infant,Детёныш стража святилища
 Shrouded Spear,Закутанное копьё
 Shrunken Destroyer Troll,Уменьшенный тролль-разрушитель
 Shu Arai,Шу Араи
@@ -101,7 +101,7 @@ Sidra Scorcheye,Сидра Скорчеглаз
 Siege Master,Мастер осадных орудий
 Siege Master Marith,Мастер осадных орудий Марит
 Siege Turtle,Осадная черепаха
-Siege Turtle Hatchling,Детеныш осадной черепахи
+Siege Turtle Hatchling,Детёныш осадной черепахи
 Siegemaster Dulfy,Мастер осадных орудий Далфи
 Siegemaster Gaddise,Мастер осадных орудий Гаддис
 Sieran,Сиеран
@@ -288,7 +288,7 @@ Spectre of Wrath,Спектр гнева
 Speelunkk,Спилункк
 Spelunker's Delve,Пещера спелеолога
 Spencer,Спенсер
-Spider Hatchling,Детеныш паука
+Spider Hatchling,Детёныш паука
 Spike Trap,Ловушка с шипами
 Spiked Inquest Gloves,Шипованные перчатки Инквеста
 Spiked Inquest Greaves,Шипованные наголенники Инквеста

--- a/pn/pn_names_017.csv
+++ b/pn/pn_names_017.csv
@@ -22,7 +22,7 @@ Veteran Awakened Mummy,Ветеран: пробужденная мумия
 Veteran Awakened Prisoner,Ветеран: пробуждённый заключенный
 Veteran Bandit Cutpurse,Ветеран: бандит-карманник
 Veteran Bandit Leader,Ветеран: главарь бандитов
-Veteran Bandit Raid Leader,Ветеран: лидер бандитского налета
+Veteran Bandit Raid Leader,Ветеран: лидер бандитского налёта
 Veteran Bandit Saboteur,Ветеран: бандит-диверсант
 Veteran Bandit Scout,Ветеран: бандит-разведчик
 Veteran Bandit Spirit,Ветеран: дух бандита
@@ -39,7 +39,7 @@ Veteran Branded Djinn,Ветеран: клеймёный джинн
 Veteran Branded Dredge Excavator,Ветеран: клеймёный землекоп-дредж
 Veteran Branded Dredge Miner,Ветеран: клеймёный шахтер-дредж
 Veteran Branded Earth Elemental,Ветеран: клеймёный элементаль земли
-Veteran Branded Ley-Line Anomaly,Ветеран: клейменая аномалия лей-линии
+Veteran Branded Ley-Line Anomaly,Ветеран: клеймёная аномалия лей-линии
 Veteran Branded Ravager,Ветеран: клеймёный опустошитель
 Veteran Bristleback,Ветеран: щетиноспин
 Veteran Brotherhood Scrapper,Ветеран: мусорщик Братства
@@ -77,8 +77,8 @@ Veteran Destroyer Soldier,Ветеран: Солдат Разрушителей
 Veteran Devourer,Ветеран: Пожиратель
 Veteran Discarded Awakened,Ветеран: Брошенный Пробуждённый
 Veteran Discontent Djinn,Ветеран: Недовольный джинн
-Veteran Displaced Freshwater Crab,Ветеран: Перемещенный пресноводный краб
-Veteran Displaced Polar Bear,Ветеран: Перемещенный белый медведь
+Veteran Displaced Freshwater Crab,Ветеран: Перемещённый пресноводный краб
+Veteran Displaced Polar Bear,Ветеран: Перемещённый белый медведь
 Veteran Dominion Axe Fiend,Ветеран: Топорник Доминиона
 Veteran Dominion Bladestorm,Ветеран: Буреклинок Доминиона
 Veteran Dominion Duelist,Ветеран: Дуэлянт Доминиона
@@ -100,7 +100,7 @@ Veteran Ebon Knight Moith,Ветеран: Эбоновый рыцарь Мойт
 Veteran Edd'ard Sandtail,Ветеран: Эдд'ард Песчаный Хвост
 Veteran Elder Jacaranda,Ветеран: Древняя джакаранда
 Veteran Elonian Skale,Ветеран: Элонский скайл
-Veteran Enraged Ettin,Ветеран: Разъяренный эттин
+Veteran Enraged Ettin,Ветеран: Разъярённый эттин
 Veteran Ert and Burt,Ветеран: Эрт и Берт
 Veteran Escaping Djinn,Ветеран: Сбегающий джинн
 Veteran Ettin,Ветеран: Эттин
@@ -206,14 +206,14 @@ Veteran Orb Scout,Ветеран: Орб-разведчик
 Veteran Orrian Captain,Ветеран: Оррианский капитан
 Veteran Owl Griffon,Ветеран: Совиный грифон
 Veteran Owl Griffon Sire,Ветеран: Отец совиных грифонов
-Veteran Phantom Raider,Ветеран: Фантом-налетчик
+Veteran Phantom Raider,Ветеран: Фантом-налётчик
 Veteran PM-632z,Ветеран: PM-632z
 Veteran Portal Researcher,Ветеран: Исследователь порталов
 Veteran Pummel Spider,Ветеран: Паук-колотун
 Veteran Purist Spirit Archer,Ветеран: Пурист-дух лучника
 Veteran Purist Spirit Swordsman,Ветеран: Дух-мечник пуристов
 Veteran Pyrite Elemental,Ветеран: Пиритовый элементаль
-Veteran Rampaging Skale,Ветеран: Разъяренный скейл
+Veteran Rampaging Skale,Ветеран: Разъярённый скейл
 Veteran Raptor Swiftwing,Ветеран: Раптор Свифтвинг
 Veteran Razorwing Guard,Ветеран: Страж-бритвокрыл
 Veteran Realm Hound,Ветеран: Гончая Царства
@@ -310,7 +310,7 @@ Veteran Undead Romke,Ветеран-нежить Ромке
 Veteran Undersea Wurm,Ветеран-подводный червь
 Veteran Vikon,Ветеран-Викон
 Veteran Void Corpseknitter,Ветеран-Пустотный вязальщик трупов
-Veteran Void Despoiler,Ветеран-Пустотный мародер
+Veteran Void Despoiler,Ветеран-Пустотный мародёр
 Veteran Void Shambler,Ветеран-Пустотный бродяга
 Veteran Void Warforged,Ветеран: Выкованный Пустотой
 Veteran Wallow,Ветеран: Валлоу
@@ -419,7 +419,7 @@ Vortex Crystal,Вихревой кристалл
 Vortex Slash,Вихревой удар
 Vrackan,Вракан
 Vragi Einarson,Враги Эйнарсон
-Vulture Raptor Hatchling,Детеныш стервятника-раптора
+Vulture Raptor Hatchling,Детёныш стервятника-раптора
 Vyacheslav,Вячеслав
 Vyrea Moonshield,Вирея Лунный Щит
 Vyrnn Twobear,Вирнн Двумедведь

--- a/pn/pn_names_018.csv
+++ b/pn/pn_names_018.csv
@@ -15,7 +15,7 @@ Westergard,Вестергард
 Wexx,Векс
 Weyandt,Вейандт
 Whipmane,Плетегрив
-Whiptail Devourer Hatchling,Детеныш пожирателя с хлыстохвостом
+Whiptail Devourer Hatchling,Детёныш пожирателя с хлыстохвостом
 Whisper's Secret,Тайна Шёпота
 Whispers Agent,Агент Шепчущих
 Whispers Creator,Творец Шепчущих
@@ -228,7 +228,7 @@ Zinn,Зинн
 Zinn's Print-o-Matic,Печатающий автомат Зинна
 Zinnia,Цинния
 Zintl Fanatic,Зинтл-фанатик
-Zintl Marauder,Зинтл-мародер
+Zintl Marauder,Зинтл-мародёр
 Zipp,Зипп
 Ziya the Radiant,Зия Сияющая
 Zizel,Зизель

--- a/pn/pn_names_022.csv
+++ b/pn/pn_names_022.csv
@@ -48,16 +48,16 @@ Scout Acan,Разведчик Акан
 Shining Blade Exemplar Talie,"Сияющий клинок, образец Тали"
 Stegron Hornfist,Стегрон Рогокулак
 Traveling Merchant Orthun,Странствующий торговец Orthun
-Awakened Archon Iberu,Пробужденный Архонт Iberu
+Awakened Archon Iberu,Пробуждённый Архонт Iberu
 Bear Shaman Marga,Шаманка Медведицы Марга
 Beetle Trainer Keploch,Trainer жуков Keploch
 Biomancer Plezzi,Биомант Плецци
 Champion Aetherblade Admiral,Чемпион Эфирного клинка Адмирал
 Champion Angry Pet Rock,Чемпион сердитый питомец-камень
 Champion Arrowhead,Чемпион наконечника стрелы
-Champion Awakened Abomination,Чемпион Пробужденное чудовище
+Champion Awakened Abomination,Чемпион Пробуждённое чудовище
 Champion Balthazar's Lost,Чемпион потерянный Balthazar
-Champion Blighted Beast,Чемпион: Оскверненный зверь
+Champion Blighted Beast,Чемпион: Осквернённый зверь
 Champion Brackish Skale,Чемпион Солоноватый чешуйник
 Champion Captain Cork,Чемпион Капитан Корк
 Champion Crystalwing,Чемпион Crystalwing

--- a/pn/pn_names_023.csv
+++ b/pn/pn_names_023.csv
@@ -5,15 +5,15 @@ Awakened Archer,Пробуждённый лучник
 Champion Arid Devourer,Чемпион Arid Devourer
 Champion Arid Parasite Devourer,Чемпион Arid Parasite Devourer
 Champion Asphodel,Чемпион Асфодель
-Champion Awakened Defiler,Чемпион Пробужденный осквернитель
+Champion Awakened Defiler,Чемпион Пробуждённый осквернитель
 Champion Awakened Devastator,Чемпион — пробуждённый опустошитель
 Champion Awakened Scavenger,Чемпион Awakened Scavenger
 Champion Awakened Stray,Чемпион Пробуждённый бродяга
 Champion Bandit Foreman,Чемпион: Бандитский бригадир
 Champion Bat Matriarch,Матриарх летучих мышей-чемпион
 Champion Blossom Weaver,Чемпион: Ткач цветения
-Champion Branded Forgotten Priest,Клейменный чемпион — забытый жрец
-Champion Branded Hydra,Клейменный чемпион — гидра
+Champion Branded Forgotten Priest,Клеймённый чемпион — забытый жрец
+Champion Branded Hydra,Клеймённый чемпион — гидра
 Champion Branded Josso Essher,Чемпион Branded Josso Essher
 Champion Branded Ley-Line Anomaly,Чемпион Branded Ley-Line Anomaly
 Champion Branded Mender,Чемпион Брендированный целитель
@@ -37,7 +37,7 @@ Champion Embalmer Eweje,Чемпион-бальзамировщик Эведже
 Champion Enchanted Staff,Чемпион зачарованный посох
 Champion Engorged Ice Elemental,Чемпион Engorged Ice Elemental
 Champion Enraged Spider Queen,Чемпионская разъяренная королева пауков
-Champion Enraged Spirit,Разъяренный дух-чемпион
+Champion Enraged Spirit,Разъярённый дух-чемпион
 Champion Forged Lurker,Кованый скрытень чемпион
 Champion Frost Totem,Тотем чемпиона-мороза
 Champion Giant Risen Krill,Чемпион гигантский Risen Krill
@@ -87,7 +87,7 @@ Champion Speaker Lieutenant,Чемпион лейтенант Speaker
 Champion Speaker Ritualist,Чемпион ритуалист Speaker
 Champion Steam Commander,Чемпион Паровой Коммандир
 Champion Stone Summit Crusher,Чемпион Каменная Вершина Дробитель
-Champion Svanir Marauder,Чемпион Сванир-мародер
+Champion Svanir Marauder,Чемпион Сванир-мародёр
 Champion Terror-Seven Krewe Leader,Чемпион: лидер группы Ужас-Семь
 Champion Toxic Alchemist,Чемпион: Токсичный алхимик
 Champion Twisted Skelk,Чемпион Twisted Skelk
@@ -125,7 +125,7 @@ Elite Volatile Jade Spark,Элитная нестабильная нефрито
 Engineer Arath,Инженер Арат
 Engineer Snaretooth,Инженер Снейртус
 Jorund Soderhem,Йорунд Сёдерхем
-Legendary Awakened Hoarder,Легендарный пробужденный накопитель
+Legendary Awakened Hoarder,Легендарный пробуждённый накопитель
 Legendary Blade,Легендарный клинок
 Legendary Branded Hydra,Легендарная Клеймёная Гидра
 Legendary Branded Riftstalker Matriarch,Легендарная Клеймёная Матриарх Разломохода
@@ -171,14 +171,14 @@ Veteran Berserker Councillor,Ветеран-берсерк советник
 Veteran Black Moa,Чёрный моа-ветеран
 Veteran Bloated Chromatic Choya,Ветеран: Раздутая хроматическая чойя
 Veteran Branded Charr,Ветеран-изгой чарр
-Veteran Branded Forgotten Priest,Ветеран: Клейменный жрец Забытых
+Veteran Branded Forgotten Priest,Ветеран: Клеймённый жрец Забытых
 Veteran Branded Human,"Ветеран-человек, отмеченный клеймом"
-Veteran Branded Minotaur,Ветеран Клейменный минотавр
+Veteran Branded Minotaur,Ветеран Клеймённый минотавр
 Veteran Branded Ogre,Ветеран клейменного огра
 Veteran Cave Spitter,Ветеран пещерный плевун
 Veteran Chak Blitzer,Ветеран Chak Blitzer
 Veteran Chaos Creature,Ветеран: Существо хаоса
-Veteran Corrupted Hunter,Ветеран Оскверненный охотник
+Veteran Corrupted Hunter,Ветеран Осквернённый охотник
 Veteran Coztic,Ветеран Coztic
 Veteran Crazy Inquest Researcher,Ветеран: Безумный исследователь Inquest
 Veteran Destroyer Troll,Ветеран-тролль-разрушитель

--- a/pn/pn_names_024.csv
+++ b/pn/pn_names_024.csv
@@ -379,8 +379,8 @@ Awakened Lead Researcher,Пробуждённый ведущий исследо�
 Awakened Lieutenant,Пробуждённый лейтенант
 Awakened Lifebinder,Пробуждённый жизневяз
 Awakened Mending,Исцеление Пробуждённых
-Awakened Minelayer,Пробужденный минер
-Awakened Morale,Боевой дух Пробужденных
+Awakened Minelayer,Пробуждённый минер
+Awakened Morale,Боевой дух Пробуждённых
 Awakened Mummy,Пробуждённая мумия
 Awakened Observer,Пробуждённый наблюдатель
 Awakened Officer,Пробуждённый офицер
@@ -493,7 +493,7 @@ Blighted Canach,Заражённый Канах
 Blighted Eir Stegalkin,Заражённый Эйр Стегалкин
 Blighted Electrum,Проклятый электрум
 Blighted Garm,Заражённый Гарм
-Blighted Growth,Оскверненный нарост
+Blighted Growth,Осквернённый нарост
 Blighted Grub,Порченая личинка
 Blighted Husk,Порченая оболочка
 Blighted Maguuma Spring,Порченый источник Магуумы

--- a/pn/pn_names_025.csv
+++ b/pn/pn_names_025.csv
@@ -18,7 +18,7 @@ Blood Legion Soldier,Солдат Кровавого легиона
 Blood Legionnaire,Кровный легионер
 Centurion Volante Tornpaw,Центурион Воланте Рваная Лапа
 Branded Accumulation,Клеймёное накопление
-Branded Griffon,Клейменный грифон
+Branded Griffon,Клеймённый грифон
 Branded Minotaur,Клеймёный минотавр
 Captain Suwash,Капитан Суваш
 Chief Akik'tak,Вождь Акик'так
@@ -59,7 +59,7 @@ Branded Relic,Клеймёная реликвия
 Branded Seed,Клеймёное семя
 Branded Tornado,Клеймёный смерч
 Branded Waterfall,Клеймёный водопад
-Branded Wyvern,Клейменный виверн
+Branded Wyvern,Клеймённый виверн
 Captain Ferrine,Капитан Феррин
 Captain Hao Luen,Капитан Хао Луэн
 Captain Horvath,Капитан Хорват
@@ -90,7 +90,7 @@ Blood Centurion,Центурион Кровавых
 Blood Collector,Сборщик крови
 Blood Collectors,Сборщики крови
 Blood Console,Кровавая консоль
-Blood Cub,Кровавый детеныш
+Blood Cub,Кровавый детёныш
 Blood Cyclone,Кровавый циклон
 Blood Division,Кровавое разделение
 Blood Drinker,Кровопийца
@@ -138,14 +138,14 @@ Branded Beam,Клеймёный луч
 Branded Beasts,Клеймёные звери
 Branded Bolt,Клеймёный разряд
 Branded Bombardier,Клеймёный бомбардир
-Branded Captain,Клейменный капитан
+Branded Captain,Клеймённый капитан
 Branded Charge,Клеймёный заряд
 Branded Charr,Клеймёный чарр
 Branded Charr Physical Death,Клеймёный чарр: физическая смерть
 Branded Chest,Клеймёный сундук
 Branded Chosen Mummy,Клеймёная мумия Избранного
 Branded Conflagration,Фирменный пожар
-Branded Corporal,Клейменный капрал
+Branded Corporal,Клеймённый капрал
 Branded Crystal Containment,Контейнер с клейменным кристаллом
 Branded Crystal Elemental,Клеймёный кристаллический элементаль
 Branded Crystal Explosion,Взрыв клеймёного кристалла
@@ -170,7 +170,7 @@ Branded Glow,Клеймёное свечение
 Branded Gore,Клеймёная кровь
 Branded Heal,Клеймёное исцеление
 Branded Jab,Клеймёный тычок
-Branded Lieutenant,Клейменный лейтенант
+Branded Lieutenant,Клеймённый лейтенант
 Branded Lieutenant Priest,Клеймёный лейтенант-жрец
 Branded Light,Клеймёный свет
 Branded Lighting Strike,Клеймёный молниевый удар
@@ -189,7 +189,7 @@ Branded Rifts' Chest,Сундук разломов Клейма
 Branded Rock Dog,Проклятый каменный пёс
 Branded Rock Spire,Каменный шпиль Клейма
 Branded Runners,Клеймёные бегуны
-Branded Sergeant,Клейменный сержант
+Branded Sergeant,Клеймённый сержант
 Branded Shard Burst,Взрыв осколков Клейма
 Branded Spikes,Шипы из Клейма
 Branded Starfish,Клеймёная морская звезда

--- a/pn/pn_names_027.csv
+++ b/pn/pn_names_027.csv
@@ -385,7 +385,7 @@ Kodan Bureau,Коданское бюро
 Kodan Cabinet,Коданский шкаф
 Kodan Cache Keys,Ключи от тайника коданов
 Kodan Ceiling Lamp,Потолочная лампа коданов
-Kodan Conjured Doorway,Призванный дверной проем коданов
+Kodan Conjured Doorway,Призванный дверной проём коданов
 Kodan Decorative Torch,Декоративный факел коданов
 Kodan Defender,Защитник кодан
 Kodan Experience,Опыт кодан
@@ -415,7 +415,7 @@ Kodan Shoot,Коданий выстрел
 Kodan Sink,Коданое затопление
 Kodan Smash,Коданое сокрушение
 Kodan Snowcaller,Кодан-снегозов
-Kodan Soup Kettle,Коданий суповой котел
+Kodan Soup Kettle,Коданий суповой котёл
 Kodan Stormcaller,Призыватель бурь коданов
 Kodan Table Setting,Сервировка стола кодана
 Kodan Tea Set,Чайный набор кодана

--- a/pn/pn_names_028.csv
+++ b/pn/pn_names_028.csv
@@ -495,7 +495,7 @@ Orrian Corruption,Оррианская порча
 Orrian Corruptions,Осквернения Орриана
 Orrian Crab,Орианский краб
 Orrian Door,Оррианская дверь
-Orrian Elemental Cauldron,Оррианский элементальный котел
+Orrian Elemental Cauldron,Оррианский элементальный котёл
 Orrian Explosives,Оррианская взрывчатка
 Orrian Eye,Оррианское око
 Orrian Finger,Оррианский палец

--- a/pn/pn_names_030.csv
+++ b/pn/pn_names_030.csv
@@ -8,7 +8,7 @@ Seraph Elmder,Серафим Эльмдер
 Supply Box,Коробка с припасами
 Seraph Observers,Серафимы-наблюдатели
 Spirit Energy,Энергия духа
-Scholar Krasso,Ученый Крассо
+Scholar Krasso,Учёный Крассо
 Scholar Merla,Учёный Мерла
 Skritt Tunnel,Туннель скриттов
 Scholar Mossi,Учёный Мосси
@@ -49,7 +49,7 @@ Sand Vortex,Песчаный вихрь
 Scholar Ela Makkay,Учёная Эла Маккей
 Scholar Fryxx,Учёный Фрикс
 Scholar Glokk,Учёный Глокк
-Scholar Nabbi,Ученый Набби
+Scholar Nabbi,Учёный Набби
 Scholar Rakka,Учёный Ракка
 Scout Imal,Разведчик Имал
 Scout Variloo,Разведчик Варилу
@@ -75,7 +75,7 @@ Sand Wave,Песчаная волна
 Sand Wither,Песчаное иссушение
 Scholar Ailis,Учёная Айлис
 Scholar Aimee Testibrie,Учёный Эйми Тестибри
-Scholar Alexis,Ученый Алексис
+Scholar Alexis,Учёный Алексис
 Scholar Andele,Учёный Андель
 Scholar Benita,Учёная Бенита
 Scholar Blaithnat,Учёная Блайтнат

--- a/pn/pn_names_034.csv
+++ b/pn/pn_names_034.csv
@@ -40,39 +40,39 @@ Juvenile Jacaranda,Юная жакаранда
 Juvenile Jaguar,Юный ягуар
 Juvenile Janthiri Bee,Юная джантирская пчела
 Juvenile Jungle Spider,Юный паук джунглей
-Juvenile Jungle Stalker,Детеныш лесного сталкера
-Juvenile Lynx,Детеныш рыси
-Juvenile Marsh Drake,Детеныш болотного дрейка
-Juvenile Murellow,Детеныш муреллоу
-Juvenile Owl,Детеныш совы
-Juvenile Phoenix,Детеныш феникса
-Juvenile Pig,Детеныш свиньи
-Juvenile Pink Moa,Детеныш розового моа
-Juvenile Polar Bear,Детеныш белого медведя
-Juvenile Rainbow Jellyfish,Детеныш радужной медузы
-Juvenile Raptor Swiftwing,Детеныш раптора-быстрокрыла
-Juvenile Raven,Детеныш ворона
-Juvenile Red Moa,Детеныш красного моа
-Juvenile Reef Drake,Детеныш рифового дрейка
-Juvenile River Drake,Детеныш речного дрейка
-Juvenile River Otter,Детеныш речной выдры
-Juvenile Rock Gazelle,Детеныш скальной газели
-Juvenile Sand Lion,Детеныш песчаного льва
-Juvenile Shark,Детеныш акулы
-Juvenile Siamoth,Детеныш сиамота
-Juvenile Siege Turtle,Детеныш осадной черепахи
-Juvenile Sky-Chak Striker,Детеныш небесного чака-налетчика
-Juvenile Smokescale,Детеныш дымочешуя
-Juvenile Snow Leopard,Детеныш снежного барса
-Juvenile Spinegazer,Детеныш шипоглаза
-Juvenile Tiger,Детеныш тигра
-Juvenile Wallow,Детеныш валлоу
-Juvenile Warclaw,Детеныш боевого когтя
-Juvenile Warthog,Детеныш бородавочника
-Juvenile White Moa,Детеныш белого моа
-Juvenile White Raven,Детеныш белого ворона
-Juvenile White Tiger,Детеныш белого тигра
-Juvenile Wolf,Детеныш волка
+Juvenile Jungle Stalker,Детёныш лесного сталкера
+Juvenile Lynx,Детёныш рыси
+Juvenile Marsh Drake,Детёныш болотного дрейка
+Juvenile Murellow,Детёныш муреллоу
+Juvenile Owl,Детёныш совы
+Juvenile Phoenix,Детёныш феникса
+Juvenile Pig,Детёныш свиньи
+Juvenile Pink Moa,Детёныш розового моа
+Juvenile Polar Bear,Детёныш белого медведя
+Juvenile Rainbow Jellyfish,Детёныш радужной медузы
+Juvenile Raptor Swiftwing,Детёныш раптора-быстрокрыла
+Juvenile Raven,Детёныш ворона
+Juvenile Red Moa,Детёныш красного моа
+Juvenile Reef Drake,Детёныш рифового дрейка
+Juvenile River Drake,Детёныш речного дрейка
+Juvenile River Otter,Детёныш речной выдры
+Juvenile Rock Gazelle,Детёныш скальной газели
+Juvenile Sand Lion,Детёныш песчаного льва
+Juvenile Shark,Детёныш акулы
+Juvenile Siamoth,Детёныш сиамота
+Juvenile Siege Turtle,Детёныш осадной черепахи
+Juvenile Sky-Chak Striker,Детёныш небесного чака-налетчика
+Juvenile Smokescale,Детёныш дымочешуя
+Juvenile Snow Leopard,Детёныш снежного барса
+Juvenile Spinegazer,Детёныш шипоглаза
+Juvenile Tiger,Детёныш тигра
+Juvenile Wallow,Детёныш валлоу
+Juvenile Warclaw,Детёныш боевого когтя
+Juvenile Warthog,Детёныш бородавочника
+Juvenile White Moa,Детёныш белого моа
+Juvenile White Raven,Детёныш белого ворона
+Juvenile White Tiger,Детёныш белого тигра
+Juvenile Wolf,Детёныш волка
 Legendary Ravenous Wanderer,Легендарный Ravenous Wanderer
 Legendary Victory,Легендарная победа
 Mordrem Camp Center Area,Центральная зона лагеря Мордрем

--- a/pn/pn_names_037.csv
+++ b/pn/pn_names_037.csv
@@ -62,7 +62,7 @@ Captain Zor,Капитан Зор
 Caravan Guide Willhelm,Караванный проводник Вильхельм
 Carnie Jeb,Балаганщик Джеб
 "Ceara! Ceara, Ceara, Ceara!","Сеара! Сеара, Сеара, Сеара!"
-Champion Branded,Чемпион: Клейменные
+Champion Branded,Чемпион: Клеймённые
 Champion Brotherhood Scrapper,Чемпион: Скраппер Братства
 Champion Cabochon,Чемпион: Кабошон
 Champion Dredge Overseer,Чемпион: Дредж-надзиратель

--- a/pn/pn_names_040.csv
+++ b/pn/pn_names_040.csv
@@ -448,8 +448,8 @@ Vengeance Duration,Длительность Возмездия
 Vengeful Blast,Мстительный взрыв
 Venomspinner,Ядопряд
 Vermignus,Вермигнус
-Veteran Awakened General,Ветеран: Генерал пробужденных
-Veteran Branded Devourer,Ветеран: Клейменный пожиратель
+Veteran Awakened General,Ветеран: Генерал пробуждённых
+Veteran Branded Devourer,Ветеран: Клеймённый пожиратель
 Veteran Countess Lavinia Durheim,Ветеран: Графиня Лавиния Дурхейм
 Veteran Enraged Spider Queen,Ветеран: Разъярённая королева пауков
 Veteran Fleshreaver,Ветеран: Плотерез

--- a/pn/pn_skills_001.csv
+++ b/pn/pn_skills_001.csv
@@ -109,7 +109,7 @@ Facet of Elements,Грань стихий
 Fire Trail,Огненный след
 Flame Blast,Огненный взрыв
 Forsaken Magic,Забытая магия
-Frozen Ground,Замерзшая земля
+Frozen Ground,Замёрзшая земля
 Glider Basics,Основы планирования
 Great Champion,Великий чемпион
 Hounds of Balthazar,Гончие Бальтазара
@@ -133,7 +133,7 @@ Siren of Orr,Сирена из Орра
 Tectonic Shift,Тектонический сдвиг
 Toss Elixir U,Бросить эликсир U
 Warclaw Mount,Ездовой варкло
-We Bleed Fire,Мы истекаем огнем
+We Bleed Fire,Мы истекаем огнём
 Weave Self,Сплетение стихий
 Wild Castoran Magic,Дикая магия Касторана
 Your condition damage is increased.,Ваш урон от состояний увеличен.
@@ -254,7 +254,7 @@ Toss Elixir C,Бросить эликсир C
 Toss Elixir H,Бросить эликсир H
 Toss Elixir R,Бросить эликсир R
 Train this mastery to gain bonus effects:,"Изучите это мастерство, чтобы получить бонусные эффекты:"
-United Legions Waystation Synchronization,Синхронизация перевалочного пункта Объединенных легионов
+United Legions Waystation Synchronization,Синхронизация перевалочного пункта Объединённых легионов
 Unlock the A New Friend achievement.,Разблокируйте достижение «Новый друг».
 Unsheathe Gunsaber,Обнажить гансейбер
 Unstable Skritt Bomb,Нестабильная бомба скриттов
@@ -361,7 +361,7 @@ Flame Expulsion,Выброс пламени
 Focused Destruction,Сфокусированное разрушение
 Forest's Fortification,Укрепление леса
 Form of the Warrior,Облик воина
-Fortified Descent,Укрепленный спуск
+Fortified Descent,Укреплённый спуск
 Frostbite Aura,Аура обморожения
 "Gain bonus power, which is increased when wielding a dagger.","Получайте бонус к силе, который увеличивается при использовании кинжала."
 "Gain power, then gain extra power while you are revealed.","Получайте силу, а затем дополнительную силу, пока вы раскрыты."

--- a/pn/pn_skills_003.csv
+++ b/pn/pn_skills_003.csv
@@ -136,7 +136,7 @@ Arcane Restoration,Магическое восстановление
 Arcane Resurrection,Магическое воскрешение
 Arcane Thievery,Магическое воровство
 Arcane Wave,Магическая волна
-Archivist of Whispers,Архивариус Шепотов
+Archivist of Whispers,Архивариус Шёпотов
 Arcing Affliction,Дуговое поражение
 Arcing Arrow,Дуговая стрела
 Arcing Jade,Дуговой нефрит
@@ -158,7 +158,7 @@ Astral Amenities,Астральные удобства
 Astral Force per Damage,Астральная сила за урон
 Astral Force per Heal,Астральная сила за исцеление
 Astral Surge,Астральный всплеск
-Astral Wisp,Астральный огонек
+Astral Wisp,Астральный огонёк
 "At maximum, charges gain a burst of power.",При достижении максимума заряды дают всплеск силы.
 "At maximum, charges gain a burst of speed.",При достижении максимума заряды дают всплеск скорости.
 Attack of Opportunity,Атака по возможности
@@ -349,8 +349,8 @@ Boiling Point,Точка кипения
 Bola Shot,Выстрел бола
 Bold Reversal,Смелый разворот
 Bolster Allies,Поддержка союзников
-Bolstered Bonds,Укрепленные узы
-Bolstered Elements,Укрепленные элементы
+Bolstered Bonds,Укреплённые узы
+Bolstered Elements,Укреплённые элементы
 Bolstering Brew,Укрепляющее варево
 Bolt Break,Разрыв молнии
 Bolt of Wrath,Стрела гнева

--- a/pn/pn_skills_004.csv
+++ b/pn/pn_skills_004.csv
@@ -177,10 +177,10 @@ Corpse Detonation,Детонация трупа
 Corrosive Residue,Едкий остаток
 Corrupt Boon,Осквернение благословения
 Corrupt the Living,Испортить живое
-Corrupted Claws,Оскверненные когти
-Corrupted Ground,Оскверненная земля
-Corrupted Siphon,Оскверненный сифон
-Corrupted Talent,Оскверненный талант
+Corrupted Claws,Осквернённые когти
+Corrupted Ground,Осквернённая земля
+Corrupted Siphon,Осквернённый сифон
+Corrupted Talent,Осквернённый талант
 Corrupter's Fervor,Пыл осквернителя
 Corrupting Vines,Оскверняющие лозы
 Corruption,Осквернение

--- a/pn/pn_skills_005.csv
+++ b/pn/pn_skills_005.csv
@@ -389,7 +389,7 @@ Flame Wave,Огненная волна
 Flame Wheel,Огненное колесо
 Flame bursts from torch skills inflict additional burning.,Вспышки пламени от умений факела вызывают дополнительное горение.
 Flamestrike,Огненный удар
-Flamethrower,Огнемет
+Flamethrower,Огнемёт
 Flamewall,Стена пламени
 Flaming Cascade,Огненный каскад
 Flaming Flurry,Огненный шквал

--- a/pn/pn_skills_006.csv
+++ b/pn/pn_skills_006.csv
@@ -9,7 +9,7 @@ Frost Volley,Ледяной залп
 Frostblades,Ледяные клинки
 Frostfire Flurry,Ледяной шквал
 Frostfire Ward,Ледяной оберег
-Frozen Abyss,Замерзшая бездна
+Frozen Abyss,Замёрзшая бездна
 Frozen Barrier,Ледяной барьер
 Frozen Burst,Ледяной взрыв
 Frozen Demise,Ледяная гибель
@@ -241,9 +241,9 @@ Hamstring,Подрезание сухожилий
 Hard Light Arena,Арена жесткого света
 Hard to Catch,Трудноуловимый
 Harden,Закалка
-Hardened Armor,Закаленная броня
-Hardened Auras,Закаленные ауры
-Hardened Chrome,Закаленный хром
+Hardened Armor,Закалённая броня
+Hardened Auras,Закалённые ауры
+Hardened Chrome,Закалённый хром
 Hardening Persistence,Упорство закалки
 Hardy Conduit,Стойкий проводник
 Hare's Agility,Заячья ловкость
@@ -395,7 +395,7 @@ Icy Roar,Ледяной рык
 Icy Screech,Ледяной визг
 Ignite,Воспламенение
 Igniting Brand,Воспламеняющее клеймо
-Illuminated,Озаренный
+Illuminated,Озарённый
 Illuminating Inspiration,Озаряющее вдохновение
 Illusion of Drowning,Иллюзия утопления
 Illusion of Vulnerability,Иллюзия уязвимости

--- a/pn/pn_skills_007.csv
+++ b/pn/pn_skills_007.csv
@@ -276,7 +276,7 @@ Mantra of Lore,Мантра знаний
 Mantra of Potence,Мантра мощи
 Mantra of Solace,Мантра утешения
 Mantra of Truth,Мантра истины
-Marauder's Resilience,Стойкость мародера
+Marauder's Resilience,Стойкость мародёра
 Mariner's Frenzy,Ярость моряка
 Mariner's Shot,Выстрел моряка
 Mark of Anguish,Метка мучений
@@ -320,7 +320,7 @@ Measured Shot,Выверенный выстрел
 Mech Arms: High-Impact Drivers,Механические руки: Ударные приводы
 Mech Arms: Jade Cannons,Механические руки: Нефритовые пушки
 Mech Arms: Single-Edge Cutters,Механические руки: Однолезвийные резаки
-Mech Command. Launch a powerful mortar attack at the target.,Команда меха. Нанесите мощный минометный удар по цели.
+Mech Command. Launch a powerful mortar attack at the target.,Команда меха. Нанесите мощный миномётный удар по цели.
 Mech Core: Barrier Engine,Ядро меха: Барьерный двигатель
 Mech Core: J-Drive,Ядро меха: J-привод
 Mech Core: Jade Dynamo,Ядро меха: Нефритовое динамо
@@ -396,7 +396,7 @@ Mist Smash,Сокрушающий удар Тумана
 Mist Swing,Взмах Тумана
 Mist Unleashed,Высвобожденный Туман
 Mist-Charged Chop,Заряженный Туманом рубящий удар
-Mistburn Mortar,Миномет «Ожог Тумана»
+Mistburn Mortar,Миномёт «Ожог Тумана»
 Mistfire,Огонь тумана
 Mistlock Instability: Earthquake,Нестабильность Тумана: Землетрясение
 Mistral,Мистраль

--- a/pn/pn_skills_008.csv
+++ b/pn/pn_skills_008.csv
@@ -228,7 +228,7 @@ Procession of Blades,Процессия клинков
 Prodigious Pincher,Чудовищный захватчик
 Productive Downtime,Продуктивный отдых
 Project Tranquility,Проект «Спокойствие»
-Prolific Plunderer,Плодовитый мародер
+Prolific Plunderer,Плодовитый мародёр
 Propel,Движение
 Prosperity Unending,Бесконечное процветание
 Protecting Screech,Защитный визг

--- a/pn/pn_skills_010.csv
+++ b/pn/pn_skills_010.csv
@@ -2,7 +2,7 @@ english,translate
 Stow Flamethrower,Убрать огнемет
 Stow Grenade Kit,Убрать набор гранат
 Stow Med Kit,Убрать аптечку
-Stow Mortar Kit,Убрать миномет
+Stow Mortar Kit,Убрать миномёт
 Stow Tome,Убрать фолиант
 Stow Tool Kit,Убрать набор инструментов
 Stream Strike,Потоковый удар
@@ -305,9 +305,9 @@ Twin Fangs,Двойные клыки
 Twin Moon Sweep,Удар двойной луны
 Twin Strike,Двойной удар
 Twist of Fate,Ирония судьбы
-Twisted Light,Искаженный свет
-Twisted Medicine,Искаженная медицина
-Twisted Shadow,Искаженная тень
+Twisted Light,Искажённый свет
+Twisted Medicine,Искажённая медицина
+Twisted Shadow,Искажённая тень
 Twister,Вихрь
 Twisting Fangs,Скрученные клыки
 Two-Clone Heal,Исцеление двумя клонами
@@ -326,7 +326,7 @@ Unhindered Delivery,Беспрепятственная доставка
 Unholy Feast,Нечестивый пир
 Unholy Martyr,Нечестивый мученик
 Unholy Sanctuary,Нечестивое святилище
-United Legions Waystation Mastery,Мастерство перевалочного пункта Объединенных легионов
+United Legions Waystation Mastery,Мастерство перевалочного пункта Объединённых легионов
 Unleash Pet,Высвободить питомца
 Unleash Ranger,Высвободить рейнджера
 Unleashed,Высвобожденный

--- a/pn/pn_skills_011.csv
+++ b/pn/pn_skills_011.csv
@@ -68,7 +68,7 @@ Wings of Resolve,Крылья решимости
 Winter's Bite,Укус зимы
 Wintersday Aura,Аура Дня зимы
 Wintry Orb,Зимняя сфера
-Wisp of Will,Огонек воли
+Wisp of Will,Огонёк воли
 Withdraw,Отступление
 Withering Plague,Увядающая чума
 Wolf's Onslaught,Натиск волка

--- a/pn/pn_terms_001.csv
+++ b/pn/pn_terms_001.csv
@@ -11,13 +11,13 @@ asura,асура
 asuran,асурский
 asurans,асура
 aurillium,ауриллий
-Awakened,Пробужденные
+Awakened,Пробуждённые
 Balthazar's Mercenaries,Наемники Бальтазара
 Bandits,Бандиты
 Black Lion Trading Company,Чёрная торговая компания
 Blood Legion,Кровавый легион
 bookah,букашка
-Branded,Клейменные
+Branded,Клеймённые
 Breachmaker,Брешелом
 Brim & Scarab Detective Agency,Детективное агентство «Брим и Скарабей»
 Brotherhood of the Dragon,Братство Дракона

--- a/pn/pn_terms_003.csv
+++ b/pn/pn_terms_003.csv
@@ -22,7 +22,7 @@ Team Administrator,Администратор команды
 Beetletun Statue Fragments,Фрагменты статуи Битлтуна
 Centaur Banner,Знамя кентавра
 Cilantro and Cured Meat Flatbread,Лепёшка с кинзой и вяленым мясом
-Clove and Veggie Flatbread,Лепешка с гвоздикой и овощами
+Clove and Veggie Flatbread,Лепёшка с гвоздикой и овощами
 Clove-Spiced Creme Brulee,Крем-брюле с гвоздикой
 Clove-Spiced Eggs Benedict,Яйца Бенедикт с гвоздикой
 Clove-Spiced Pear and Cured Meat Flatbread,"Лепёшка с грушей, вяленым мясом и гвоздикой"
@@ -51,9 +51,9 @@ Mission Slot: PvP,Слот миссии: PvP
 Mission Slot: WvW,Слот миссии: WvW
 Mushroom Clove Sous-Vide Steak,Стейк су-вид с грибами и гвоздикой
 Orange Clove Cheesecake,Апельсиновый чизкейк с гвоздикой
-Peppercorn and Veggie Flatbread,Лепешка с перцем и овощами
+Peppercorn and Veggie Flatbread,Лепёшка с перцем и овощами
 Peppercorn-Spiced Eggs Benedict,Яйца Бенедикт с перцем
-Peppered Cured Meat Flatbread,Лепешка с вяленым мясом и перцем
+Peppered Cured Meat Flatbread,Лепёшка с вяленым мясом и перцем
 Potted Tree,Дерево в горшке
 Roller Beetle Rental Post,Аренда жука-катуна
 Salsa Eggs Benedict,Яйца бенедикт с сальсой

--- a/pn/pn_terms_005.csv
+++ b/pn/pn_terms_005.csv
@@ -86,7 +86,7 @@ Boardwalk (240 x 1920),Дощатый настил (240 x 1920)
 Boardwalk (240 x 960),Дощатый настил (240 x 960)
 Boardwalk (480 x 960),Дощатый настил (480 x 960)
 Body Topiary,Топиарий «Тело»
-Bonfire,Костер
+Bonfire,Костёр
 Bowl Topiary,Топиарий-чаша
 Bowl of Fruit Salad with Cilantro Garnish,Миска фруктового салата с кинзой
 Bowl of Fruit Salad with Mint Garnish,Миска фруктового салата с мятным гарниром
@@ -94,7 +94,7 @@ Bowl of Fruit Salad with Orange-Clove Syrup,Миска фруктового са
 Bowl of Sesame Fruit Salad,Миска фруктового салата с кунжутом
 Bowl of Spiced Fruit Salad,Миска пряного фруктового салата
 Branchless Bush,Куст без ветвей
-Branded Devourer Monument,Монумент клейменого пожирателя
+Branded Devourer Monument,Монумент клеймёного пожирателя
 Branded Spire,Клеймёный шпиль
 Brawling Obstacle: Chill Turrets,Препятствие для драки: турели холода
 Brawling Obstacle: Cripple Turrets,Препятствие для драки: турели калечения
@@ -175,7 +175,7 @@ Charr Scrap Cannon,Пушка для лома чаров
 Charr Statue,Статуя чарра
 Charr Summit Banner,Знамя саммита чарров
 Charr Summit Flag,Флаг саммита чарров
-Cheery Balloon Bundle,Связка веселых шариков
+Cheery Balloon Bundle,Связка весёлых шариков
 Chunk of the Solid Ocean,Кусок Твёрдого океана
 Cilantro Lime Sous-Vide Steak,Стейк су-вид с кинзой и лаймом
 Cloaking Waters,Маскирующие воды
@@ -195,8 +195,8 @@ Complete the restoration of your war room.,Завершите восстанов
 Complete the restoration of your workshop.,Завершите восстановление вашей мастерской.
 Comprehensive Disciplines Research Commemorative Statue,Памятная статуя исследования всесторонних дисциплин
 Conjured Amalgamate's Token,Жетон призванного амальгамата
-Corrupted Eagle Shrine,Оскверненное святилище орла
-Corrupted Ox Shrine,Оскверненное святилище быка
+Corrupted Eagle Shrine,Осквернённое святилище орла
+Corrupted Ox Shrine,Осквернённое святилище быка
 Corrupted Wolverine Shrine,Осквернённое святилище росомахи
 Craft schematics to manufacture WvW arrowcarts.,Создать чертежи для изготовления стреломётов для WvW.
 Craft schematics to manufacture WvW ballistae.,Создайте чертежи для производства баллист в WvW.
@@ -443,8 +443,8 @@ Guild Weaponsmith 1,Оружейник гильдии 1
 Guild Weaponsmith 2,Оружейник гильдии 2
 Hanging Brazier,Подвесная жаровня
 Hanging Tree,Висячее дерево
-Hardened Gates,Закаленные врата
-Hardened Siege,Закаленная осада
+Hardened Gates,Закалённые врата
+Hardened Siege,Закалённая осада
 Hardy Island Fern,Выносливый островной папоротник
 Haunted Armchair,Проклятое кресло
 Haunted Bell,Проклятый колокол

--- a/pn/pn_terms_006.csv
+++ b/pn/pn_terms_006.csv
@@ -103,7 +103,7 @@ Mining Rate 4,Скорость добычи 4
 Mining Rate 5,Скорость добычи 5
 Mining Rate 6,Скорость добычи 6
 Minor Supply Drop,Малый сброс припасов
-Mint-Pear Cured Meat Flatbread,Лепешка с мятно-грушевым вяленым мясом
+Mint-Pear Cured Meat Flatbread,Лепёшка с мятно-грушевым вяленым мясом
 Mists Dolyak Statue,Статуя дольяка Туманов
 Mists Drake Statue,Статуя дрейка Туманов
 Mists Griffon Statue,Статуя грифона Туманов
@@ -293,7 +293,7 @@ Red Festival Umbrella,Красный фестивальный зонт
 Red Lantern,Красный фонарь
 Red Pirate Flag,Красный пиратский флаг
 Red Throw Pillow,Красная декоративная подушка
-Refined Streetlamp,Утонченный уличный фонарь
+Refined Streetlamp,Утончённый уличный фонарь
 Reindeer Ice Sculpture,Ледяная скульптура северного оленя
 Repair Anvil,Наковальня для ремонта
 Resurrection Tablet,Табличка воскрешения
@@ -497,5 +497,5 @@ Super Cave Pillar,Супер пещерная колонна
 Super Cave Plateau,Супер пещерное плато
 Super Cave Stalagmite,Супер сталагмит пещеры
 Super Chest,Супер сундук
-Super Cliff Face,Супер утес
+Super Cliff Face,Супер утёс
 Super Cloud,Супер облако

--- a/pn/pn_terms_007.csv
+++ b/pn/pn_terms_007.csv
@@ -43,7 +43,7 @@ Super Rock Wall,Супер каменная стена
 Super Short Cliff Face,Супер короткий обрыв скалы
 Super Small Rock,Маленький камень супер
 Super Snow Floor,Супер снежный пол
-Super Snowy Cliff Face,Супер снежный утес
+Super Snowy Cliff Face,Супер снежный утёс
 Super Tall Cliff Face,Высокий утёс супер
 Super Tree,Супер дерево
 Super Tree Branch,Ветка супердерева

--- a/pn/pn_terms_008.csv
+++ b/pn/pn_terms_008.csv
@@ -212,7 +212,7 @@ Vibrant Companions Mount Adoption License,Лицензия на ездовое �
 Void Saltspray Dragon,Дракон Пустотной Соленой Пены
 Warclaw Frontline Mount Pack,Набор ездового животного «Боевой коготь: передовая»
 Western Corrupted Shard,Западный осквернённый осколок
-Whispers of Wind,Шепот ветра
+Whispers of Wind,Шёпот ветра
 Wild Roar Mount Adoption License,Лицензия на ездовое животное «Дикий рёв»
 Your Presence Is Requested,Требуется ваше присутствие
 Zildi's Assist-o-Matic,Автоматизированный помощник Зилди

--- a/pn/pn_world_map_001.csv
+++ b/pn/pn_world_map_001.csv
@@ -10,7 +10,7 @@ A Different Dream,Другой сон
 A Fork in the Road,Развилка
 A Fragile Peace,Хрупкий мир
 A Grisly Shipment,Жуткий груз
-A Kindness Repaid,Возвращенная доброта
+A Kindness Repaid,Возвращённая доброта
 A Legacy Damned: Alliance Staging Ground,Проклятое наследие: Плацдарм Альянса
 A Legacy Damned: The Golden Lake,Проклятое наследие: Золотое озеро
 A Light in the Darkness,Свет во тьме

--- a/pn/pn_world_map_002.csv
+++ b/pn/pn_world_map_002.csv
@@ -18,7 +18,7 @@ Blighted Depths,Погибельные глубины
 Blightwater Basin,Бассейн Гнилой воды
 Blightwater Shatterstrike,Удар Гнилой воды
 Blind Faith,Слепая вера
-Blister Cauldron,Котел волдырей
+Blister Cauldron,Котёл волдырей
 Blistering Abyss,Волдырная бездна
 Blistering Undercroft,Пылающее подземелье
 Blistering Undercroft Emergency Waypoint A,Аварийный путь «Палящая Подземка»
@@ -101,7 +101,7 @@ Bramble Walls,Ежевичные стены
 Brand,Порча
 Brandalf's Steading,Усадьба Брандальфа
 Branded for Termination,Клеймение на уничтожение
-Branded Rise,Клейменный подъём
+Branded Rise,Клеймённый подъём
 Brandview Waypoint,Путевая точка «Брэндвью»
 Brandwatch Encampment Waypoint,Путевая точка «Лагерь Брэндвотч»
 Brassburn Torch,Факел из Латунного Пламени

--- a/pn/pn_world_map_003.csv
+++ b/pn/pn_world_map_003.csv
@@ -485,7 +485,7 @@ Enemy of My Enemy,Враг моего врага
 Enemy of My Enemy: The Beastmarshal,Враг моего врага: Зверомаршал
 Enemy of My Enemy: The Troopmarshal,Враг моего врага: Войсковой маршал
 Engaged Demo Station,Демонстрационная станция
-Enraged and Unashamed,Разъяренный и бесстыдный
+Enraged and Unashamed,Разъярённый и бесстыдный
 Enrav Exploration Post,Пост для исследований Энрава
 Entrance Waypoint,Входная путевая точка
 Entrapment: The Deep,Западня: Глубина

--- a/pn/pn_world_map_004.csv
+++ b/pn/pn_world_map_004.csv
@@ -5,7 +5,7 @@ Estate of Decay,Поместье разложения
 Estates of the Favored,Поместья избранных
 Estates Waypoint,Путевая точка «Поместья»
 Eternal Battlegrounds,Вечные поля битвы
-Eternal Cauldron,Вечный котел
+Eternal Cauldron,Вечный котёл
 Eternal Coliseum,Вечный Колизей
 Eternal Necropolis,Вечная некрополь
 Eternal Necropolis Emergency Waypoint,Аварийная путевая точка Вечного некрополя
@@ -167,7 +167,7 @@ Forbidden Vault,Запретное хранилище
 Forced Entry: Bava Nisos,Силовой прорыв: Бава Нисос
 Forced Entry: Bava Nisos Outskirts,Силовой прорыв: Окраины Бава Нисос
 Forced Hand: Nyedra,Силовой захват: Ниедра
-Forearmed Is Forewarned,Предупрежден — значит вооружен
+Forearmed Is Forewarned,Предупреждён — значит вооружён
 Forecastle Rock,Скальный выступ Фо́ркасл
 Forest of a Thousand Voices,Лес тысячи голосов
 Forest of Niflhel,Лес Нифльхель
@@ -490,7 +490,7 @@ Grogslinger's,Грогслингер
 Grostogg's Kraal Waypoint,Путевая точка Крааля Гростогга
 Grothmar Valley,Долина Гротмар
 Grotto of Spirits,Грот духов
-Grotto of the Defeated,Грот побежденных
+Grotto of the Defeated,Грот побеждённых
 Ground Zero Waypoint,Путевая точка Эпицентра
 Grove,Роща
 Grove of the First Kryptis,Роща Первых Криптисов

--- a/pn/pn_world_map_005.csv
+++ b/pn/pn_world_map_005.csv
@@ -373,7 +373,7 @@ Jade Statuette,Нефритовая статуэтка
 Jade Wind's Respite,Приют Нефритового Ветра
 Jadepillar Point Base,База Нефритового столпа
 Jadepillar Point Waypoint,Путь к Изумрудной гусенице
-Jahai Bluffs,Джахайские утесы
+Jahai Bluffs,Джахайские утёсы
 Jahai Great Hall,Великий зал Джахаи
 Jahai Keep,Крепость Джахаи
 Jaka Itzel,Джака Итцель

--- a/pn/pn_world_map_006.csv
+++ b/pn/pn_world_map_006.csv
@@ -398,7 +398,7 @@ Ministry of Security: Main Office,Министерство безопаснос�
 Ministry of Transit,Министерство транспорта
 Ministry Ward,Министерский квартал
 Ministry Ward Waypoint,Путевая точка Министерства
-Minotaur Rampant,Разъяренный минотавр
+Minotaur Rampant,Разъярённый минотавр
 MinSec Server Room,Серверная МиньСек
 Mire Switchback,Трясинный серпантин
 Mire Waypoint,Путевая точка Трясины
@@ -423,7 +423,7 @@ Mist Portals Waypoint,Путевая точка: Порталы Туманов
 Mist Warden Camp,Лагерь Стражей Туманов
 Mist Warden Outpost,Аванпост Стражей Туманов
 Mistarion Beach,Пляж Мистарион
-Mistburned Barrens,Опаленные Туманом пустоши
+Mistburned Barrens,Опалённые Туманом пустоши
 Mistgate Graveyard,Кладбище Туманных врат
 Mistlock Observatory,Обсерватория Мистлока
 Mistlock Sanctuary,Убежище Мистлока

--- a/pn/pn_world_map_007.csv
+++ b/pn/pn_world_map_007.csv
@@ -42,7 +42,7 @@ Mystic Clover Garden,Сад мистического клевера
 Mystic Passage,Мистический проход
 Mystic Plaza,Мистическая площадь
 Mystic Waters,Мистические воды
-Mythwright Cauldron,Котел Мифотворца
+Mythwright Cauldron,Котёл Мифотворца
 Mythwright Gambit,Гамбит Мифотворца
 N.K. Broadcast Terminal Beta,Бета-версия вещательного терминала N.K.
 Nadijeh's Assembly,Сборочный цех Надидже
@@ -89,7 +89,7 @@ Night of Fires,Ночь огней
 Nightguard Beach,Пляж Ночной стражи
 Nightguard Waypoint,Путь ночных стражей
 Nightmare,Кошмар
-Nightshade Garden,Сад паслена
+Nightshade Garden,Сад паслёна
 Nimbose Butte,Облачный холм
 Nirvana's Ascent,Восхождение Нирваны
 Nivermer Rill,Нивермер-Рилл
@@ -470,7 +470,7 @@ Prism Sanctuary,Призматическое святилище
 Prismatic Falls,Призматический водопад
 Prismatic Postpile,Призматический стог
 Prison Camp,Тюремный лагерь
-Prisoner's Perch,Насест заключенного
+Prisoner's Perch,Насест заключённого
 Prisoners of the Dragon,Узники Дракона
 Private Reserve,Частный заповедник
 Privateer's Moorage,Причал капера

--- a/pn/pn_world_map_008.csv
+++ b/pn/pn_world_map_008.csv
@@ -106,7 +106,7 @@ Reception Court Waypoint,Путевая точка Приемного двора
 Reception Hall,Приёмный зал
 Reckoner's Terrace,Терраса Расчётчика
 Reckoner's Waypoint,Путевая точка Расчётчика
-Reclaimed Chantry,Возвращенная обитель
+Reclaimed Chantry,Возвращённая обитель
 Reclaimed Chantry Waypoint,Путевая точка Возвращенной обители
 Reclaimed Lyceum,Возвращённый лицей
 Recon Cove,Бухта разведки

--- a/pn/pn_world_map_010.csv
+++ b/pn/pn_world_map_010.csv
@@ -76,7 +76,7 @@ The Burrows,Норы
 The Busted Flagon,Разбитый кубок
 The Cathedral of Blood,Собор Крови
 The Cathedral of Silence,Собор Тишины
-The Cauldron of Searing,Котел Опаления
+The Cauldron of Searing,Котёл Опаления
 The Centaur's Path,Путь Кентавра
 The Championship Fight,Чемпионский бой
 The Channeling Chamber,Зал Направленности
@@ -268,7 +268,7 @@ The Mystic Telescope,Мистический телескоп
 The Narthex,Нартекс
 The Necropolis,Некрополь
 The Neverfalls,Неверфоллс
-The Newly Awakened,Недавно пробужденные
+The Newly Awakened,Недавно пробуждённые
 The Nightmare Ends,Кошмар окончен
 The Nightmare Incarnate,Воплощение Кошмара
 The Northern Extractor,Северный экстрактор
@@ -374,7 +374,7 @@ The Sunderlands,Расколотые земли
 The Survivors: Astral Ward Camp,Выжившие: Лагерь Астральной стражи
 The Survivors: Heitor's Gate,Выжившие: Врата Хейтор
 The Svanir Hive,Улей Сваниров
-The Sword Regrown,Возрожденный меч
+The Sword Regrown,Возрождённый меч
 The Sylvari Dream,Сон сильвари
 The Tangle,Чаща
 The Teratohedron,Тератоэдр
@@ -396,9 +396,9 @@ The Tribune's Call,Зов трибуна
 The Triumph of Palawa Joko,Триумф Палавы Джоко
 The Trodden Forum,Топтанный форум
 The Twin's Table,Стол близнецов
-The Twisted Marionette,Искаженная марионетка
-The Twisted Marionette (Private Squad),Искаженная марионетка (закрытый отряд)
-The Twisted Marionette (Public),Искаженная марионетка (открытая)
+The Twisted Marionette,Искажённая марионетка
+The Twisted Marionette (Private Squad),Искажённая марионетка (закрытый отряд)
+The Twisted Marionette (Public),Искажённая марионетка (открытая)
 The Tyrian Alliance: Guild Initiative Headquarters,Tyrian Alliance: штаб-квартира гильдейских инициатив
 The Underbelly,Подбрюшье
 The Undermarket,Подрынок

--- a/pn/pn_world_map_011.csv
+++ b/pn/pn_world_map_011.csv
@@ -448,8 +448,8 @@ What's Left Behind,Что осталось позади
 Where Credit Is Due,Где отдают должное
 Where Life Goes,Куда уходит жизнь
 Whisper Bay,Бухта Шёпота
-Whisper of Jormag,Шепот Йормага
-Whisper of Jormag (Public),Шепот Йормага (публичный)
+Whisper of Jormag,Шёпот Йормага
+Whisper of Jormag (Public),Шёпот Йормага (публичный)
 Whispering Artifact,Шепчущий артефакт
 Whispering Caverns,Шепчущие пещеры
 Whispering Depths,Шепчущие глубины

--- a/pn/pn_world_map_016.csv
+++ b/pn/pn_world_map_016.csv
@@ -6,7 +6,7 @@ Cannon Mastery,Мастерство пушки
 Defense Against Guards,Защита от стражей
 Shield Generator Mastery,Мастерство генератора щита
 Supply Master,Мастер припасов
-Arrow Cart Mastery,Мастерство стреломета
+Arrow Cart Mastery,Мастерство стреломёта
 Ballista Mastery,Мастерство баллисты
 Burning Oil Mastery,Мастерство горящего масла
 Catapult Mastery,Мастерство катапульты
@@ -28,7 +28,7 @@ Barren Outpost,Пустынный аванпост
 Deathless Necropolis,Бессмертный некрополь
 Flying Circus,Цирк Летающих
 Flywheel Depot,Депо Флайуил
-Hardened Rampart,Укрепленный Вал
+Hardened Rampart,Укреплённый Вал
 Harrier's Palace,Дворец Вестника
 "Help Drojkor, Spirit Squall, control jackals.","Помогите Дрожкору, Духовному Шквалу, контролировать шакалов."
 "Help the Pricklepatch Hollow choya, or don't.","Помогите чойям из Pricklepatch Hollow, или не помогайте."

--- a/pn/pn_world_map_018.csv
+++ b/pn/pn_world_map_018.csv
@@ -63,7 +63,7 @@ Greenbriar,Гринбрайар
 Greenvale Refuge,Убежище Гринвейл
 Habib's Encampment,Лагерь Хабиба
 Hughe's Hideaway,Убежище Хью
-Improve arrow cart skills,Улучшает навыки стреломета
+Improve arrow cart skills,Улучшает навыки стреломёта
 Improve ballista skills,Улучшает навыки баллисты
 Improve cannon use,Улучшает использование пушки
 Improve catapult skills,Улучшает навыки катапульты


### PR DESCRIPTION
CLAUDE.md §5 требует ё безоговорочно, поэтому здесь не нужны ни корпус, ни решение владельца: **если одно и то же слово стоит в слое и с ё, и без неё, форма без ё — опечатка**. Доказательство берётся из самого слоя — правится не «где ё могла бы быть», а «где она уже стоит рядом, при том же имени».

**753 записи в 160 файлах.** Крупнейшее: `Планёр` 128, `Детёныш` 57, `Клеймённый` 35, `бронёй` 18, `Разъярённый` 15, `Перемещённый` 14, `Освящённый` 13, `Осквернённый` 13, `Пробуждённый` 11, `Шёпот` 9.

## Частота здесь не судья

Первым делом я попробовал проверять находки по корпусу — и отбросил эту проверку: **корпус сам массово теряет ё**.

| слово | без ё в корпусе | с ё |
|---|---|---|
| котел / котёл | 47 | 27 |
| знамена / знамёна | 27 | 8 |
| заключенного / заключённого | 20 | 8 |

Проверка по большинству вычеркнула бы как раз верные правки. Правило проекта сильнее частоты.

## Что отброшено разбором

Весь список из 171 пары просмотрен глазами, снято десять:

* **соединительная гласная в сложных словах** — `копьеносец`, `копьемаршал` идут от «копьё», но пишутся через «е»; ё там законна только в хвосте: «копьемёт», как «пулемёт»;
* **заимствование** `финишер`;
* **прямые ошибки** — «сплетёние» и «чёрничный» (от «черника»);
* **омограф `звезды`** — это и родительный падеж единственного числа (без ё), и именительный множественного (с ё). Все 38 случаев в слое оказались первым:

```
Recipe: Steelstar's Claymore    Рецепт: клеймор Стальной Звезды
The Theign Star Fragment        Осколок Звезды Тейн
```

Такое решает контекст, а не буква, — в партию они не взяты.

## Гейт

Линтер по 160 изменённым файлам — **дельта 0**.
