### PR TITLE
Слой: сведён разнобой удвоенных согласных, 191 запись

### DIFF
--- a/pn/pn_achievements_002.csv
+++ b/pn/pn_achievements_002.csv
@@ -268,7 +268,7 @@ Nimble Onslaught,Ловкий натиск
 No Culinary Application,Не для кулинарии
 "No Geysers, No Problems",Нет гейзеров — нет проблем
 No Ingredients Wasted,Никаких потраченных впустую ингредиентов
-"No More Tricks, Scarlet","Больше никаких трюков, Скарлетт"
+"No More Tricks, Scarlet","Больше никаких трюков, Скарлет"
 No One Left Behind,Никто не останется позади
 No Shocks Here,Здесь нет ударов током
 No Stranger to Success,Успех — дело привычное

--- a/pn/pn_items_005.csv
+++ b/pn/pn_items_005.csv
@@ -275,7 +275,7 @@ Megalodon Bone Meal,Костная мука мегалодона
 Melitta's Bloom,Цветок Мелитты
 Memoirs of Captain Greywind,Мемуары капитана Грейвинда
 "Memoirs of Captain Greywind, Unabridged","Мемуары капитана Грейвинда, полная версия"
-Memories of Scarlet Box,Воспоминания о Скарлетт: коробка
+Memories of Scarlet Box,Воспоминания о Скарлет: коробка
 Metal Aquabreather,Металлический аквадыхатель
 Metal Scrap,Металлолом
 Midnight Lotus Fishing Rod,Полуночная удочка лотоса

--- a/pn/pn_items_015.csv
+++ b/pn/pn_items_015.csv
@@ -366,8 +366,8 @@ Attuned Sandford Family Ring,Настроенное кольцо семьи Сэ
 Attuned Sandford Family Ring (Infused),Настроенное кольцо семьи Сэндфорд (насыщенное)
 Attuned Seal of the Khan-Ur,Настроенная печать Хан-Ура
 Attuned Seal of the Khan-Ur (Infused),Настроенная печать Хан-Ура (насыщенная)
-Attuned Sigil of the Fool,Настроенная сигилла глупца
-Attuned Sigil of the Fool (Infused),Настроенная сигилла глупца (насыщенная)
+Attuned Sigil of the Fool,Настроенная сигила глупца
+Attuned Sigil of the Fool (Infused),Настроенная сигила глупца (насыщенная)
 Attuned Snaff's Gyre,Настроенный вихрь Снаффа
 Attuned Snaff's Gyre (Infused),Настроенный вихрь Снаффа (насыщенный)
 Attuned Vassar's Band,Настроенное кольцо Вассара

--- a/pn/pn_items_026.csv
+++ b/pn/pn_items_026.csv
@@ -236,8 +236,8 @@ Celestial Rascal Shoulders of the Ranger,Наплечники плута рей�
 Celestial Rascal Shoulders of the Thief,Наплечники плута вора Небесного
 Celestial Rooster Glider,Небесный планер петуха
 Celestial Rooster Harvesting Tool,Небесный петух — инструмент для сбора
-Celestial Sigil,Небесная сигилла
-Celestial Sigil (Infused),Небесная сигилла (насыщенная)
+Celestial Sigil,Небесная сигила
+Celestial Sigil (Infused),Небесная сигила (насыщенная)
 Celestial Snaketail Breeches,Небесные штаны змеехвоста
 Celestial Subterfuge Hood of the Thief,Капюшон уловок вора Небесного
 Celestial Tempered Scale Chestplate of the Guardian,Нагрудник стража Небесного из закалённой чешуи

--- a/pn/pn_items_029.csv
+++ b/pn/pn_items_029.csv
@@ -47,7 +47,7 @@ Cleric's Iron Pistol of Blood,Железный пистолет Клирика �
 Cleric's Iron Pistol of Chilling,Железный пистолет клирика охлаждения
 Cleric's Iron Pistol of Energy,Железный пистолет Энергии Клирика
 Cleric's Iron Pistol of Force,Железный пистолет клирика силы
-Cleric's Iron Pistol of Grawl Slaying,Железный пистолет клирика для убийства грауллов
+Cleric's Iron Pistol of Grawl Slaying,Железный пистолет клирика для убийства граулов
 Cleric's Iron Pistol of Hobbling,Железный пистолет клирика хромоты
 Cleric's Iron Pistol of Ice,Железный пистолет клирика со льдом
 Cleric's Iron Pistol of Perception,Железный пистолет Клирика Восприятия
@@ -218,7 +218,7 @@ Cleric's Privateer Hat of Rata Sum,Шляпа клирика-капера из �
 Cleric's Privateer Hat of the Citadel,Пиратская шляпа клирика Цитадели
 Cleric's Privateer Hat of the Lich,Шляпа пирата клирика лича
 Cleric's Privateer Pants of Grenth,клирика Штаны капера Грента
-Cleric's Privateer Pants of Melandru,Штаны капера Мелландру клирика
+Cleric's Privateer Pants of Melandru,Штаны капера Меландру клирика
 Cleric's Privateer Pants of the Dolyak,Штаны капера клирика из дойака
 Cleric's Privateer Shoulders of Melandru,Плечи пирата-служителя Меландру
 Cleric's Privateer Shoulders of the Flame Legion,Наплечники пирата-клирика из ордена Пламени

--- a/pn/pn_items_034.csv
+++ b/pn/pn_items_034.csv
@@ -23,10 +23,10 @@ Dire Banded Legs of the Flock,Грозные окованные поножи с�
 Dire Banded Pauldrons of Lyssa,Грозные пластинчатые наплечья Лиссы
 Dire Banded Pauldrons of the Citadel,Грозные нашивные наплечники Цитадели
 Dire Banded Pauldrons of the Dolyak,Грозные бандажные наплечники Дольяка
-Dire Cabalist Boots,Сапоги кабалиста ужаса
-Dire Cabalist Coat,Грозная куртка кабалиста
-Dire Cabalist Gloves,Грозные перчатки кабалиста
-Dire Cabalist Hood,Грозный капюшон кабалиста
+Dire Cabalist Boots,Сапоги каббалиста ужаса
+Dire Cabalist Coat,Грозная куртка каббалиста
+Dire Cabalist Gloves,Грозные перчатки каббалиста
+Dire Cabalist Hood,Грозный капюшон каббалиста
 Dire Cabalist Legs,Ноги каббалиста (Душегуб)
 Dire Cabalist Shoulders,Грозные плечи каббалиста
 Dire Ceremonial Bulwark of Accuracy,Грозный церемониальный бастион точности

--- a/pn/pn_items_042.csv
+++ b/pn/pn_items_042.csv
@@ -199,7 +199,7 @@ Frostforged Longbow,Морозная длинная лука
 Frostforged Longbow Skin,Облик длинного лука «Ледяная ковка»
 Frostforged Mace,Морозная булава
 Frostforged Mace Skin,Облик булавы «Ледяная ковка»
-Frostforged Pistol,Морозокованный пистолет
+Frostforged Pistol,Морозокованый пистолет
 Frostforged Pistol Skin,Облик пистолета «Ледяная ковка»
 Frostforged Rifle,Морозная винтовка
 Frostforged Rifle Skin,Облик винтовки «Ледяная ковка»

--- a/pn/pn_items_045.csv
+++ b/pn/pn_items_045.csv
@@ -179,7 +179,7 @@ Grawl Supply Sack,Припасы граулов
 Grawl Tribal Paint,Племенная раскраска граулов
 Grawl Trinket,Безделушка граулов
 Grawl-String Short Bow,Короткий лук из тетивы граулов
-Grawlgrinder,Дробитель грауллов
+Grawlgrinder,Дробитель граулов
 Gray,Серый
 Gray Dye,Краска «Серый»
 Gray Market Black Diamond,Чёрный алмаз с серого рынка

--- a/pn/pn_items_053.csv
+++ b/pn/pn_items_053.csv
@@ -234,12 +234,12 @@ Knight's Black Earth Trident,Трезубец чёрной земли рыцар
 Knight's Bronze Spear of Rending,Бронзовое копьё рыцаря разрыва
 Knight's Bronze Sword of Draining,Облик бронзового меча рыцаря истощения
 Knight's Bronze Sword of Rending,Бронзовый меч разрывания рыцаря
-Knight's Cabalist Boots,Сапоги кабалиста рыцаря
-Knight's Cabalist Coat,Куртка кабалиста рыцаря
-Knight's Cabalist Gloves,Перчатки кабалиста рыцаря
-Knight's Cabalist Hood,Капюшон кабалиста Рыцаря
-Knight's Cabalist Legs,Ноги кабалиста рыцаря
-Knight's Cabalist Shoulders,Плечи кабалиста рыцаря
+Knight's Cabalist Boots,Сапоги каббалиста рыцаря
+Knight's Cabalist Coat,Куртка каббалиста рыцаря
+Knight's Cabalist Gloves,Перчатки каббалиста рыцаря
+Knight's Cabalist Hood,Капюшон каббалиста Рыцаря
+Knight's Cabalist Legs,Ноги каббалиста рыцаря
+Knight's Cabalist Shoulders,Плечи каббалиста рыцаря
 Knight's Chainmail Chestpiece,Кольчужный нагрудник рыцаря
 Knight's Chainmail Footgear,Кольчужная обувь рыцаря
 Knight's Chainmail Gauntlets,Кольчужные рукавицы рыцаря

