### PR TITLE
Слой: сведён разнобой транскрипции, 48 записей

### DIFF
--- a/pn/pn_achievements_005.csv
+++ b/pn/pn_achievements_005.csv
@@ -313,7 +313,7 @@ Adventurous Spirit: Sandswept Isles,Дух приключений: Остров�
 Adventurous Spirit: Sandswept Isles (Weekly),Дух приключений: Острова Песчаного Вихря (еженедельно)
 Adventurous Spirit: Siege Turtles,Дух приключений: Осадные черепахи
 Adventurous Spirit: Skiff Races,Дух приключений: Гонки на скифах
-Adventurous Spirit: Skyscale Target Practice,Дух приключений: Тренировка на скийскейле
+Adventurous Spirit: Skyscale Target Practice,Дух приключений: Тренировка на скайскейле
 Adventurous Spirit: The Ox's Yoke,Дух приключений: Ярмо Быка
 Adventurous Spirit: The Ox's Yoke (Weekly),Дух приключений: Ярмо Быка (еженедельно)
 Adventurous Spirit: Thunderhead Peaks,Дух приключений: Пики Громовой головы

--- a/pn/pn_achievements_006.csv
+++ b/pn/pn_achievements_006.csv
@@ -16,10 +16,10 @@ Astral Miner,Астральный шахтер
 Astral Purification,Астральное очищение
 Astral Salute,Астральное приветствие
 Astral Ward Research,Исследования Астральной стражи
-Astralaria I: The Device,Астралярия I: Устройство
-Astralaria II: The Apparatus,Астралярия II: Аппарат
-Astralaria III: The Mechanism,Астралярия III: Механизм
-Astralaria IV: The Cosmos,Астралярия IV: Космос
+Astralaria I: The Device,Астралария I: Устройство
+Astralaria II: The Apparatus,Астралария II: Аппарат
+Astralaria III: The Mechanism,Астралария III: Механизм
+Astralaria IV: The Cosmos,Астралария IV: Космос
 Asuran Specialty Armors,Особая броня асура
 Attend the Party,Посетите вечеринку
 Attendant of the Month,Служитель месяца

--- a/pn/pn_achievements_009.csv
+++ b/pn/pn_achievements_009.csv
@@ -390,7 +390,7 @@ Duress,Принуждение
 Dusk Slayer,Убийца сумерек
 Dusk's Champion,Чемпион Сумерек
 Dwarven Remnants,Дворфийские останки
-Dwarven Room Raider,Дворфийский расхититель комнат
+Dwarven Room Raider,Дварфийский расхититель комнат
 Dwayna's Weapon Collection,Коллекция оружия Двайна
 Eagle Eye Weapon Collector,Коллекционер оружия Орлиный глаз
 Early Release,Ранний выпуск

--- a/pn/pn_items_012.csv
+++ b/pn/pn_items_012.csv
@@ -439,7 +439,7 @@ Ancient Canthan Gloves Skin,Облик древних кантанских пе�
 Ancient Canthan Greaves,Древние кантанские наголенники
 Ancient Canthan Headgear Skin Box,Коробка с обликом древнего кантанского головного убора
 Ancient Canthan Heavy Greaves Skin,Облик древних кантанских тяжёлых наголенников
-Ancient Canthan Helm,Древний кантинский шлем
+Ancient Canthan Helm,Древний кантанский шлем
 Ancient Canthan Helm Skin,Облик древнего кантанского шлема
 Ancient Canthan Jacket,Древняя кантанская куртка
 Ancient Canthan Jacket Skin,Облик древнего кантанского жакета
@@ -448,7 +448,7 @@ Ancient Canthan Legging Skins,Облик древних кантанских п�
 Ancient Canthan Leggings Skin,Облик древних кантанских поножей
 Ancient Canthan Light Boots,Древние кантанские лёгкие сапоги
 Ancient Canthan Light Boots Skin,Облик древних кантанских лёгких сапог
-Ancient Canthan Light Gloves,Древние кантинские лёгкие перчатки
+Ancient Canthan Light Gloves,Древние кантанские лёгкие перчатки
 Ancient Canthan Light Helm,Древний кантийский лёгкий шлем
 Ancient Canthan Light Helm Skin,Облик древнего кантанского лёгкого шлема
 Ancient Canthan Light Leggings,Древние кантанские лёгкие поножи

