### PR TITLE
Корпус: мелкий ремонт — 8 строк в трёх классах

### DIFF
--- a/events/events_012.csv
+++ b/events/events_012.csv
@@ -314,12 +314,12 @@ Here's more Risen. Cut them down!,Вот ещё Risen. Рубите их!
 "Here, try something. Touch the crystal. See if you can utilize its magic to cut off Mordremoth's influence.","Вот, попробуй кое-что. Коснись кристалла. Посмотри, сможешь ли ты использовать его магию, чтобы отсечь влияние Mordremoth."
 Here? Wouldn't it be more sensible to bring the artifact back to examine?,Здесь? Разве не разумнее было бы забрать артефакт с собой для изучения?
 Hermit Crab,Hermit Crab
-Hero Challenge: Defeat Carnie Jeb the Strong-Man,Победите Carnie Jeb the Strong-Man
-Hero Challenge: Defeat Chhk the Windmill King,"Победите Chhk, Короля ветряных мельниц"
+Hero Challenge: Defeat Carnie Jeb the Strong-Man,Героическое испытание: Победите Carnie Jeb the Strong-Man
+Hero Challenge: Defeat Chhk the Windmill King,"Героическое испытание: Победите Chhk, Короля ветряных мельниц"
 Hero Challenge: Defeat Tarkkakt,Испытание героя: Победите Tarkkakt
-Hero Challenge: Defeat the Ancient Ember and Its Minions,Победите Ancient Ember и его прислужников
-Hero Challenge: Defeat the Ancient Hylek Defenders,Победите древних защитников хилеков
-Hero Challenge: Fight the Quaggan Pirate,Победите пирата-кваггана
+Hero Challenge: Defeat the Ancient Ember and Its Minions,Героическое испытание: Победите Ancient Ember и его прислужников
+Hero Challenge: Defeat the Ancient Hylek Defenders,Героическое испытание: Победите древних защитников хилеков
+Hero Challenge: Fight the Quaggan Pirate,Героическое испытание: Победите пирата-кваггана
 Hero Challenge: Spar with Zzzig,Испытание героя: спарринг с Zzzig
 Heroes standing ready: %num1%,Героев готовы к бою: %num1%
 Heroic Grawl Brood,Героический выводок граулов

--- a/misc/misc_016.csv
+++ b/misc/misc_016.csv
@@ -161,7 +161,7 @@ Into the Valley of Shadow: Alliance Staging Ground,Into the Valley of Shadow: Al
 Into the Valley of Shadow: Valley of Agony,Into the Valley of Shadow: Valley of Agony
 Into the Woods,Into the Woods
 Introduce the Tyrian Alliance to the bearkin.,Представьте Tyrian Alliance медведям.
-Introduce your allies to the lowland council:,Представьте союзников совету низин:: 0/3
+Introduce your allies to the lowland council:,Представьте союзников совету низин: 0/3
 Introduce your allies to the lowland council:: 0/3,Представьте своих союзников совету низин:: 0/3
 Introduce yourself to Belinda.,Представьтесь Belinda.
 Invader,Invader

--- a/new/new_063.csv
+++ b/new/new_063.csv
@@ -186,7 +186,7 @@ Hero Challenge: Defeat Utcua,Героическое испытание: побе
 Hero Challenge: Defeat Warmaster Yulia,Испытание героя: одолей Военачальницу Юлию
 Hero Challenge: Defeat the IQ1800 LX,Героическое испытание: победите IQ1800 LX.
 Hero Challenge: Defeat the Kirin,Героическое испытание: победите Кирина.
-Hero Challenge: Defeat the River Drake Broodmother,Победите матку речных дрейков
+Hero Challenge: Defeat the River Drake Broodmother,Героическое испытание: Победите матку речных дрейков
 Hero Challenge: Defeat the Spider Queen,Героическое испытание: победите Королеву пауков.
 Hero Challenge: Defeat the Steam Foes,Испытание героя: Победите паровых врагов.
 Hero Challenge: Fight Flowing Ice,Героическое испытание: Сражайтесь с текучим льдом.

--- a/new/new_082.csv
+++ b/new/new_082.csv
@@ -208,7 +208,7 @@ Pacified,Умиротворённый
 Pacified Spirit,Умиротворенный дух
 Pacifies the target.,Успокаивает цель.
 Pack up!,Собирайтесь!
-Pack%num1%,Пакет[а|ов]%num1%
+Pack%num1%,Пакет%num1%
 Package[s] of Elementally Charged Plant Food,Пакет[|ы|а] элементально заряженного удобрения для растений
 Package[s] of Old Equipment,Пакет[|ы|а] старого снаряжения
 Packing eggs in: %str1%,Упаковка яиц в: %str1%


### PR DESCRIPTION
Три остатка, каждый из которых не тянул на отдельную партию.

### Потерян префикс `Hero Challenge:` — 6 строк

В корпусе он переведён «Героическое испытание» двадцать раз, а здесь пропал совсем.

```
Hero Challenge: Defeat Chhk the Windmill King
было   Победите Chhk, Короля ветряных мельниц
стало  Героическое испытание: Победите Chhk, Короля ветряных мельниц
```

### Двойное двоеточие — 1 строка

«Представьте союзников совету низин**::** 0/3» при оригинале с одним знаком. След склейки.

### Группа форм там, где оригинал её не просит — 1 строка

«Пакет[а|ов]%num1%» при `Pack%num1%`. Маркера множественного числа в оригинале нет, значит и группы быть не должно; вдобавок форм две вместо трёх, и в игре это печатается литералом.

**Родовые формы из этого класса исключены.** «%str1% благословлён[|а]» при `%str1% is blessed.` тоже стоит без маркера в оригинале, но это не лишняя разметка: движок такую группу поддерживает, и она нужна женскому персонажу. Первый заход их сносил — поймал на выборке, добавил условие.

### Чего здесь нет

Класс «юнит» в набор не вошёл. Стандарт интерфейса требует «боевая единица / объект», канон корпуса для `Unit` — «блок» («Блок сдерживания», «Блок хранения энергии»), но три оставшихся случая спорны: «Юнит онлайн» — манера речи големов, а «Гидро-юнит» и «развлекательный юнит» сидят в названиях, где смена термина меняет имя предмета. Это ваше решение, а не мелкий ремонт.

* Гейт: каждая правка — одно из трёх (приставлен префикс, снят лишний знак, снята скобочная группа), ничего сверх этого не тронуто.
* Линтер: 60 ошибок до и после, 1 предупреждение до и после.