--- a/pn/pn_items_057.csv
+++ b/pn/pn_items_057.csv
@@ -307,11 +307,11 @@ Magi's Banded Helm,Полосатый шлем мага
 Magi's Banded Legs,Полосатые штаны мага
 Magi's Banded Pauldrons,Поночи мага
 Magi's Black Earth Trident,Чёрный трезубец мага
-Magi's Cabalist Boots,Сапоги кабалиста мага
-Magi's Cabalist Coat,Куртка кабалиста мага
-Magi's Cabalist Gloves,Перчатки кабалиста мага
-Magi's Cabalist Hood,Капюшон кабалиста мага
-Magi's Cabalist Legs,Штаны кабалиста мага
+Magi's Cabalist Boots,Сапоги каббалиста мага
+Magi's Cabalist Coat,Куртка каббалиста мага
+Magi's Cabalist Gloves,Перчатки каббалиста мага
+Magi's Cabalist Hood,Капюшон каббалиста мага
+Magi's Cabalist Legs,Штаны каббалиста мага
 Magi's Cabalist Shoulders,Плечи Кабалиста Мага
 Magi's Ceremonial Bulwark,Церемониальный бастион мага
 Magi's Ceremonial Dagger,Церемониальный кинжал мага

--- a/pn/pn_items_062.csv
+++ b/pn/pn_items_062.csv
@@ -303,7 +303,7 @@ Minor Potion of Mordrem Slaying,Малый эликсир уничтожения
 Minor Potion of Nightmare Court Slaying,Малое зелье уничтожения Nightmare Court
 Minor Potion of Ogre Slaying,Малое зелье убийства огров
 Minor Potion of Outlaw Slaying,Малое зелье убийства грабителей
-Minor Potion of Slaying Scarlet's Armies,«Малый эликсир убийства армий Скарлетт»
+Minor Potion of Slaying Scarlet's Armies,«Малый эликсир убийства армий Скарлет»
 Minor Potion of Sons of Svanir Slaying,Малый эликсир истребления сыновей Сванира
 Minor Potion of Undead Slaying,Малое зелье убийства нежити
 Minor Rune of Altruism,Малая руна альтруизма

--- a/pn/pn_items_066.csv
+++ b/pn/pn_items_066.csv
@@ -314,15 +314,15 @@ Orichalcum Gauntlet Plates,Орихалковые пластины для нар
 Orichalcum Harvesting Sickle,Орихалковый серп
 Orichalcum Helmet Casing,Основа шлема из орихалка
 Orichalcum Helmet Lining,Подкладка шлема из орихалка
-Orichalcum Hook,Оррихалковый крюк
+Orichalcum Hook,Орихалковый крюк
 Orichalcum Ingot,Слиток орихалка
 Orichalcum Legging Lining,Подкладка поножей из орихалка
 Orichalcum Legging Panel,Панель поножей из орихалка
-Orichalcum Logging Axe,Оррихалковый топор лесоруба
+Orichalcum Logging Axe,Орихалковый топор лесоруба
 Orichalcum Mining Node,Орихалковая рудная жила
-Orichalcum Mining Pick,Оррихалковая кирка
+Orichalcum Mining Pick,Орихалковая кирка
 Orichalcum Nib,Орихалковое перо
-Orichalcum Ore,Оррихалковая руда
+Orichalcum Ore,Орихалковая руда
 Orichalcum Pauldron Casing,Наплечник из орихалка: основа
 Orichalcum Pauldron Lining,Подкладка наплечника из орихалка
 Orichalcum Plated Dowel,Орихалковый пластинчатый штифт
@@ -330,7 +330,7 @@ Orichalcum Reinforcing Plate,Орихалковая укрепляющая пл�
 Orichalcum Rifle Barrel,Орихалковый ствол винтовки
 Orichalcum Setting,Орихалковая оправа
 Orichalcum Shield Backing,Орихалковая основа щита
-Orichalcum Shield Boss,Оррихалковая накладка на щит
+Orichalcum Shield Boss,Орихалковая накладка на щит
 Orichalcum Spear Head,Орихалковый наконечник копья
 Orichalcum Trident Head,«Наконечник трезубца из орихалка»
 Orichalcum Warhorn Mouthpiece,Орихалковый мундштук боевого рога
@@ -395,44 +395,44 @@ Orr's Fall,Падение Орра
 Orrax Contained Homestead Decoration,Украшение усадьбы «Заточённый Орракс»
 Orrax Manifested Backpack and Glider Combo,Проявленный рюкзак и планирующий модуль Орракс
 Orrax Manifested Glider,Проявленный планерист Орракс
-Orrian Anglerfish,Орианская удильщиковая рыба
+Orrian Anglerfish,Оррианская удильщиковая рыба
 Orrian Armor Tybalt,Доспех Тибальта из Орриана
 Orrian Artifact Shards,Осколки артефакта Орриана
 Orrian Axe,Оррианский топор
-Orrian Axe Skin,Орианская кирка
+Orrian Axe Skin,Оррианская кирка
 Orrian Axe of Accuracy,Топор Орриана с бонусом к точности
-Orrian Axe of Air,Орианский топор воздуха
+Orrian Axe of Air,Оррианский топор воздуха
 Orrian Axe of Earth,Топор земли из Орриана
-Orrian Axe of Energy,Орианский топор энергии
-Orrian Axe of Vision,Орианский топор провидения
+Orrian Axe of Energy,Оррианский топор энергии
+Orrian Axe of Vision,Оррианский топор провидения
 Orrian Blade,Оррианский клинок
 Orrian Bow,Оррианский лук
-Orrian Bow Skin,Орианский лук
+Orrian Bow Skin,Оррианский лук
 Orrian Bow of Accuracy,"Лук Орриана, дающий точность"
-Orrian Bow of Air,Орианский лук воздуха
+Orrian Bow of Air,Оррианский лук воздуха
 Orrian Bow of Bloodlust,"Лук Орриана, пробуждающий жажду крови"
 Orrian Bow of Earth,Лук Орриана Земли
-Orrian Bow of Energy,Орианский лук энергии
+Orrian Bow of Energy,Оррианский лук энергии
 Orrian Bow of Vision,Лук Ориана Прозрения
 Orrian Bow of Water,Лук Ориана Воды
 Orrian Bow of the Geomancer,Лук Орриана геоманта
 Orrian Building Materials,Оррианские строительные материалы
 Orrian Celestial Codex,Оррианский небесный кодекс
-Orrian Coffer,Орианский ларец
+Orrian Coffer,Оррианский ларец
 Orrian Dagger,Оррианский кинжал
-Orrian Dagger Skin,Орианский кинжал
-Orrian Dagger of Air,Орианский кинжал воздуха
-Orrian Dagger of Bloodlust,Орианский кинжал жажды крови
-Orrian Dagger of Earth,Орианский кинжал земли
-Orrian Dagger of Energy,Орианский кинжал энергии
-Orrian Dagger of Rage,Орианский кинжал ярости
+Orrian Dagger Skin,Оррианский кинжал
+Orrian Dagger of Air,Оррианский кинжал воздуха
+Orrian Dagger of Bloodlust,Оррианский кинжал жажды крови
+Orrian Dagger of Earth,Оррианский кинжал земли
+Orrian Dagger of Energy,Оррианский кинжал энергии
+Orrian Dagger of Rage,Оррианский кинжал ярости
 Orrian Drake Scale,Оррианская чешуя драка
 Orrian Driftwood,Оррианский плавник
 Orrian Energy Source,Оррианский источник энергии
 Orrian Fishing Reward,Награда за рыбалку в Орриане
 Orrian Focus,Оррианский фокус
 Orrian Focus Skin,Облик оррианского фокуса
-Orrian Focus of Accuracy,Орианский фокус точности
+Orrian Focus of Accuracy,Оррианский фокус точности
 Orrian Focus of Air,Оррианский фокус воздуха
 Orrian Focus of Bloodlust,Оррианский фокус жажды крови
 Orrian Focus of Corruption,Оррианский фокус порчи

--- a/pn/pn_items_068.csv
+++ b/pn/pn_items_068.csv
@@ -221,11 +221,11 @@ Penetrating Aureate Warhorn of Earth,Пронзающий золочёный б�
 Penetrating Aureate Warhorn of Ogre Slaying,Пронзающий золочёный боевой рог истребления огров
 Penetrating Black Earth Aquabreather of the Citadel,Проникающий черноземный аквадыхатель цитадели
 Penetrating Boots,Пробивающие сапоги
-Penetrating Cabalist Boots,Проникающие сапоги кабалиста
-Penetrating Cabalist Coat,Проникающая куртка кабалиста
-Penetrating Cabalist Gloves,Пробивающие перчатки кабалиста
+Penetrating Cabalist Boots,Проникающие сапоги каббалиста
+Penetrating Cabalist Coat,Проникающая куртка каббалиста
+Penetrating Cabalist Gloves,Пробивающие перчатки каббалиста
 Penetrating Cabalist Hood,Проникающий капюшон каббалиста
-Penetrating Cabalist Legs,Проникающие поножи кабалиста
+Penetrating Cabalist Legs,Проникающие поножи каббалиста
 Penetrating Cabalist Shoulders,Проникающие плечи каббалиста
 Penetrating Chestpiece,Проникающий нагрудник
 Penetrating Chestplate,Пробивающий нагрудник