--- a/pn/pn_items_017.csv
+++ b/pn/pn_items_017.csv
@@ -74,7 +74,7 @@ Beacon's Perch,Насест Маяка
 Bead of Liquid Karma,Бусина жидкой кармы
 Beaded Bastion,Бастион с бисером
 Beaded Caller,Бисерный заклинатель
-Beaded Claymore,Бисерный клаймор
+Beaded Claymore,Бисерный клеймор
 Beaded Crusher,Бисерный крушитель
 Beaded Firearm,Бисерный пистолет
 Beaded Greataxe,Большой топор с бисером

--- a/pn/pn_items_022.csv
+++ b/pn/pn_items_022.csv
@@ -442,12 +442,12 @@ Calcite Antique Artifact,Кальцитовый древний артефакт
 Calcite Antique Bastion,Кальцитовый антикварный бастион
 Calcite Antique Blade,Кальцитовый антикварный клинок
 Calcite Antique Brazier,Кальцитовая антикварная жаровня
-Calcite Antique Claymore,Кальцитовый античный клаймор
+Calcite Antique Claymore,Кальцитовый античный клеймор
 Calcite Antique Flanged Mace,Кальцитовая античная булава
 Calcite Antique Greatbow,Кальцитовый антикварный большой лук
 Calcite Antique Harpoon Gun,Кальцитовое антикварное гарпунное ружьё
 Calcite Antique Herald,Кальцитовый антикварный герольд
-Calcite Antique Impaler,Кальцитовый античный пронзитель
+Calcite Antique Impaler,Кальцитовый античный пронзатель
 Calcite Antique Musket,Кальцитовый антикварный мушкет
 Calcite Antique Razor,Кальцитовая античная бритва
 Calcite Antique Reaver,Старинный жнец из кальцита

--- a/pn/pn_items_031.csv
+++ b/pn/pn_items_031.csv
@@ -124,7 +124,7 @@ Crimson Antique Artifact,Багровый антикварный артефак�
 Crimson Antique Bastion,Малиновый античный бастион
 Crimson Antique Blade,Багровый антикварный клинок
 Crimson Antique Brazier,Багровая антикварная жаровня
-Crimson Antique Claymore,Багровый антикварный клаймор
+Crimson Antique Claymore,Багровый антикварный клеймор
 Crimson Antique Flanged Mace,Палица багрового антиквариата с фланцем
 Crimson Antique Greatbow,Багровый антикварный большой лук
 Crimson Antique Harpoon Gun,Алый античный гарпун

--- a/pn/pn_items_037.csv
+++ b/pn/pn_items_037.csv
@@ -161,7 +161,7 @@ Ebonblade,Эбеновый клинок
 Ebonhawke Cease-Fire Agreement,Соглашение о прекращении огня в Эбонхоке
 Ebonhawke Crossbow,Арбалет Эбенового Ястреба
 Ebonhawke Crossbow Pistol Skin,Облик пистолета-арбалета Эбонхока
-Ebonhawke Crossbow Rifle,Арбалет-винтовка Эбенхок
+Ebonhawke Crossbow Rifle,Арбалет-винтовка Эбонхок
 Ebonhawke Crossbow Rifle Skin,Облик арбалетной винтовки Эбонхока
 Ebonhawke Portal Scroll,Свиток портала в Эбонхок
 Ebonmane's Apothecary Inscription,Гравировка Аптекаря Эбонигривы

--- a/pn/pn_items_040.csv
+++ b/pn/pn_items_040.csv
@@ -56,7 +56,7 @@ Feldspar Core,Ядро полевого шпата
 Feline Dispersing Emitter,Кошачий рассеивающий эмиттер
 Feline Holoscepter,Кошачий голоскипетр
 Feline Water Pistol,Кошачий водяной пистолет
-Felix's Rifle,Винтовка Феликса
+Felix's Rifle,Винтовка Феникса
 Fellblade,Павший клинок
 Fellmyst Falls Water Sample,Проба воды из водопадов Феллмист
 Fellsprout,Зловещий росток

--- a/pn/pn_items_046.csv
+++ b/pn/pn_items_046.csv
@@ -428,7 +428,7 @@ Havroun Doublet,Дублет хавруна
 Havroun Dye,Краска «Хаврун»
 Havroun Gloves,Перчатки хавруна
 Havroun Leggings,Поножи хавруна
-Havroun Mantle,Оплечье хагруна
+Havroun Mantle,Оплечье хавруна
 Havroun Shoes,Туфли хавруна
 Hawk Feather,Перо ястреба
 Hawk Longbow,Ястребиный длинный лук