--- a/pn/pn_items_070.csv
+++ b/pn/pn_items_070.csv
@@ -328,7 +328,7 @@ Powerful Potion of Mordrem Slaying,Могучее зелье истреблен�
 Powerful Potion of Nightmare Court Slaying,Могучее зелье истребления Nightmare Court
 Powerful Potion of Ogre Slaying,Могучее зелье истребления огров
 Powerful Potion of Outlaw Slaying,Могучее зелье истребления изгоев
-Powerful Potion of Slaying Scarlet's Armies,Мощное зелье уничтожения армий Скарлетт
+Powerful Potion of Slaying Scarlet's Armies,Мощное зелье уничтожения армий Скарлет
 Powerful Potion of Sons of Svanir Slaying,Могучее зелье истребления сынов Сванира
 Powerful Potion of Undead Slaying,Могучее зелье истребления нежити
 Powerful Ring,Могучее кольцо

--- a/pn/pn_items_072.csv
+++ b/pn/pn_items_072.csv
@@ -51,7 +51,7 @@ Rabid Bronze Pistol of Fire,Бешеный бронзовый пистолет �
 Rabid Bronze Pistol of Smoldering,Бешеный бронзовый пистолет тления
 Rabid Bronze Spear of Blight,Бешеное бронзовое копьё порчи
 Rabid Bronze Spear of Bursting,Бешеное бронзовое копьё Разрыва
-Rabid Cabalist Boots,Бешеные сапоги кабалиста
+Rabid Cabalist Boots,Бешеные сапоги каббалиста
 Rabid Cabalist Coat,Бешеная куртка каббалиста
 Rabid Cabalist Gloves,Перчатки каббалиста бешенства
 Rabid Cabalist Hood,Бешеный капюшон каббалиста

--- a/pn/pn_items_073.csv
+++ b/pn/pn_items_073.csv
@@ -22,8 +22,8 @@ Rampager's Bronze Pistol of Earth,Бронзовый пистолет Земли
 Rampager's Bronze Spear of Earth,Бронзовое копьё Земли Буяна
 Rampager's Cabalist Boots,Сапоги Кабалиста Буяна
 Rampager's Cabalist Boots of Balthazar,Сапоги Кабалиста Бальтазара Буяна
-Rampager's Cabalist Boots of Hoelbrak,Сапоги кабалиста Хоэльбрака Буяна
-Rampager's Cabalist Boots of Strength,Сапоги яростного кабалиста силы
+Rampager's Cabalist Boots of Hoelbrak,Сапоги каббалиста Хоэльбрака Буяна
+Rampager's Cabalist Boots of Strength,Сапоги яростного каббалиста силы
 Rampager's Cabalist Boots of the Pack,Сапоги Кабалиста из стаи Буяна
 Rampager's Cabalist Coat,Кабалистическая куртка Буяна
 Rampager's Cabalist Coat of Dwayna,Кабалистская куртка Двайны яростного
@@ -31,16 +31,16 @@ Rampager's Cabalist Coat of Infiltration,Куртка скрытности гр�
 Rampager's Cabalist Coat of the Lich,Кабалистская куртка Лича Рэмпейджера
 Rampager's Cabalist Gloves,Перчатки Кабалиста Буяна
 Rampager's Cabalist Gloves of Balthazar,Перчатки Кабалиста Бальтазара Буяна
-Rampager's Cabalist Gloves of Divinity,Рукавицы божественного кабалиста Буяна
+Rampager's Cabalist Gloves of Divinity,Рукавицы божественного каббалиста Буяна
 Rampager's Cabalist Gloves of Scavenging,"Перчатки алхимика разрушителя, дающие бонус к сбору ресурсов"
-Rampager's Cabalist Gloves of the Dolyak,Рукавицы кабалиста Дольяка Буяна
+Rampager's Cabalist Gloves of the Dolyak,Рукавицы каббалиста Дольяка Буяна
 Rampager's Cabalist Hood,Капюшон Кабалиста Буяна
 Rampager's Cabalist Hood of the Centaur,Капюшон Кабалиста-разрушителя кентавра
-Rampager's Cabalist Hood of the Flame Legion,Капюшон кабалиста из Flame Legion
+Rampager's Cabalist Hood of the Flame Legion,Капюшон каббалиста из Flame Legion
 Rampager's Cabalist Hood of the Flock,Капюшон Кабалиста Буяна из стаи
 Rampager's Cabalist Legs,Ноги Кабалиста Буяна
-Rampager's Cabalist Legs of Divinity,Ноги божественного кабалиста Буяна
-Rampager's Cabalist Legs of Melandru,Ноги кабалиста Меландру Буяна
+Rampager's Cabalist Legs of Divinity,Ноги божественного каббалиста Буяна
+Rampager's Cabalist Legs of Melandru,Ноги каббалиста Меландру Буяна
 Rampager's Cabalist Legs of the Lich,Ноги лича из экипировки Буяна
 Rampager's Cabalist Legs of the Traveler,Ноги странника из экипировки Буяна
 Rampager's Cabalist Shoulders,Плечи Кабалиста Буяна

--- a/pn/pn_items_074.csv
+++ b/pn/pn_items_074.csv
@@ -318,46 +318,46 @@ Ravaging Bandit Trident,Разорительный бандитский трез
 Ravaging Bandit Ward,Амулет бандита «Опустошение»
 Ravaging Black Earth Trident,Рагующий трезубец Чёрной земли
 Ravaging Cabalist Boots of Balthazar,Грабительские сапоги каббалиста Бальтазара
-Ravaging Cabalist Boots of Dwayna,Опустошающие сапоги кабалиста Двайны
-Ravaging Cabalist Boots of Grenth,Сапоги кабалиста разорения Грента
+Ravaging Cabalist Boots of Dwayna,Опустошающие сапоги каббалиста Двайны
+Ravaging Cabalist Boots of Grenth,Сапоги каббалиста разорения Грента
 Ravaging Cabalist Boots of Lyssa,Разрушительные сапоги каббалиста Лиссы
-Ravaging Cabalist Boots of Rata Sum,Разорительные сапоги кабалиста из Рата-Сума
+Ravaging Cabalist Boots of Rata Sum,Разорительные сапоги каббалиста из Рата-Сума
 Ravaging Cabalist Boots of Vampirism,Разорительные сапоги каббалиста вампиризма
 Ravaging Cabalist Boots of the Dolyak,Разорительные сапоги каббалиста дольяка
 Ravaging Cabalist Coat of Infiltration,Опустошающая Куртка Кабалиста Проникновения
 Ravaging Cabalist Coat of Mercy,Опустошающая кабалистическая куртка милосердия
 Ravaging Cabalist Coat of Strength,Разорительная куртка каббалиста Силы
 Ravaging Cabalist Coat of the Centaur,Разрушительная куртка каббалиста кентавра
-Ravaging Cabalist Coat of the Citadel,Опустошающая куртка кабалиста из Цитадели
-Ravaging Cabalist Coat of the Dolyak,Разорительная куртка кабалиста Долака
+Ravaging Cabalist Coat of the Citadel,Опустошающая куртка каббалиста из Цитадели
+Ravaging Cabalist Coat of the Dolyak,Разорительная куртка каббалиста Долака
 Ravaging Cabalist Coat of the Grove,Разорительная кабалистическая куртка рощи
 Ravaging Cabalist Gloves of Divinity,Опустошающие перчатки каббалиста Божественности
-Ravaging Cabalist Gloves of Scavenging,Опустошающие перчатки кабалиста добытчика
+Ravaging Cabalist Gloves of Scavenging,Опустошающие перчатки каббалиста добытчика
 Ravaging Cabalist Gloves of Strength,Опустошающие перчатки каббалиста силы
-Ravaging Cabalist Gloves of the Centaur,Разрушительные перчатки кабалиста из шкуры кентавра
-Ravaging Cabalist Gloves of the Flame Legion,Опустошающие перчатки кабалиста из Flame Legion
+Ravaging Cabalist Gloves of the Centaur,Разрушительные перчатки каббалиста из шкуры кентавра
+Ravaging Cabalist Gloves of the Flame Legion,Опустошающие перчатки каббалиста из Flame Legion
 Ravaging Cabalist Gloves of the Flock,Опустошающие перчатки каббалиста из стаи
-Ravaging Cabalist Hood of Balthazar,Разорительный капюшон кабалиста Бальтазара
+Ravaging Cabalist Hood of Balthazar,Разорительный капюшон каббалиста Бальтазара
 Ravaging Cabalist Hood of Divinity,Опустошающий капюшон каббалиста божественности
-Ravaging Cabalist Hood of Grenth,Опустошающий капюшон кабалиста Грента
+Ravaging Cabalist Hood of Grenth,Опустошающий капюшон каббалиста Грента
 Ravaging Cabalist Hood of Rata Sum,Опустошающий капюшон каббалиста Рата Сум
 Ravaging Cabalist Hood of Scavenging,Опустошающий капюшон каббалиста мародерства
 Ravaging Cabalist Hood of the Afflicted,Опустошающый кабалистский капюшон страждущего
-Ravaging Cabalist Hood of the Citadel,Опустошающий капюшон кабалиста Цитадели
+Ravaging Cabalist Hood of the Citadel,Опустошающий капюшон каббалиста Цитадели
 Ravaging Cabalist Hood of the Eagle,Опустошающий капюшон каббалиста орла
 Ravaging Cabalist Hood of the Traveler,Капюшон опустошающый кабалистический путешественника
-Ravaging Cabalist Legs of Dwayna,Опустошающые штаны кабалиста Двайны
+Ravaging Cabalist Legs of Dwayna,Опустошающые штаны каббалиста Двайны
 Ravaging Cabalist Legs of Hoelbrak,Опустошающые кабалистические поножи Хельброка
 Ravaging Cabalist Legs of Scavenging,«Опустошающые штаны каббалиста мародёрства»
 Ravaging Cabalist Legs of Strength,Опустошающие штаны каббалиста силы
 Ravaging Cabalist Legs of Vampirism,Опустошающие кабалистические поножи вампиризма
-Ravaging Cabalist Legs of the Dolyak,Опустошающие брюки кабалиста дольяка
+Ravaging Cabalist Legs of the Dolyak,Опустошающие брюки каббалиста дольяка
 Ravaging Cabalist Legs of the Flock,Опустошающие штаны каббалиста стаи
 Ravaging Cabalist Shoulders of Dwayna,Опустошающие плечи каббалиста Дуэйны
-Ravaging Cabalist Shoulders of Hoelbrak,Опустошающие наплечники кабалиста Хоэльбрака
-Ravaging Cabalist Shoulders of Rage,Опустошающие плечи кабалиста ярости
-Ravaging Cabalist Shoulders of Rata Sum,Опустошающые плечи кабалиста Рата-Сума
-Ravaging Cabalist Shoulders of the Afflicted,Опустошающие наплечники кабалиста Одержимых
+Ravaging Cabalist Shoulders of Hoelbrak,Опустошающие наплечники каббалиста Хоэльбрака
+Ravaging Cabalist Shoulders of Rage,Опустошающие плечи каббалиста ярости
+Ravaging Cabalist Shoulders of Rata Sum,Опустошающые плечи каббалиста Рата-Сума
+Ravaging Cabalist Shoulders of the Afflicted,Опустошающие наплечники каббалиста Одержимых
 Ravaging Cabalist Shoulders of the Centaur,Опустошающые плечи каббалиста кентавра
 Ravaging Cabalist Shoulders of the Dolyak,Опустошающие наплечники каббалиста Дольяка
 Ravaging Conjurer Chest of Rata Sum,Сундук опустошающего заклинателя из Рата Сум

--- a/pn/pn_items_075.csv
+++ b/pn/pn_items_075.csv
@@ -50,7 +50,7 @@ Ravaging Glyphic Rifle of the Hydromancer,Опустошающая глифич�
 Ravaging Glyphic Scepter,Опустошающый глифический скипетр
 Ravaging Glyphic Scepter of Accuracy,Опустошающий глифический скипетр точности
 Ravaging Glyphic Scepter of Debility,Опустошающий глифический скипетр слабости
-Ravaging Glyphic Scepter of Grawl Slaying,Опустошающий глифический скипетр убийства грауллов
+Ravaging Glyphic Scepter of Grawl Slaying,Опустошающий глифический скипетр убийства граулов
 Ravaging Glyphic Scepter of Serpent Slaying,Опустошающий глифический скипетр убийства змей
 Ravaging Glyphic Scepter of Smoldering,Опустошающый глифический скипетр тления
 Ravaging Glyphic Scepter of the Hydromancer,Опустошающий скипетр с глифами гидроманта
@@ -64,7 +64,7 @@ Ravaging Glyphic Short Bow of the Hydromancer,Опустошающий глиф�
 Ravaging Glyphic Spear,Опустошающое глифическое копьё
 Ravaging Glyphic Spear of Accuracy,Опустошающее глифическое копьё точности
 Ravaging Glyphic Spear of Debility,Опустошающое глифическое копьё немощи
-Ravaging Glyphic Spear of Grawl Slaying,Опустошающое глифическое копьё убийства грауллов
+Ravaging Glyphic Spear of Grawl Slaying,Опустошающое глифическое копьё убийства граулов
 Ravaging Glyphic Spear of Serpent Slaying,Опустошающее глифическое копьё убийства змей
 Ravaging Glyphic Spear of Smoldering,Опустошающее глифическое копьё тления
 Ravaging Glyphic Spear of the Hydromancer,Опустошающее глифическое копьё гидроманта

--- a/pn/pn_items_078.csv
+++ b/pn/pn_items_078.csv
@@ -134,7 +134,7 @@ Recipe: Feast of Sage-Stuffed Mushrooms,"Рецепт: пиршество из �
 Recipe: Feast of Sage-Stuffed Poultry,Рецепт: пиршество из фаршированной птицей
 Recipe: Feast of Seaweed Salad,Рецепт: пиршество из салата из морских водорослей
 Recipe: Feast of Sesame-Roasted Dinners,Рецепт: пиршество из кунжутно-жареных ужинов
-Recipe: Feast of Sesame-Roasted Meat,"Рецепт: пиршество из мяса, жаренного с кунжутом"
+Recipe: Feast of Sesame-Roasted Meat,"Рецепт: пиршество из мяса, жареного с кунжутом"
 Recipe: Feast of Spiced Mashed Yams,Рецепт: пиршество из пряного пюре из ямса
 Recipe: Feast of Spicier Flank Steaks,Рецепт: пиршество из пикантных стейков с боков
 Recipe: Feast of Spicy Cheeseburgers,Рецепт: пиршество из острых чизбургеров

--- a/pn/pn_items_080.csv
+++ b/pn/pn_items_080.csv
@@ -472,7 +472,7 @@ Recipe: Potent Superior Sharpening Stones,Рецепт: мощные точил�
 Recipe: Potion of Azantil,Рецепт: зелье Азантиля
 Recipe: Powerful Potion of Branded Slaying,Рецепт: мощное зелье убийства меченых
 Recipe: Powerful Potion of Mordrem Slaying,Рецепт: могучее зелье истребления мордремов
-Recipe: Powerful Potion of Slaying Scarlet's Armies,Рецепт: мощное зелье уничтожения армий Скарлетт
+Recipe: Powerful Potion of Slaying Scarlet's Armies,Рецепт: мощное зелье уничтожения армий Скарлет
 Recipe: Prickly Pear Pie,Рецепт: пирог с опунцией
 Recipe: Prickly Pear Sorbet,Рецепт: сорбет из опунции
 Recipe: Prismatium Ingot,Рецепт: слиток призматия

--- a/pn/pn_items_082.csv
+++ b/pn/pn_items_082.csv
@@ -497,5 +497,5 @@ Recipe: Thackeray's Boots,Рецепт: сапоги Теккерея
 Recipe: Thackeray's Breastplate,Рецепт: нагрудник Такерея
 Recipe: Thackeray's Bugle,Рецепт: горн Тэккерея
 Recipe: Thackeray's Bulwark,Рецепт: оплот Теккерея
-Recipe: Thackeray's Cleaver,Рецепт: тесак Тэккери
+Recipe: Thackeray's Cleaver,Рецепт: тесак Тэкери
 Recipe: Thackeray's Cloth Breather,Рецепт: тканевая дыхательная маска Такерея

--- a/pn/pn_items_083.csv
+++ b/pn/pn_items_083.csv
@@ -1,7 +1,7 @@
 english,translate
 Recipe: Thackeray's Crescent,Рецепт: полумесяц Тэккерея
 Recipe: Thackeray's Crusader,Рецепт: крестоносец Такерея
-Recipe: Thackeray's Crusher,Рецепт: дробилка Таккерея
+Recipe: Thackeray's Crusher,Рецепт: дробилка Такерея
 Recipe: Thackeray's Cuirass,Рецепт: кираса Тэкери
 Recipe: Thackeray's Doublet,Рецепт: дублет Такерея
 Recipe: Thackeray's Epaulets,Рецепт: эполеты Такерея
@@ -9,7 +9,7 @@ Recipe: Thackeray's Flame,Рецепт: пламя Теккерея
 Recipe: Thackeray's Focus,Рецепт: фокус Тэккерея
 Recipe: Thackeray's Footwear,Рецепт: обувь Такерея
 Recipe: Thackeray's Gauntlets,Рецепт: рукавицы Теккерея
-Recipe: Thackeray's Gavel,Рецепт: молот Тэккери
+Recipe: Thackeray's Gavel,Рецепт: молот Тэкери
 Recipe: Thackeray's Gladius,Рецепт: гладиус Теккерея
 Recipe: Thackeray's Gloves,Рецепт: перчатки Теккерея
 Recipe: Thackeray's Greatbow,Рецепт: большой лук Такерея
@@ -24,11 +24,11 @@ Recipe: Thackeray's Pants,Рецепт: штаны Теккерея
 Recipe: Thackeray's Pauldrons,Рецепт: наплечники Такерея
 Recipe: Thackeray's Pillar,Рецепт: столп Теккерея
 Recipe: Thackeray's Rifle,Рецепт: винтовка Таккерая
-Recipe: Thackeray's Rod,Рецепт: удочка Тэккери
+Recipe: Thackeray's Rod,Рецепт: удочка Тэкери
 Recipe: Thackeray's Seraph Inscription,Рецепт: серафимская гравировка Такерея
 Recipe: Thackeray's Seraph Insignia,Рецепт: серафимская инсигния Такерея
 Recipe: Thackeray's Shoulderguard,Рецепт: наплечный доспех Такерея
-Recipe: Thackeray's Skewer,Рецепт: шпажка Тэккери
+Recipe: Thackeray's Skewer,Рецепт: шпажка Тэкери
 Recipe: Thackeray's Slicer,Рецепт: резак Теккерея
 Recipe: Thackeray's Spire,Рецепт: шпиль Такерея
 Recipe: Thackeray's Tassets,Рецепт: набедренники Такерея