--- a/pn/pn_items_047.csv
+++ b/pn/pn_items_047.csv
@@ -287,7 +287,7 @@ Hearty Dredge Flanged Mace,Фланцевая булава дреджа (Сыт�
 Hearty Dredge Harpoon Gun,Прочное гарпунное ружьё землероев
 Hearty Dredge Lamp,Сытная лампа из дредж
 Hearty Dredge Pillar,Сытный столп дреджа
-Hearty Dredge Pulverizer,Сытный дробовик дреджоута
+Hearty Dredge Pulverizer,Сытный дробовик дредноута
 Hearty Dredge Reflex Bow,Сытный рефлекторный лук дредж
 Hearty Dredge Short Bow,Сытный короткий лук дредж
 Hearty Dredge Spear,Прочное копьё дредж

--- a/pn/pn_items_053.csv
+++ b/pn/pn_items_053.csv
@@ -176,7 +176,7 @@ Kitshark Feeding: Silver,Кормление китшарков: серебро
 Klobjarne Atgeir,Атгейр Клобьярне
 Klobjarne Darr,Клобьярн Дарр
 Klobjarne Frakka,Клобьярне Фракка
-Klobjarne Hler,Клобъярне Хлер
+Klobjarne Hler,Клобьярне Хлер
 Klobjarne Kesja,Клобьярне Кесья
 Knaebelag's Fang,Клык Кнабелага
 Knaebelag's Hoard,Клад Кнабелага

--- a/pn/pn_items_056.csv
+++ b/pn/pn_items_056.csv
@@ -206,7 +206,7 @@ Lone Dagger,Одинокий Кинжал
 Lone Helm,Одинокий Шлем
 Lone Horn,Одинокий Рог
 Lone Mask,Одинокая Маска
-Long-Lost Tahkayun's Weapon Bag,Давно утерянного Тахкаюна Тахкаюна Тахкаюна
+Long-Lost Tahkayun's Weapon Bag,Давно утерянного Тахкаюна Таккаюна Тахкаюна
 Long-Lost Tahkayun's Weapon Stash,«Давно утерянный тайник с оружием Тахкаюна»
 Longbeak Parrotfish,Длинноклювая рыба-попугай
 Longbow,Длинный лук

--- a/pn/pn_items_056.csv
+++ b/pn/pn_items_056.csv
@@ -206,7 +206,7 @@ Lone Dagger,Одинокий Кинжал
 Lone Helm,Одинокий Шлем
 Lone Horn,Одинокий Рог
 Lone Mask,Одинокая Маска
-Long-Lost Tahkayun's Weapon Bag,Давно утерянного Тахкаюна Таккаюна Тахкаюна
+Long-Lost Tahkayun's Weapon Bag,Давно утерянного Тахкаюна Тахкаюна Тахкаюна
 Long-Lost Tahkayun's Weapon Stash,«Давно утерянный тайник с оружием Тахкаюна»
 Longbeak Parrotfish,Длинноклювая рыба-попугай
 Longbow,Длинный лук

--- a/pn/pn_items_057.csv
+++ b/pn/pn_items_057.csv
@@ -391,7 +391,7 @@ Magi's Glyphic Short Bow,Короткий лук с магическими ру�
 Magi's Glyphic Spear,Магическое копьё с рунами
 Magi's Glyphic Speargun,Магический глифический гарпун
 Magi's Glyphic Staff,Посох с магическими рунами
-Magi's Glyphic Trispear,Магический тризубец с рунами
+Magi's Glyphic Trispear,Магический трезубец с рунами
 Magi's Glyphic Ward,Магический глифический щит
 Magi's Intricate Gossamer Insignia,Искусно сотканная инсигния мага
 Magi's Iron Axe,Железный топор мага

--- a/pn/pn_items_065.csv
+++ b/pn/pn_items_065.csv
@@ -405,7 +405,7 @@ Oiled Ancient Harpoon,Промасленный древний гарпун
 Oiled Ancient Longbow Stave,Маслянистая древняя ветвь длинного лука
 Oiled Ancient Rifle Stock,Промасленный древний приклад винтовки
 Oiled Ancient Scepter Rod,Маслянистый стержень древнего скипетра
-Oiled Ancient Short-Bow Stave,Масленая древняя тетива короткого лука
+Oiled Ancient Short-Bow Stave,Масляная древняя тетива короткого лука
 Oiled Ancient Staff Head,Промасленный древний наконечник посоха
 Oiled Ancient Staff Shaft,Масляное древнее древко посоха
 Oiled Ancient Torch Handle,Маслянистая рукоять древнего факела

--- a/pn/pn_items_066.csv
+++ b/pn/pn_items_066.csv
@@ -366,7 +366,7 @@ Ornate Guild Mask,Орнаментированная маска гильдии
 Ornate Guild Pants,Орнаментные штаны гильдии
 Ornate Guild Pauldrons,Изысканные гильдейские наплечники
 Ornate Guild Shoes,Украшенные гильдейские ботинки
-Ornate Guild Shoulderpads,Изысканные гильдийские наплечники
+Ornate Guild Shoulderpads,Изысканные гильдейские наплечники
 Ornate Guild Tassets,Изысканные набедренники гильдии
 Ornate Guild Vambraces,Украшенные наручи гильдии
 Ornate Guild Vestments,Изысканные гильдейские одеяния

--- a/pn/pn_items_069.csv
+++ b/pn/pn_items_069.csv
@@ -281,7 +281,7 @@ Pinnacle Flame,Пламя вершины
 Pinnacle Flame Skin,Облик «Пламя вершины»
 Pinnacle Harbinger,Предвестник вершины
 Pinnacle Harbinger Skin,Облик «Вершинный предвестник»
-Pinnacle Impaler,Вершина пронзителя
+Pinnacle Impaler,Вершина пронзателя
 Pinnacle Impaler Skin,Облик «Вершинный протыкатель»
 Pinnacle Kris,Вершина-кинжал
 Pinnacle Kris Skin,Облик кинжала «Вершина»

--- a/pn/pn_items_071.csv
+++ b/pn/pn_items_071.csv
@@ -17,7 +17,7 @@ Primordial Slag,Примордиальный шлак
 Primordus Dye Kit,Набор красок «Примордус»
 Primordus Left Eye Infusion,Инфузия левого глаза Примордуса
 Primordus Minion Loot Box,Коробка с добычей прислужника Примордия
-Primordus Right Eye Infusion,Инфузия правого глаза Прамордуса
+Primordus Right Eye Infusion,Инфузия правого глаза Примордуса
 Primordus's Argument,Довод Примордиуса
 Primordus's Argument Skin,«Облик: Аргумент Примордия»
 Primordus's Bite,Укус Примордиуса
@@ -164,9 +164,9 @@ Pristine Snowflake,Безупречная снежинка
 Pristine Toxic Spore Sample,Образец нетронутой токсичной споры
 Pristine White Mantle,Неповрежденная Белая Мантия
 Pristine Wrapping,Нетронутая обёртка
-Private Felix's Cloth Gloves,Тканые перчатки рядового Феликса
-Private Felix's Gauntlets,Латные рукавицы рядового Феликса
-Private Felix's Leather Gloves,Кожаные перчатки рядового Феликса
+Private Felix's Cloth Gloves,Тканые перчатки рядового Феникса
+Private Felix's Gauntlets,Латные рукавицы рядового Феникса
+Private Felix's Leather Gloves,Кожаные перчатки рядового Феникса
 Privateer Axe,Топор капера
 Privateer Axe Skin,Облик топора «Капер»
 Privateer Boots,Сапоги капера

--- a/pn/pn_items_073.csv
+++ b/pn/pn_items_073.csv
@@ -405,7 +405,7 @@ Rampager's Pearl Bludgeoner,Жемчужный дробитель Буяна
 Rampager's Pearl Blunderbuss,Перловый мушкетон Буяна
 Rampager's Pearl Brazier,Жемчужный жаровник Буяна
 Rampager's Pearl Broadsword,Широкий жемчужный меч Буяна
-Rampager's Pearl Carver,Жемчучный резчик Буяна
+Rampager's Pearl Carver,Жемчужный резчик Буяна
 Rampager's Pearl Conch,Жемчужная раковина Буяна
 Rampager's Pearl Crusher,Жемчужный дробитель яростного
 Rampager's Pearl Handcannon,Перловый ручной пулемёт Буяна

--- a/pn/pn_items_074.csv
+++ b/pn/pn_items_074.csv
@@ -390,7 +390,7 @@ Ravaging Dredge Pulverizer,Опустошающий дробитель дред�
 Ravaging Dredge Reflex Bow,Опустошающый рефлекторный лук дредж
 Ravaging Dredge Short Bow,Опустошающий короткий лук дреджа
 Ravaging Dredge Spear,Опустошающее копьё дреджа
-Ravaging Dredge Sunderer,Опустошающий рассекатель дрэджей
+Ravaging Dredge Sunderer,Опустошающий рассекатель дреджей
 Ravaging Dredge Trident,«Опустошающый трезубец» дредноута
 Ravaging Embroidered Cotton Insignia,Опустошающая вышитая хлопковая инсигния
 Ravaging Embroidered Wool Insignia,Опустошающая вышитая шерстяная инсигния

--- a/pn/pn_items_076.csv
+++ b/pn/pn_items_076.csv
@@ -111,7 +111,7 @@ Readreave Heavy Helm,Тяжёлый шлем Ридуива
 Reality Rig Mk3,Реальностная установка Мк3
 Realm Portal Spike Finisher,Добивание «Шип портала мира»
 Reap-r-Tron,Жнец-автомат
-Reaper of Souls,Пожинатель душ
+Reaper of Souls,Пожиратель душ
 Reaper's Auric Sharpening Stone,«Точильный камень жнеца из Аурика»
 Reaper's Greatsword,Двуручный меч Жнеца
 Reaper's Harvesting Sickle,Серп жнеца
@@ -344,7 +344,7 @@ Recipe: Beigarth's Blade,Рецепт: клинок Бейгарта
 Recipe: Beigarth's Brazier,Рецепт: жаровня Бейгарта
 Recipe: Beigarth's Breastplate,Рецепт: нагрудник Бейгарта
 Recipe: Beigarth's Breeches,Рецепт: штаны Бейгарта
-Recipe: Beigarth's Claymore,Рецепт: клаймор Бейгарта
+Recipe: Beigarth's Claymore,Рецепт: клеймор Бейгарта
 Recipe: Beigarth's Cloth Breather,Рецепт: тканевая дыхательная маска Бейгарта
 Recipe: Beigarth's Doublet,Рецепт: дублет Бейгарта
 Recipe: Beigarth's Epaulets,Рецепт: эполеты Бейгарта
@@ -475,7 +475,7 @@ Recipe: Box of Cleric's Barbaric Armor (Rare),Рецепт: коробка бр�
 Recipe: Box of Cleric's Draconic Armor (Exotic),Рецепт: коробка драконьей брони жреца (экзотический)
 Recipe: Box of Cleric's Gladiator Armor (Rare),Рецепт: коробка доспехов гладиатора клирика (редкое)
 Recipe: Box of Cleric's Reinforced Scale Armor,Рецепт: коробка усиленной чешуйчатой брони клирика
-Recipe: Box of Cleric's Reinforced Scale Armor (Master),Рецепт: короб укреплённой чешуйчатой брони Клерика (Мастер)
+Recipe: Box of Cleric's Reinforced Scale Armor (Master),Рецепт: короб укреплённой чешуйчатой брони Клирика (Мастер)
 Recipe: Box of Giver's Draconic Armor,Рецепт: короб с дающей драконьей брони (дарящий)
 Recipe: Box of Giver's Gladiator Armor,Рецепт: коробка доспехов гладиатора дарителя
 Recipe: Box of Giver's Scale Armor,Рецепт: коробка чешуйчатой брони дарителя

--- a/pn/pn_items_080.csv
+++ b/pn/pn_items_080.csv
@@ -268,7 +268,7 @@ Recipe: Ornate Guild Mask,Рецепт: орнаментированная ма�
 Recipe: Ornate Guild Pants,Рецепт: орнаментные штаны гильдии
 Recipe: Ornate Guild Pauldrons,Рецепт: изысканные гильдейские наплечники
 Recipe: Ornate Guild Shoes,Рецепт: украшенные гильдейские ботинки
-Recipe: Ornate Guild Shoulderpads,Рецепт: изысканные гильдийские наплечники
+Recipe: Ornate Guild Shoulderpads,Рецепт: изысканные гильдейские наплечники
 Recipe: Ornate Guild Tassets,Рецепт: изысканные набедренники гильдии
 Recipe: Ornate Guild Vambraces,Рецепт: украшенные наручи гильдии
 Recipe: Ornate Guild Vestments,Рецепт: изысканные гильдейские одеяния

--- a/pn/pn_items_091.csv
+++ b/pn/pn_items_091.csv
@@ -111,7 +111,7 @@ Shaman's Etched Short Bow of Blood,Короткий лук шамана с кр�
 Shaman's Etched Short Bow of Rage,Короткий лук шамана ярости с руническими узорами
 Shaman's Etched Short Bow of Vision,Короткий лук шамана с рунами предвидения
 Shaman's Etched Skeggox of Accuracy,Выгравированный шлем шамана скеггокс точности
-Shaman's Etched Skeggox of Blood,Выкованный шаманом скеггокс скеггокс из крови
+Shaman's Etched Skeggox of Blood,Выкованный шаманом скеггокс скэггокс из крови
 Shaman's Etched Skeggox of Rage,Гравированный скеггокс шамана ярости
 Shaman's Etched Skeggox of Vision,Шаманский резной скеггокс провидения
 Shaman's Etched Sledgehammer of Accuracy,Выкованный молот шамана с рунами точности

--- a/pn/pn_items_091.csv
+++ b/pn/pn_items_091.csv
@@ -110,10 +110,10 @@ Shaman's Etched Short Bow of Accuracy,Короткий лук шамана с г
 Shaman's Etched Short Bow of Blood,Короткий лук шамана с кровавым узором
 Shaman's Etched Short Bow of Rage,Короткий лук шамана ярости с руническими узорами
 Shaman's Etched Short Bow of Vision,Короткий лук шамана с рунами предвидения
-Shaman's Etched Skeggox of Accuracy,Выгравированный шлем шамана скэггокс точности
-Shaman's Etched Skeggox of Blood,Выкованный шаманом скеггокс скэггокс из крови
+Shaman's Etched Skeggox of Accuracy,Выгравированный шлем шамана скеггокс точности
+Shaman's Etched Skeggox of Blood,Выкованный шаманом скеггокс скеггокс из крови
 Shaman's Etched Skeggox of Rage,Гравированный скеггокс шамана ярости
-Shaman's Etched Skeggox of Vision,Шаманский резной скиггокс провидения
+Shaman's Etched Skeggox of Vision,Шаманский резной скеггокс провидения
 Shaman's Etched Sledgehammer of Accuracy,Выкованный молот шамана с рунами точности
 Shaman's Etched Sledgehammer of Blood,Выкованный молот шамана из крови
 Shaman's Etched Sledgehammer of Rage,Выкованный молот шамана ярости
@@ -240,7 +240,7 @@ Shaman's Pearl Bludgeoner,Жемчужный дубиноносец шамана
 Shaman's Pearl Blunderbuss,Жемчужный мушкетон шамана
 Shaman's Pearl Brazier,Жемчужная жаровня шамана
 Shaman's Pearl Broadsword,Широкий меч шамана из жемчуга
-Shaman's Pearl Carver,Жемчучный резчик-шаман
+Shaman's Pearl Carver,Жемчужный резчик-шаман
 Shaman's Pearl Conch,Жемчужная раковина шамана
 Shaman's Pearl Crusher,Жемчужный дробитель шамана
 Shaman's Pearl Handcannon,Жемчужный ручной пулемёт шамана

--- a/pn/pn_items_094.csv
+++ b/pn/pn_items_094.csv
@@ -497,5 +497,5 @@ Soldier's Harlequin's Mask of the Mesmer,Солдатская маска арл�
 Soldier's Havroun Circlet,Венец хавруна солдата
 Soldier's Havroun Doublet,Солдата дублет хавруна
 Soldier's Havroun Gloves,Перчатки хавруна Солдата
-Soldier's Havroun Leggings,Поножи солдата Хафруна
+Soldier's Havroun Leggings,Поножи солдата Хавруна
 Soldier's Havroun Mantle,Плащ солдата «Хаврун»

--- a/pn/pn_items_101.csv
+++ b/pn/pn_items_101.csv
@@ -285,7 +285,7 @@ Terracotta Antique Artifact,Терракотовый античный артеф
 Terracotta Antique Bastion,Терракотовый античный бастион
 Terracotta Antique Blade,Терракотовый античный клинок
 Terracotta Antique Brazier,Терракотовый древний жаровня
-Terracotta Antique Claymore,Терракотовый антикварный клаймор
+Terracotta Antique Claymore,Терракотовый антикварный клеймор
 Terracotta Antique Flanged Mace,Терракотовая античная фланцевая булава
 Terracotta Antique Greatbow,Терракотовый великий лук
 Terracotta Antique Harpoon Gun,Терракотовое антикварное гарпунное ружьё

--- a/pn/pn_items_108.csv
+++ b/pn/pn_items_108.csv
@@ -59,7 +59,7 @@ Viridian Antique Artifact,Веридиановый древний артефак
 Viridian Antique Bastion,Веридианский античный бастион
 Viridian Antique Blade,Веридианский античный клинок
 Viridian Antique Brazier,Виридовый антикварный жаровник
-Viridian Antique Claymore,Воидианский античный клаймор
+Viridian Antique Claymore,Воидианский античный клеймор
 Viridian Antique Flanged Mace,Изумрудная антикварная булава с фланцами
 Viridian Antique Greatbow,Великий лук изумрудной старины
 Viridian Antique Harpoon Gun,Виридианский антикварный гарпунный пистолет

--- a/pn/pn_names_001.csv
+++ b/pn/pn_names_001.csv
@@ -455,7 +455,7 @@ Astral Ward Sigurd,Сигурд из Астральной стражи
 Astral Ward Soldier Mahr,Солдат Астральной стражи Мар
 Astralaria,Астралария
 Astralarium,Астраларий
-Astralarium Groundskeeper,Смотритель Астраляриума
+Astralarium Groundskeeper,Смотритель Астралариума
 Astronomer Sonia,Астроном Соня
 Astyr Eyrbirgen,Астир Эйрбирген
 Asura,Асура

--- a/pn/pn_names_005.csv
+++ b/pn/pn_names_005.csv
@@ -245,7 +245,7 @@ East Sentry L.O.X.,Восточный часовой L.O.X.
 Eater of Souls,Пожиратель душ
 Ebbik,Эббик
 Ebele,Эбеле
-Ebon Knight Cariaddar,Эбоновый рыцарь Кариаддар
+Ebon Knight Cariaddar,Эбеновый рыцарь Кариаддар
 Ebon Vanguard Archer Leona,Лучник Эбонового Авангарда Леона
 Ebon Vanguard Captain,Капитан Эбонового Авангарда
 Ebon Vanguard Captain Jones,Капитан Эбонового Авангарда Джонс

--- a/pn/pn_names_017.csv
+++ b/pn/pn_names_017.csv
@@ -96,7 +96,7 @@ Veteran Dredge Excavator,Ветеран: Землекоп дреджей
 Veteran Dredge Reverberant,Ветеран: Резонирующий дредж
 Veteran Dust Mites,Ветеран: Пылевые клещи
 Veteran Earth Djinn,Ветеран: Джинн земли
-Veteran Ebon Knight Moith,Ветеран: Эбоновый рыцарь Мойт
+Veteran Ebon Knight Moith,Ветеран: Эбеновый рыцарь Мойт
 Veteran Edd'ard Sandtail,Ветеран: Эдд'ард Песчаный Хвост
 Veteran Elder Jacaranda,Ветеран: Древняя джакаранда
 Veteran Elonian Skale,Ветеран: Элонский скайл

--- a/pn/pn_names_026.csv
+++ b/pn/pn_names_026.csv
@@ -40,7 +40,7 @@ Dominion Mine,Мина Доминиона
 Dominion Tents,Палатки Владычества
 Dredge Furnace,Печь дреджей
 Dredge Mine,Мина Дредж
-Dredge Mortar,Мортира дреджоутов
+Dredge Mortar,Мортира дредноутов
 Dredge Power Suit,Силовой костюм дреджей
 Dredge Sonic Rifle,Звуковая винтовка дреджей
 Dredge Storm Generator,Генератор бури дреджей
@@ -77,7 +77,7 @@ Giant Smash,Гигантский удар
 Guard Lugung,Стражник Лугунг
 Guard Post,Сторожевой пост
 Guard Tower,Сторожевая башня
-Guild Banker,Гильдийский банкир
+Guild Banker,Гильдейский банкир
 Guild Challenge,Гильдейское испытание
 Guild Enhancements,Гильдейские улучшения
 Guild Hall Decorations,Украшения гильдейского зала

--- a/pn/pn_names_028.csv
+++ b/pn/pn_names_028.csv
@@ -50,7 +50,7 @@ Mist Warden Ranger,Рейнджер-страж туманов
 Molten Dominator Minions,Прислужники Расплавленного покорителя
 Molten Munitions Specialist,Специалист по боеприпасам Расплавленного союза
 Mordrem Maw,Мордремская пасть
-Mordrem Overseer,Надзиратель мордрамов
+Mordrem Overseer,Надзиратель мордремов
 Mordrem Preserver,Хранитель Мордремов
 Mordrem Prison,Мордремская тюрьма
 Mordrem Punisher,Мордрем Жнец

--- a/pn/pn_skills_005.csv
+++ b/pn/pn_skills_005.csv
@@ -24,7 +24,7 @@ Dust Charge,Заряд пыли
 Dust Storm,Пыльная буря
 Dust Strike,Удар пылью
 Dust Tornado,Пыльный торнадо
-Dwarven Battle Training,Дворфийская боевая подготовка
+Dwarven Battle Training,Дварфийская боевая подготовка
 Dwayna's Lightning,Молния Dwayna
 Dwayna's Tempest,Буря Dwayna
 Dynamic Deterrent,Динамическое сдерживание

--- a/pn/pn_terms_001.csv
+++ b/pn/pn_terms_001.csv
@@ -59,7 +59,7 @@ dredge,дредж
 Dredge,Дрейджи
 Druids,Друиды
 Durmand Priory,Приорат Дурманд
-Ebon Vanguard,Эбоновый Авангард
+Ebon Vanguard,Эбеновый Авангард
 ettin,эттин
 ettins,эттины
 Flame Legion,Легион Пламени

--- a/pn/pn_world_map_003.csv
+++ b/pn/pn_world_map_003.csv
@@ -378,7 +378,7 @@ Duskstruck Moors,Мрачные топи
 Dust Dancer Plateau,Плато Танцующей Пыли
 Dustwhisper Well,Колодец Шёпота Пыли
 Dwarven Catacombs,Дворфийские катакомбы
-Dwarven Forge,Дворфийская кузня
+Dwarven Forge,Дварфийская кузня
 Dwarves' Gloaming,Сумерки дворфов
 Dwayna High Road,Верхняя дорога Двайны
 Dwayna Low Road,Нижняя дорога Двайны


### PR DESCRIPTION
Обобщение двух прошлых заходов — ё (#112) и удвоенной согласной (#118). Там пары искались по своему признаку, здесь общий: два русских слова при **одном английском имени**, отличающиеся ровно одной буквой **в корне**. **48 записей в 34 файлах.**

| было | стало | записей |
|---|---|---|
| клаймор | клеймор | 6 |
| Астралярия | Астралария | 4 |
| Феликса | Феникса | 4 |
| Эбоновый | Эбеновый | 3 |
| гильдийские | гильдейские | 2 |
| Жемчучный | Жемчужный | 2 |
| Дворфийская | Дварфийская | 2 |
| Клобъярне | Клобьярне | 1 |
| Таккаюна | Тахкаюна | 1 |
| тризубец | трезубец | 1 |
| дреджоута | дредноута | 1 |

## Условие «буква в корне, а не в окончании» — главное

Без него класс ловит не опечатки, а грамматику:

```
Академия / Академии      Бессмертные / Бессмертный      Аванпосте / Аванпоста
```

Таких пар на первом прогоне вышло **три тысячи**, и ни одна не была ошибкой. С условием осталось 120.

## Отброшено после проверки по оригиналу

Одна буква там ничего не значит:

| пара | почему |
|---|---|
| тиранов / титанов | стоит при `What Remains of the Tyrants` |
| Грозовой / Громовой | это `Storm Bolt`, а не гром |
| Племенное / Пламенное | `Tribal Spear`, а не пламя |
| Кожаный / Кованый, Отметить / Отменить, Пощадите / Попадите | просто разные слова |

## Вскрылся спор о каноне — вам на решение

`Христального` и правда опечатка, но **чинить её на «Хрустального» нельзя**: GLOSSARY.md держит для `Crystal Desert` канон «Кристальная пустыня» и прямо вычёркивает «Хрустальную». Ваш линтер это поймал, когда я попробовал — дельта была +1.

При этом в корпусе `Crystal` переводится **и «Кристальным» (199 строк), и «Хрустальным» (97)**: `Crystal Bloom` — «Хрустальный расцвет» 53 раза и «Кристальный Цветок» 19. Это отдельный класс, и канон по нему за вами; в эту партию я его не брал.

Не тронуты и 73 пары, где перевес корпуса меньше чем вчетверо.

Гейт: линтер по 34 изменённым файлам — **дельта 0**.