--- a/pn/pn_items_088.csv
+++ b/pn/pn_items_088.csv
@@ -300,7 +300,7 @@ Scarecrow Finisher,Добивание «Пугало»
 Scarlet Dye,Краска «Алая»
 Scarlet's Box of Desert Knickknacks,Коробка пустынных безделушек Скарлет
 Scarlet's Champions Mini 3-Pack,Мини-набор чемпионов Скарлет (3 шт.)
-Scarlet's Grasp,Хватка Скарлетт
+Scarlet's Grasp,Хватка Скарлет
 Scarlet's Grasp Skin,Облик «Хватка Скарлет»
 Scarlet's Kiss,Поцелуй Скарлет
 Scarlet's Lockbox Code Fragment,Фрагмент кода ларца Скарлет
@@ -309,7 +309,7 @@ Scarlet's Prototype Mechanism,Прототип механизма Скарлет
 Scarlet's Rainbow,Радуга Скарлет
 Scarlet's Secret Stash,Тайник Скарлет
 Scarlet's Spare Keys,Запасные ключи Скарлет
-Scarlet's Spaulders,Наплечники Скарлетт
+Scarlet's Spaulders,Наплечники Скарлет
 Scarlet's Spaulders Skin,Облик «Наплечники Скарлет»
 Scarlet's Veil,Покров Скарлет
 Scarlet's Veil Skin,Облик «Вуаль Скарлет»

--- a/pn/pn_items_089.csv
+++ b/pn/pn_items_089.csv
@@ -215,15 +215,15 @@ Sentinel's Barbaric Pauldrons,Варварские наплечники стра
 Sentinel's Black Earth Trident,Чёрный трезубец стража
 Sentinel's Black Earth Trident of Ice,Трезубец ледяной земли стража
 Sentinel's Black Earth Trident of the Hydromancer,Чёрный трезубец-посох Гидроманта стража
-Sentinel's Cabalist Boots,Сапоги кабалиста стража
+Sentinel's Cabalist Boots,Сапоги каббалиста стража
 Sentinel's Cabalist Boots of Strength,"Сапоги Кабалиста стража, дарующие мощь"
-Sentinel's Cabalist Coat,Куртка кабалиста стража
-Sentinel's Cabalist Coat of Balthazar,Куртка кабалиста из Бхалтазара (стража)
-Sentinel's Cabalist Gloves,Рукавицы кабалиста стража
+Sentinel's Cabalist Coat,Куртка каббалиста стража
+Sentinel's Cabalist Coat of Balthazar,Куртка каббалиста из Бхалтазара (стража)
+Sentinel's Cabalist Gloves,Рукавицы каббалиста стража
 Sentinel's Cabalist Gloves of the Afflicted,Рукавицы Кабалиста стража для страдающих
-Sentinel's Cabalist Hood,Капюшон кабалиста стража
-Sentinel's Cabalist Hood of Vampirism,Капюшон кабалиста-стража вампиризма
-Sentinel's Cabalist Legs,Штаны кабалиста стража
+Sentinel's Cabalist Hood,Капюшон каббалиста стража
+Sentinel's Cabalist Hood of Vampirism,Капюшон каббалиста-стража вампиризма
+Sentinel's Cabalist Legs,Штаны каббалиста стража
 Sentinel's Cabalist Legs of Scavenging,Набедренники Кабалиста стража с бонусом к поиску
 Sentinel's Cabalist Shoulders,Плечи Кабалиста стража
 Sentinel's Cabalist Shoulders of the Grove,Наплечники Кабалиста из Рощи стража

--- a/pn/pn_items_090.csv
+++ b/pn/pn_items_090.csv
@@ -94,18 +94,18 @@ Settler's Banded Pauldrons of Dwayna,Наплечники поселенца Д�
 Settler's Black Earth Trident,Чёрный трезубец поселенца
 Settler's Black Earth Trident of Ice,"Трёхзубец из чёрной земли поселенца, дарующий силу льда"
 Settler's Black Earth Trident of the Hydromancer,Трёхзубец Гидроманта из чёрной земли поселенца
-Settler's Cabalist Boots,Сапоги поселенца-кабалиста
-Settler's Cabalist Boots of Strength,Сапоги поселенца-кабалиста силы
-Settler's Cabalist Coat,Куртка поселенца-кабалиста
-Settler's Cabalist Coat of Balthazar,Куртка поселенца-кабалиста Бальтазара
-Settler's Cabalist Gloves,Перчатки поселенца-кабалиста
-Settler's Cabalist Gloves of the Afflicted,Перчатки поселенца-кабалиста страждущих
-Settler's Cabalist Hood,Капюшон поселенца-кабалиста
-Settler's Cabalist Hood of Vampirism,Капюшон поселенца-кабалиста вампиризма
-Settler's Cabalist Legs,Штаны поселенца-кабалиста
-Settler's Cabalist Legs of Scavenging,Штаны поселенца-кабалиста собирательства
-Settler's Cabalist Shoulders,Наплечники поселенца-кабалиста
-Settler's Cabalist Shoulders of the Grove,Наплечники поселенца-кабалиста Рощи
+Settler's Cabalist Boots,Сапоги поселенца-каббалиста
+Settler's Cabalist Boots of Strength,Сапоги поселенца-каббалиста силы
+Settler's Cabalist Coat,Куртка поселенца-каббалиста
+Settler's Cabalist Coat of Balthazar,Куртка поселенца-каббалиста Бальтазара
+Settler's Cabalist Gloves,Перчатки поселенца-каббалиста
+Settler's Cabalist Gloves of the Afflicted,Перчатки поселенца-каббалиста страждущих
+Settler's Cabalist Hood,Капюшон поселенца-каббалиста
+Settler's Cabalist Hood of Vampirism,Капюшон поселенца-каббалиста вампиризма
+Settler's Cabalist Legs,Штаны поселенца-каббалиста
+Settler's Cabalist Legs of Scavenging,Штаны поселенца-каббалиста собирательства
+Settler's Cabalist Shoulders,Наплечники поселенца-каббалиста
+Settler's Cabalist Shoulders of the Grove,Наплечники поселенца-каббалиста Рощи
 Settler's Conjurer Chest of Divinity,Сундук заклинателя поселенца из Божественного Предела
 Settler's Conjurer Gloves of the Eagle,Перчатки заклинателя поселенца с орлиным мотивом
 Settler's Conjurer Mantle of Balthazar,Плащ заклинателя поселенца Бальтазара
@@ -495,7 +495,7 @@ Shaman's Banded Legs of Strength,Поножи шамана силы
 Shaman's Banded Legs of the Traveler,Поножи странника шамана
 Shaman's Banded Pauldrons of Dwayna,Поночи Шамана Двайны
 Shaman's Banded Pauldrons of Rage,Наплечники шамана ярости
-Shaman's Cabalist Boots,Сапоги шамана-кабалиста
-Shaman's Cabalist Boots of Rage,Сапоги шамана-кабалиста ярости
-Shaman's Cabalist Boots of Rata Sum,Сапоги шамана-кабалиста Рата Сум
-Shaman's Cabalist Boots of Scavenging,Сапоги шамана-кабалиста собирательства
+Shaman's Cabalist Boots,Сапоги шамана-каббалиста
+Shaman's Cabalist Boots of Rage,Сапоги шамана-каббалиста ярости
+Shaman's Cabalist Boots of Rata Sum,Сапоги шамана-каббалиста Рата Сум
+Shaman's Cabalist Boots of Scavenging,Сапоги шамана-каббалиста собирательства

--- a/pn/pn_items_091.csv
+++ b/pn/pn_items_091.csv
@@ -1,30 +1,30 @@
 english,translate
-Shaman's Cabalist Boots of Strength,Сапоги шамана-кабалиста силы
-Shaman's Cabalist Coat,Куртка шамана-кабалиста
-Shaman's Cabalist Coat of Balthazar,Куртка шамана-кабалиста Бальтазара
-Shaman's Cabalist Coat of Strength,Куртка шамана-кабалиста силы
-Shaman's Cabalist Coat of the Eagle,Куртка шамана-кабалиста орла
-Shaman's Cabalist Coat of the Flock,Куртка шамана-кабалиста стаи
-Shaman's Cabalist Gloves,Перчатки шамана-кабалиста
-Shaman's Cabalist Gloves of Infiltration,Перчатки шамана-кабалиста проникновения
-Shaman's Cabalist Gloves of the Afflicted,Перчатки шамана-кабалиста страждущих
-Shaman's Cabalist Gloves of the Centaur,Перчатки шамана-кабалиста кентавра
-Shaman's Cabalist Gloves of the Grove,Перчатки шамана-кабалиста Рощи
-Shaman's Cabalist Hood,Капюшон шамана-кабалиста
-Shaman's Cabalist Hood of Grenth,Капюшон шамана-кабалиста Грента
-Shaman's Cabalist Hood of Hoelbrak,Капюшон шамана-кабалиста Хёльбрака
-Shaman's Cabalist Hood of Infiltration,Капюшон шамана-кабалиста проникновения
-Shaman's Cabalist Hood of Vampirism,Капюшон шамана-кабалиста вампиризма
-Shaman's Cabalist Legs,Штаны шамана-кабалиста
-Shaman's Cabalist Legs of Infiltration,Штаны шамана-кабалиста проникновения
-Shaman's Cabalist Legs of Melandru,Штаны шамана-кабалиста Меландру
-Shaman's Cabalist Legs of Scavenging,Штаны шамана-кабалиста собирательства
-Shaman's Cabalist Legs of the Citadel,Штаны шамана-кабалиста Цитадели
-Shaman's Cabalist Shoulders,Наплечники шамана-кабалиста
-Shaman's Cabalist Shoulders of Hoelbrak,Наплечники шамана-кабалиста Хёльбрака
-Shaman's Cabalist Shoulders of the Afflicted,Наплечники шамана-кабалиста страждущих
-Shaman's Cabalist Shoulders of the Flame Legion,Наплечники шамана-кабалиста Flame Legion
-Shaman's Cabalist Shoulders of the Grove,Наплечники шамана-кабалиста Рощи
+Shaman's Cabalist Boots of Strength,Сапоги шамана-каббалиста силы
+Shaman's Cabalist Coat,Куртка шамана-каббалиста
+Shaman's Cabalist Coat of Balthazar,Куртка шамана-каббалиста Бальтазара
+Shaman's Cabalist Coat of Strength,Куртка шамана-каббалиста силы
+Shaman's Cabalist Coat of the Eagle,Куртка шамана-каббалиста орла
+Shaman's Cabalist Coat of the Flock,Куртка шамана-каббалиста стаи
+Shaman's Cabalist Gloves,Перчатки шамана-каббалиста
+Shaman's Cabalist Gloves of Infiltration,Перчатки шамана-каббалиста проникновения
+Shaman's Cabalist Gloves of the Afflicted,Перчатки шамана-каббалиста страждущих
+Shaman's Cabalist Gloves of the Centaur,Перчатки шамана-каббалиста кентавра
+Shaman's Cabalist Gloves of the Grove,Перчатки шамана-каббалиста Рощи
+Shaman's Cabalist Hood,Капюшон шамана-каббалиста
+Shaman's Cabalist Hood of Grenth,Капюшон шамана-каббалиста Грента
+Shaman's Cabalist Hood of Hoelbrak,Капюшон шамана-каббалиста Хёльбрака
+Shaman's Cabalist Hood of Infiltration,Капюшон шамана-каббалиста проникновения
+Shaman's Cabalist Hood of Vampirism,Капюшон шамана-каббалиста вампиризма
+Shaman's Cabalist Legs,Штаны шамана-каббалиста
+Shaman's Cabalist Legs of Infiltration,Штаны шамана-каббалиста проникновения
+Shaman's Cabalist Legs of Melandru,Штаны шамана-каббалиста Меландру
+Shaman's Cabalist Legs of Scavenging,Штаны шамана-каббалиста собирательства
+Shaman's Cabalist Legs of the Citadel,Штаны шамана-каббалиста Цитадели
+Shaman's Cabalist Shoulders,Наплечники шамана-каббалиста
+Shaman's Cabalist Shoulders of Hoelbrak,Наплечники шамана-каббалиста Хёльбрака
+Shaman's Cabalist Shoulders of the Afflicted,Наплечники шамана-каббалиста страждущих
+Shaman's Cabalist Shoulders of the Flame Legion,Наплечники шамана-каббалиста Flame Legion
+Shaman's Cabalist Shoulders of the Grove,Наплечники шамана-каббалиста Рощи
 Shaman's Conjurer Chest of Divinity,Нагрудная броня заклинателя шамана из Божественного Предела
 Shaman's Conjurer Chest of the Eagle,Нагрудник шамана-заклинателя орла
 Shaman's Conjurer Chest of the Grove,Нагрудник шамана-заклинателя из рощи

--- a/pn/pn_items_094.csv
+++ b/pn/pn_items_094.csv
@@ -390,11 +390,11 @@ Soldier's Bronze Spear of Energy,Бронзовое копьё Солдата с
 Soldier's Bronze Spear of Force,Бронзовое копьё солдата силы
 Soldier's Bronze Sword of Accuracy,Бронзовый меч солдата точности
 Soldier's Bronze Sword of Force,Бронзовый меч солдата силы
-Soldier's Cabalist Boots,«Сапоги кабалиста солдата»
+Soldier's Cabalist Boots,«Сапоги каббалиста солдата»
 Soldier's Cabalist Coat,«Солдатская кабалистическая куртка»
-Soldier's Cabalist Gloves,«Перчатки кабалиста солдата»
-Soldier's Cabalist Hood,Капюшон кабалиста солдата
-Soldier's Cabalist Legs,Ноги кабалиста солдата
+Soldier's Cabalist Gloves,«Перчатки каббалиста солдата»
+Soldier's Cabalist Hood,Капюшон каббалиста солдата
+Soldier's Cabalist Legs,Ноги каббалиста солдата
 Soldier's Cabalist Shoulders,«Солдатские наплечники каббалиста»
 Soldier's Ceremonial Bulwark,«Солдатский церемониальный оплот»
 Soldier's Ceremonial Dagger,Церемониальный кинжал Солдата

--- a/pn/pn_items_097.csv
+++ b/pn/pn_items_097.csv
@@ -394,12 +394,12 @@ Story of a Djinn,История джинна
 Storyteller's Lute,Лютня сказителя
 Stout,Крепкий
 Stout Ale Keg,Бочонок крепкого эля
-Stout Cabalist Boots,Крепкие сапоги кабалиста
+Stout Cabalist Boots,Крепкие сапоги каббалиста
 Stout Cabalist Coat,Куртка каббалиста «Крепкий»
-Stout Cabalist Gloves,Крепкие перчатки кабалиста
+Stout Cabalist Gloves,Крепкие перчатки каббалиста
 Stout Cabalist Hood,Крепкий капюшон каббалиста
-Stout Cabalist Legs,Крепкие поножи кабалиста
-Stout Cabalist Shoulders,Крепкие наплечники кабалиста
+Stout Cabalist Legs,Крепкие поножи каббалиста
+Stout Cabalist Shoulders,Крепкие наплечники каббалиста
 Stout Privateer Boots,Крепкие сапоги капера
 Stout Privateer Coat,Крепкая каперская куртка
 Stout Privateer Gloves,Крепкие перчатки капера

--- a/pn/pn_items_098.csv
+++ b/pn/pn_items_098.csv
@@ -64,17 +64,17 @@ Strong Cabalist Gloves of Grenth,Прочные перчатки каббали�
 Strong Cabalist Gloves of Hoelbrak,Прочные перчатки каббалиста Хоэльбрака
 Strong Cabalist Gloves of Lyssa,Прочные перчатки каббалиста Лиссы
 Strong Cabalist Gloves of Melandru,Прочные перчатки каббалиста Меландру
-Strong Cabalist Gloves of Scavenging,Прочные перчатки кабалиста добытчика
+Strong Cabalist Gloves of Scavenging,Прочные перчатки каббалиста добытчика
 Strong Cabalist Gloves of the Dolyak,Прочные перчатки каббалиста дольяка
 Strong Cabalist Hood of Hoelbrak,Прочный капюшон каббалиста Хоэльбрака
 Strong Cabalist Hood of Lyssa,Прочный капюшон каббалиста Лиссы
 Strong Cabalist Hood of Mercy,Прочный капюшон каббалиста милосердия
-Strong Cabalist Hood of the Citadel,Прочный капюшон кабалиста Цитадели
+Strong Cabalist Hood of the Citadel,Прочный капюшон каббалиста Цитадели
 Strong Cabalist Hood of the Traveler,Прочный капюшон каббалиста путешественника
 Strong Cabalist Legs of Balthazar,Прочные поножи каббалиста Бальтазара
 Strong Cabalist Legs of Divinity,Прочные поножи каббалиста божественности
 Strong Cabalist Legs of Grenth,Прочные поножи каббалиста Гренса
-Strong Cabalist Legs of Melandru,Прочные ноги кабалиста Меландру
+Strong Cabalist Legs of Melandru,Прочные ноги каббалиста Меландру
 Strong Cabalist Legs of the Centaur,Прочные поножи каббалиста кентавра
 Strong Cabalist Legs of the Citadel,Прочные поножи каббалиста Цитадели
 Strong Cabalist Shoulders of Divinity,Прочные наплечники каббалиста божественности
@@ -279,7 +279,7 @@ Strong Magician Boots of Lyssa,Прочные сапоги мага Лиссы
 Strong Magician Boots of Vampirism,Сапоги прочного мага вампиризма
 Strong Magician Boots of the Flock,Прочные сапоги мага из стаи
 Strong Magician Coat,Куртка прочного мага
-Strong Magician Coat of Melandru,Куртка мага прочного Мелландру
+Strong Magician Coat of Melandru,Куртка мага прочного Меландру
 Strong Magician Coat of the Afflicted,Прочная куртка мага из «Страждущих»
 Strong Magician Coat of the Flame Legion,Прочная куртка мага Flame Legion
 Strong Magician Coat of the Flock,Куртка прочного волшебника «Стая»

--- a/pn/pn_items_101.csv
+++ b/pn/pn_items_101.csv
@@ -140,7 +140,7 @@ Tasty Kryptis Skin,Вкусная шкура криптиса
 Tasty Meat,Вкусное мясо
 Tasty Minotaur Flank,Вкусный минотавр (задняя часть)
 Tasty Moss-Covered Bark,"Вкусная кора, покрытая мхом"
-Tasty Ooze-Cured Meat,"Вкусное мясо, вяленное в слизи"
+Tasty Ooze-Cured Meat,"Вкусное мясо, вяленое в слизи"
 Tasty Skale Fin,Вкусная чешуйчатая рыба.
 Tasty Skelk Liver,Вкусная печень скелька
 Tasty Spider Leg,Вкусная ножка паука

--- a/pn/pn_items_108.csv
+++ b/pn/pn_items_108.csv
@@ -477,7 +477,7 @@ Warbeast Hardened Shoulderguard Padding,Закалённая подкладка 
 Warbeast Hardened Shoulderguard Panel,Закалённая панель наплечника боевого зверя
 Warbeast Hardened Trouser Padding,Закалённая подкладка штанов боевого зверя
 Warbeast Hardened Trouser Panel,Закалённая панель штанов боевого зверя
-Warbeast Orichalcum Boot Casing,Боевая обувная основа из оррихалка с звериным принтом боевого зверя
+Warbeast Orichalcum Boot Casing,Боевая обувная основа из орихалка с звериным принтом боевого зверя
 Warbeast Orichalcum Boot Lining,Подкладка для сапог из орихалка боевого зверя
 Warbeast Orichalcum Chestplate Padding,Подкладка орихалкового нагрудника боевого зверя
 Warbeast Orichalcum Chestplate Panel,Панель нагрудника из орихалка боевого зверя
@@ -486,7 +486,7 @@ Warbeast Orichalcum Gauntlet Plates,Пластины наручей из ори�
 Warbeast Orichalcum Helmet Casing,Орихалковая основа шлема боевого зверя
 Warbeast Orichalcum Helmet Lining,Подкладка воинственного шлема из орихалка боевого зверя
 Warbeast Orichalcum Legging Lining,Подкладка для поножей из орихалка боевого зверя
-Warbeast Orichalcum Legging Panel,Панель поножей из оррихалка для боевого зверя
+Warbeast Orichalcum Legging Panel,Панель поножей из орихалка для боевого зверя
 Warbeast Orichalcum Pauldron Casing,Оболочка наплечника из орихалка Военного зверя боевого зверя
 Warbeast Orichalcum Pauldron Lining,Орихалковая подкладка наплечника боевого зверя
 Warbringer,Войновожатый

--- a/pn/pn_names_004.csv
+++ b/pn/pn_names_004.csv
@@ -428,7 +428,7 @@ Dealer,Торговец
 Dean,Дин
 Dearthair,Диртхэйр
 Death Shroud,Саван смерти
-Death-Branded Deputy Qais,Клеймённый смертью заместитель Кайс
+Death-Branded Deputy Qais,Клеймёный смертью заместитель Кайс
 Deathling,Смертник
 Deathrain,Смертодождь
 Debbie Lantys,Дебби Лантис

--- a/pn/pn_names_007.csv
+++ b/pn/pn_names_007.csv
@@ -85,7 +85,7 @@ Gejja,Гейджа
 Gellia,Гелия
 Gem Store,Магазин самоцветов
 General,Генерал
-General Almorra,Генерал Альмора
+General Almorra,Генерал Альморра
 General Almorra Soulkeeper,генерал Альморра Душехран
 General Hugo Bronzebeard,Генерал Хьюго Бронзобород
 General Molradovich,Генерал Молрадович

--- a/pn/pn_names_016.csv
+++ b/pn/pn_names_016.csv
@@ -443,7 +443,7 @@ Vark,Варк
 Varkk,Варкк
 Varonos,Варонос
 Varonos Doolbroo,Варонос Дулбру
-Varonos Flubburt,Вароносс Флаббурт
+Varonos Flubburt,Варонос Флаббурт
 Varonos Mergelp,Варонос Мергелп
 Varonos Telsip,Варонос Телсип
 Varren,Варрен

--- a/pn/pn_names_025.csv
+++ b/pn/pn_names_025.csv
@@ -417,7 +417,7 @@ Crystal Bloom Hunter,Охотник Хрустального расцвета
 Crystal Bloom Leader,Глава Хрустального расцвета
 Crystal Bloom Level,Уровень Хрустального расцвета
 Crystal Bloom Paragon,Паладин Хрустального расцвета
-Crystal Bloom Race Master,Мастер расы Кристал Блум
+Crystal Bloom Race Master,Мастер расы Кристалл Блум
 Crystal Bloom Reflector A,Отражатель Crystal Bloom A
 Crystal Bloom Reflector B,Отражатель Crystal Bloom B
 Crystal Bloom Reflector C,Отражатель Crystal Bloom C

--- a/pn/pn_names_026.csv
+++ b/pn/pn_names_026.csv
@@ -340,7 +340,7 @@ Forged Catapult Attack,Атака катапульты Кованых
 Forged Champion,Кованый чемпион
 Forged Chest,Сундук Кованых
 Forged Crawling Bomb,Выкованная ползучая бомба
-Forged Determination,Кованная решимость
+Forged Determination,Кованая решимость
 Forged Drainer,Кованый иссушитель
 Forged Explosive,Взрывчатка Кованых
 Forged Flames,Кованое пламя

--- a/pn/pn_names_028.csv
+++ b/pn/pn_names_028.csv
@@ -482,18 +482,18 @@ Old Storyteller,Старый Сказитель
 Old Treasure Chest,Старый сундук с сокровищами
 Old Wounds,Старые раны
 Orrian Amulet,Оррианский амулет
-Orrian Archer,Орианский лучник
+Orrian Archer,Оррианский лучник
 Orrian Artifact,Оррианский артефакт
 Orrian Bone Ship,Костяной корабль Орра
 Orrian Broken Bottle,Оррианская разбитая бутылка
 Orrian Captain,Капитан Орриана
-Orrian Catapult,Орианская катапульта
+Orrian Catapult,Оррианская катапульта
 Orrian Chicken Coop,Оррианский курятник
-Orrian Coffin,Орианский саркофаг
+Orrian Coffin,Оррианский саркофаг
 Orrian Corpse,Оррианский труп
 Orrian Corruption,Оррианская порча
 Orrian Corruptions,Осквернения Орриана
-Orrian Crab,Орианский краб
+Orrian Crab,Оррианский краб
 Orrian Door,Оррианская дверь
 Orrian Elemental Cauldron,Оррианский элементальный котел
 Orrian Explosives,Оррианская взрывчатка

--- a/pn/pn_names_029.csv
+++ b/pn/pn_names_029.csv
@@ -83,24 +83,24 @@ Orrian Obelisk,Облиск Орриана
 Orrian Oyster,Оррианская устрица
 Orrian Pedestal,Оррианский пьедестал
 Orrian Power Grid Restored,Энергосеть Орра восстановлена
-Orrian Priest,Орианский жрец
+Orrian Priest,Оррианский жрец
 Orrian Ruins,Руины Орриана
 Orrian Runestone,Рунный камень Орриана
 Orrian Sapling,Оррианский саженец
-Orrian Sea Turtle,Орианская морская черепаха
+Orrian Sea Turtle,Оррианская морская черепаха
 Orrian Sentry,Оррианский страж
-Orrian Shambler,Орианский шамблер
+Orrian Shambler,Оррианский шамблер
 Orrian Shrine Power Grid,Энергосеть святилища Орра
 Orrian Siege Weapon,Осадная машина оррианцев
 Orrian Soldier,Солдат Орриана
-Orrian Spectral Archer,Орианский призрачный лучник
-Orrian Spectral Flamecaster,Орианский призрачный огнемётчик
-Orrian Spectral Skirmisher,Орианский призрачный застрельщик
+Orrian Spectral Archer,Оррианский призрачный лучник
+Orrian Spectral Flamecaster,Оррианский призрачный огнемётчик
+Orrian Spectral Skirmisher,Оррианский призрачный застрельщик
 Orrian Strength,Сила Orrian
 Orrian Symbol,Оррианский символ
 Orrian Thrall,Оррианский невольник
-Orrian Tomb,Орианская гробница
-Orrian Tower,Орианская башня
+Orrian Tomb,Оррианская гробница
+Orrian Tower,Оррианская башня
 Orrian Treasure Chest,Сундук с сокровищами Орриана
 Orrian Trendril,Оррианский усик
 Orrian Vase,Оррианская ваза

--- a/pn/pn_names_036.csv
+++ b/pn/pn_names_036.csv
@@ -51,8 +51,8 @@ Bloodscale,Кровочешуй
 Bloodstone-Crazed Devourer,Обезумевший от кровавого камня пожиратель
 Bookworm Bwikki,Книжный червь Бвикки
 Boom-Boom Baines,Бум-Бум Бейнс
-Branded Awakened,Клеймённые пробуждённые
-Branded Storm Elemental,Клеймённый элементаль бури
+Branded Awakened,Клеймёные пробуждённые
+Branded Storm Elemental,Клеймёный элементаль бури
 Brandstone,Клеймокамень
 Brenner!,Бреннер!
 CHOP K1T-D,CHOP K1T-D
@@ -72,8 +72,8 @@ Chak?,Чак?
 "Champion Adal, Unyielding Firmament","Чемпион: Адал, Непреклонная Твердь"
 Champion Ancient Ghost Mage,Чемпион: Древний призрачный маг
 "Champion Aszar, Swinging Pendulum","Чемпион: Асзар, Качающийся Маятник"
-Champion Branded Griffon version,"Чемпион: Клеймённый грифон, версия"
-Champion Branded Riftstalker,Чемпион: Клеймённый охотник разломов
+Champion Branded Griffon version,"Чемпион: Клеймёный грифон, версия"
+Champion Branded Riftstalker,Чемпион: Клеймёный охотник разломов
 Champion Destroyer Harpy,Чемпион: Гарпия-разрушительница
 Champion Dunechaser,Чемпион: Дюногон
 Champion Forged Ambusher,Чемпион: Кованый засадник
@@ -147,7 +147,7 @@ Flora Vitae,Flora Vitae
 Forgal,Форгал
 Forged Demolisher,Кованый крушитель
 Forgemaster Elrik,Мастер кузни Элрик
-Fort Marriner?,Форт Маринер?
+Fort Marriner?,Форт Марринер?
 Freebooter Initiate,Новичок-флибустьер
 Gahn Towerbreaker,"Ган, Крушитель Башен"
 Galea,Галея

--- a/pn/pn_names_037.csv
+++ b/pn/pn_names_037.csv
@@ -46,9 +46,9 @@ Blattodea,Блаттодея
 Blight Tender Tricot,Смотритель порчи Трикот
 Boatswain Tennet,Боцман Теннет
 Braham - Eirsson,Брейхам - Эйрссон
-Branded Forgotten Zealot,Клеймённый фанатик Забытых
-Branded Riftstalker Matriarch,Матриарх клеймённых охотников разломов
-Branded Villagers,Клеймённые селяне
+Branded Forgotten Zealot,Клеймёный фанатик Забытых
+Branded Riftstalker Matriarch,Матриарх клеймёных охотников разломов
+Branded Villagers,Клеймёные селяне
 Brekkabek,Бреккабек
 Bronk,Бронк
 Brutish Ettin Chieftain,Звероподобный вождь эттинов

--- a/pn/pn_names_038.csv
+++ b/pn/pn_names_038.csv
@@ -33,8 +33,8 @@ Bo,Бо
 Bongo the One-Eyed,Бонго Одноглазый
 Borealis,Бореалис
 Braham...,Брейхам...
-Branded Charr Leader,Клеймённый вождь чарров
-Branded Hydra,Клеймённая гидра
+Branded Charr Leader,Клеймёный вождь чарров
+Branded Hydra,Клеймёная гидра
 Breaking the Ice,Взламывая лед
 Breann,Бреанн
 Brina the Tanner,Брина Кожевница
@@ -49,7 +49,7 @@ Chak Ley-Comb,Лей-сота чаков
 Champawat,Чампават
 Champion Awakened Occultist,Чемпион: Пробуждённый оккультист
 Champion Braek Baredfang,Чемпион: Брэк Бэрдфанг
-Champion Branded Griffon,Чемпион: Клеймённый грифон
+Champion Branded Griffon,Чемпион: Клеймёный грифон
 Champion Enbilulu,Чемпион: Энбилулу
 Champion First Mate Horrik,Чемпион: Первый помощник Хоррик
 Champion Flame Effigy,Чемпион: Чучело Пламени

--- a/pn/pn_names_039.csv
+++ b/pn/pn_names_039.csv
@@ -47,8 +47,8 @@ Bloodstone-Crazed Arctodus,Обезумевший от кровавого кам
 Bogfang,Болотоклык
 Boticca!,Ботикка!
 Braham!,Брейхам!
-Branded Awakened General Argon,Клеймённый пробуждённый генерал Аргон
-Branded Riftstalker,Клеймённый охотник разломов
+Branded Awakened General Argon,Клеймёный пробуждённый генерал Аргон
+Branded Riftstalker,Клеймёный охотник разломов
 Brigga the Bruiser,Бригга Громила
 Bright Shore,Светлый берег
 Brimstone.,Жарокамень.
@@ -68,7 +68,7 @@ Champion Badly Confused Ettin,Чемпион: Вконец растерянны�
 Champion Blighted Diarmid,Чемпион: Осквернённый Диармид
 Champion Bloodstone Elemental Mauler,Чемпион: Элементаль-маулер кровавого камня
 Champion Brandclaw,Чемпион: Клеймокоготь
-Champion Branded Minion,Чемпион: Клеймённый прислужник
+Champion Branded Minion,Чемпион: Клеймёный прислужник
 Champion Chaotic Leyspark,Чемпион: Хаотическая лей-искра
 Champion Crackedhoof,Чемпион: Трещинокопыт
 Champion Dominion Duelist/Engineer/Marksman/Scout/Soldier/Spy,Чемпион: Дуэлянт/Инженер/Стрелок/Разведчик/Солдат/Шпион Доминиона
@@ -209,7 +209,7 @@ Kryptis?,Криптис?
 Kubo,Кубо
 Kuunavang.,Куунаванг.
 Lady Livia?,Леди Ливия?
-Lawson Marriner,Лоусон Маринер
+Lawson Marriner,Лоусон Марринер
 Left Eye of Oouo,Левый глаз Оуо
 Legendary Daol Brol Shiol,Легендарный Даол Брол Шиол
 Legendary Forged Rampager,Легендарный кованый громила

--- a/pn/pn_names_040.csv
+++ b/pn/pn_names_040.csv
@@ -48,7 +48,7 @@ Carrier Cacophony,Разносчик какофонии
 Castle Lord,Лорд замка
 Celestial Shadow,Небесная тень
 Champion Agasaya,Чемпион: Агасайя
-Champion Branded Human version,"Чемпион: Клеймённый человек, версия"
+Champion Branded Human version,"Чемпион: Клеймёный человек, версия"
 Champion Butch,Чемпион Бутч
 Champion Chak Blitzer,Чемпион: Чак-блицер
 Champion Chieftain Krella,Чемпион: Вождь Крелла
@@ -98,9 +98,9 @@ Crecia?,Кресия?
 DERV,DERV
 DO NOT TRANSLATE,DO NOT TRANSLATE
 Dark Barrage,Тёмный залп
-Death-Branded Hessper Sasso,Клеймённый смертью Хесспер Сассо
-Death-Branded Shatterer,Клеймённый смертью Сокрушитель
-Death-Branded Wrathbringer,Клеймённый смертью Гневоносец
+Death-Branded Hessper Sasso,Клеймёный смертью Хесспер Сассо
+Death-Branded Shatterer,Клеймёный смертью Сокрушитель
+Death-Branded Wrathbringer,Клеймёный смертью Гневоносец
 "Decima, the Stormsinger","Децима, Певица Бурь"
 Delilah,Делайла
 Demmi!,Демми!

--- a/pn/pn_names_041.csv
+++ b/pn/pn_names_041.csv
@@ -21,7 +21,7 @@ Captain Fa.,Капитан Фа.
 Captain Mattox,Капитан Маттокс
 Champion Alpha Wolf,Чемпион: Альфа-волк
 Champion Awakened Abhorrence,Чемпион: Пробуждённое омерзение
-Champion Branded Fish,Чемпион: Клеймённая рыба
+Champion Branded Fish,Чемпион: Клеймёная рыба
 Champion Cave Troll,Чемпион: Пещерный тролль
 Champion Krait Hypnoss,Чемпион Крайт Гипносс
 Champion Lady Kahraman,Чемпион: Леди Кахраман

--- a/pn/pn_world_map_004.csv
+++ b/pn/pn_world_map_004.csv
@@ -199,8 +199,8 @@ Fort Cadence Waypoint,Путевая точка: Форт Каденс
 Fort Defiance,Форт Дефайанс
 Fort Evennia,Форт Эвенния
 Fort Huduh,Форт Худу
-Fort Marriner,Форт Маринер
-Fort Marriner Waypoint,Путевая точка: Форт Маринер
+Fort Marriner,Форт Марринер
+Fort Marriner Waypoint,Путевая точка: Форт Марринер
 Fort Salma,Форт Сальма
 Fort Salma Waypoint,Путь к форту Сальма
 Fort Stalwart,Форт Сталварт


### PR DESCRIPTION
Тот же приём, что с ё (#112): доказательство берётся из самого слоя, где **оба написания лежат рядом при одном английском имени**. `Cabalist Legs` записан «Поножи каббалиста», а производные говорят «Ноги кабалиста» — это не спор о переводе, а орфография.

Нашлось 46 пар, канон определён по корпусу у 24. **191 запись в 45 файлах.**

| было | стало | записей | корпус |
|---|---|---|---|
| кабалиста | каббалиста | 104 | 9 : 0 |
| Орианский | Оррианский | 22 | 28 : 2 |
| Клеймённый | Клеймёный | 14 | 47 : 5 |
| Скарлетт | Скарлет | 7 | 380 : 35 |
| сигилла | сигила | 4 | 85 : 2 |
| грауллов | граулов | 4 | 225 : 0 |
| Маринер | Марринер | 4 | 39 : 6 |
| Оррихалковая | Орихалковая | 3 | 10 : 0 |
| Мелландру | Меландру | 2 | 127 : 0 |

## Две пары отброшены после проверки

Автоматика предложила свести и их, но там удвоение — не опечатка:

**`Коммандир` / `Командир`.** «Коммандир» (2 490 вхождений) — это титул игрока, перевод `Commander`. «Командир» (446) стоит при обычных командирах: `Forged commander retreats in disgust` → «Командир Forged отступает в отвращении». Свести их значило бы стереть различие, которое держит текст.

**`Странница` / `Страница`** — просто разные слова, удвоение тут ни при чём: «Страница из книги «Ритуалы Дня Зимы»».

## Что не тронуто

**19 пар**, где перевес корпуса меньше чем вчетверо — решать не мне: «Бешенная»/«Бешеная» 0 против 1, «Гипносс»/«Гипнос» 0 против 0, «Клейменных»/«Клейменых» 78 против 26.

Порог в шесть букв стоит намеренно: на коротких словах слишком велик шанс поймать пару вроде «сума»/«сумма», где законны оба написания.

Гейт: линтер по 45 изменённым файлам — **дельта 0**.
