### PR TITLE
Корпус: форма названия сведена со слоем, 44 строки

### DIFF
--- a/items/items_013.csv
+++ b/items/items_013.csv
@@ -121,8 +121,8 @@ Ancient Wood Logging Node,Ancient Wood Logging Node
 Ancient Wood Pen,Ancient Wood Pen
 Ancient Wood Plank,Ancient Wood Plank
 Ancient Wood Pulp,Ancient Wood Pulp
-Ancora Bellum,«Анкора Беллум»
-Ancora Pax,«Анкора Пакс»
+Ancora Bellum,Анкора Беллум
+Ancora Pax,Анкора Пакс
 Angchu Armor Chest,Angchu Armor Chest
 Angchu Artifact,Angchu Artifact
 Angchu Bastion,Angchu Bastion

--- a/items/items_068.csv
+++ b/items/items_068.csv
@@ -257,7 +257,7 @@ Mini Awakened Jackal,Mini Awakened Jackal
 Mini Awakened Mounts Pack,Набор мини-пробуждённых верховых животных
 Mini Awakened Raptor,Mini Awakened Raptor
 Mini Awakened Skimmer,Мини-Пробуждённый скат
-Mini Awakened Springer,Мини Пробуждённый Спрингер
+Mini Awakened Springer,Мини-пробуждённый спрингер
 Mini Baby Mount Container,Mini Baby Mount Container
 Mini Barradin's Hammer,Mini Barradin's Hammer
 Mini Bioluminescent Skyscale Hatchling,Mini Bioluminescent Skyscale Hatchling
@@ -277,7 +277,7 @@ Mini Blue Skyscale Hatchling,Mini Blue Skyscale Hatchling
 Mini Blue Tigris Cub,Mini Blue Tigris Cub
 Mini Blue Turtle Hatchling,Mini Blue Turtle Hatchling
 Mini Bog Queen,Mini Bog Queen
-Mini Bone Soldier,Мини Костяной солдат
+Mini Bone Soldier,Мини-костяной солдат
 Mini Brackish Skale,Миниатюрный солоноватый скеил
 Mini Bradford the Skeleton Ghost,Mini Bradford the Skeleton Ghost
 "Mini Braham, Champion of Primordus","Mini Braham, Champion of Primordus"
@@ -294,7 +294,7 @@ Mini Brindle Basenji,Мини «Тёмно-рыжая басенджи»
 Mini Brine,Mini Brine
 Mini Bristleback,Мини щетинник
 Mini Broken King,Мини-Сломанный король
-Mini Bronze Llama,Мини-Бронзовая лама
+Mini Bronze Llama,Мини-бронзовая лама
 Mini Brown Bear,Mini Brown Bear
 Mini Brown Cuckoo Hatchling,Mini Brown Cuckoo Hatchling
 Mini Brown Springer Kit,Mini Brown Springer Kit
@@ -342,14 +342,14 @@ Mini Consortium Pacifier,Mini Consortium Pacifier
 Mini Construct of Galdra,Мини конструкт Галдры
 Mini Convalescent Logan,Мини-выздоравливающий Логан
 Mini Copper Skyscale Hatchling,Миниатюрный медный детёныш скайскейля
-Mini Corgi,Мини корги
+Mini Corgi,Мини-корги
 Mini Corrupted,Mini Corrupted
 Mini Corrupted Eagle Spirit,Мини-дух коррумпированного орла
 Mini Corrupted Ox Spirit,Мини осквернённый дух быка
 Mini Corrupted Trahearne,Mini Corrupted Trahearne
 Mini Corrupted Wolverine Spirit,Mini Corrupted Wolverine Spirit
 Mini Corsair Sloop,Мини-корсарский шлюп
-Mini Cozy Wintersday Griffon,Мини уютный зимний грифон
+Mini Cozy Wintersday Griffon,Мини-уютный зимний грифон
 Mini Cozy Wintersday Jackal,Мини-шакал «Уютный День зимы»
 Mini Cozy Wintersday Mounts Pack,Мини-набор уютных зимних скакунов
 Mini Cozy Wintersday Raptor,Мини-раптор «Уютный Зимний День»
@@ -361,13 +361,13 @@ Mini Cuckoo Hatchling Reward Chest,Mini Cuckoo Hatchling Reward Chest
 Mini Cyan Springer Kit,Mini Cyan Springer Kit
 Mini Cyborg Spineshell,Мини киборг-спайншелл
 Mini Dachshund,Мини Такса
-Mini Dancing Crab,Мини Танцующий краб
+Mini Dancing Crab,Мини-танцующий краб
 Mini Deadeye Nakato Ibori,Mini Deadeye Nakato Ibori
 Mini Derlitz the Candy Raven,Mini Derlitz the Candy Raven
 Mini Desert Vulture,Mini Desert Vulture
 Mini Destroyer of the Last King,Mini Destroyer of the Last King
 Mini Devil Dog,Мини Дьявольский Пес
-Mini Djinn Lamp,Мини Лампа Джинна
+Mini Djinn Lamp,Мини-лампа джинна
 Mini Dolyak Calf,Мини теленок дольяка
 Mini Dragon Gourdon,Mini Dragon Gourdon
 Mini Dragon's Watch Kasmeer,Mini Dragon's Watch Kasmeer

--- a/new/new_119.csv
+++ b/new/new_119.csv
@@ -451,7 +451,7 @@ Mini Aetherblade Swashbuckler,Mini Aetherblade Swashbuckler
 Mini Aetherblade Taskmaster,Mini Aetherblade Taskmaster
 Mini Aetherblade Thug,Mini Aetherblade Thug
 Mini Air Djinn,Mini Air Djinn
-Mini Air Elemental,Мини Воздушный элементаль
+Mini Air Elemental,Мини-воздушный элементаль
 Mini Albino Turtle Hatchling[s],[Мини-детёныш черепахи-альбиноса|Мини-детёныша черепахи-альбиноса|Мини-детёнышей черепахи-альбиноса]
 Mini All Seer,Mini All Seer
 Mini Almorra Soulkeeper,Mini Almorra Soulkeeper
@@ -459,7 +459,7 @@ Mini Amber Great Jungle Wurm,Mini Amber Great Jungle Wurm
 Mini Amnytas Stormscale,Мини Амнитас Штормовая Чешуя
 Mini Angry Chest,Мини Злой сундук
 Mini Angry Snowball,Мини Злой снежок
-Mini Angry Snowman,Мини Злой снеговик
+Mini Angry Snowman,Мини-злой снеговик
 Mini Angry Wintersday Gift[s],Мини Злой Wintersday Gift
 Mini Anise,Mini Anise
 Mini Apprentice Steward[s] of Galdra,Мини Ученик-стюард Галдры
@@ -467,23 +467,23 @@ Mini Aqua Jackal Pup,Мини Аквамариновый щенок шакала
 Mini Aqua Stalker,Mini Aqua Stalker
 Mini Archon Iberu,Mini Archon Iberu
 Mini Arctic Fox Kit,Mini Arctic Fox Kit
-Mini Arctic Quaggan,Мини Арктический квагган
+Mini Arctic Quaggan,Мини-арктический квагган
 Mini Arctodus Cub,Мини Детёныш арктодуса
 Mini Armored Scarlet Briar,Mini Armored Scarlet Briar
 Mini Arrowhead,Мини Стреловик
-Mini Ascalonian Mage,Мини Аскалонский маг
-Mini Ascalonian Quail,Мини Аскалонский перепел
+Mini Ascalonian Mage,Мини-аскалонский маг
+Mini Ascalonian Quail,Мини-аскалонский перепел
 Mini Assassin Trick-or-Treater[s],Мини убийца-сластёна
 Mini Astral Ward Livia,Mini Astral Ward Livia
 Mini Augmented Steward[s] of Galdra,Мини улучшенный стюард Галдры
 Mini Augmented Swiftwing[s],Мини усиленный быстрокрыл
 Mini Aurene,Мини Аурин
-Mini Avatar of Despair,Мини Аватар отчаяния
-Mini Avatar of Envy,Мини Аватар Зависти
-Mini Avatar of Gluttony,Мини Аватар обжорства
-Mini Avatar of Malice,Мини Аватар злобы
-Mini Avatar of Rage,Мини Аватар ярости
-Mini Avatar of Regret,Мини Аватар сожаления
+Mini Avatar of Despair,Мини-аватар Отчаяния
+Mini Avatar of Envy,Мини-аватар Зависти
+Mini Avatar of Gluttony,Мини-аватар Обжорства
+Mini Avatar of Malice,Мини-аватар Злобы
+Mini Avatar of Rage,Мини-аватар Ярости
+Mini Avatar of Regret,Мини-аватар Сожаления
 Mini Avatar of the Tree,Мини Аватар Древа
 Mini Aviator Trick-or-Treater[s],Мини Костюмированный авиатор
 Mini Awakened Abomination,Mini Awakened Abomination

--- a/new/new_120.csv
+++ b/new/new_120.csv
@@ -2,26 +2,26 @@ english,translate
 Mini Axemaster Hareth,Мини Мастер топора Харет
 Mini Baby Aurene Funko POP!,Mini Baby Aurene Funko POP!
 Mini Bandit Bomber,Mini Bandit Bomber
-Mini Bandit Bruiser,Мини Бандит-громила
+Mini Bandit Bruiser,Мини-бандит-громила
 Mini Bandit Cutpurse,Мини Бандит-карманник
-Mini Bandit Saboteur,Мини Бандит-диверсант
-Mini Bandit Scout,Мини Бандит-разведчик
+Mini Bandit Saboteur,Мини-бандит-диверсант
+Mini Bandit Scout,Мини-бандит-разведчик
 Mini Bangar Ruinbringer,Mini Bangar Ruinbringer
 Mini Barbed Vale,Mini Barbed Vale
-Mini Basenji,Мини Басенджи
+Mini Basenji,Мини-басенджи
 Mini Beach Gourdon,Mini Beach Gourdon
-Mini Bear Cub,Мини Медвежонок
-Mini Beetle,Мини Жук
+Mini Bear Cub,Мини-медвежонок
+Mini Beetle,Мини-жук
 Mini Beige Journeykit,Мини Бежевый странник
-Mini Beige Warclaw Cub,Мини Бежевый детёныш боевого когтя
+Mini Beige Warclaw Cub,Мини-бежевый детёныш боевого когтя
 Mini Belinda Delaqua,Mini Belinda Delaqua
-Mini Berg,Мини Берг
+Mini Berg,Мини-Берг
 Mini Big Nose Ted,Mini Big Nose Ted
 Mini Bioluminescent Skyscale Hatchling[s],Мини биолюминесцентный детёныш скайскейла
 Mini Black Bear Cub,Mini Black Bear Cub
 Mini Black Jackal Pup,Mini Black Jackal Pup
-Mini Black Labrador,Мини Чёрный лабрадор
-Mini Black Llama,Мини Чёрная лама
+Mini Black Labrador,Мини-чёрный лабрадор
+Mini Black Llama,Мини-чёрная лама
 Mini Black Moa,Мини Чёрный моа
 Mini Black Raptor Hatchling[s],[Мини-чёрный детёныш раптора|Мини-чёрных детёныша раптора|Мини-чёрных детёнышей раптора]
 Mini Black Skimmer Pup,Mini Black Skimmer Pup
@@ -39,10 +39,10 @@ Mini Blazing Turtle Hatchling[s],Мини пылающий черепашоно�
 Mini Bloodstone Elemental[s],[Мини-элементаль|Мини-элементаля|Мини-элементалей] кровавого камня
 Mini Bloodstone Rock,Мини Камень крови
 Mini Bloody Prince Thorn,Mini Bloody Prince Thorn
-Mini Blue Bauble,Мини Синяя безделушка
+Mini Blue Bauble,Мини-синяя безделушка
 Mini Blue Catmander,Мини Синий котмандир
 Mini Blue Choya,Mini Blue Choya
-Mini Blue Crab,Мини Синий краб
+Mini Blue Crab,Мини-синий краб
 Mini Blue Cuckoo Hatchling[s],[Мини-голубой птенец кукушки|Мини-голубых птенца кукушки|Мини-голубых птенцов кукушки]
 Mini Blue Drake Hatchling[s],[Мини-голубой детёныш дракона|Мини-голубых детёныша дракона|Мини-голубых детёнышей дракона]
 Mini Blue Griffon Hatchling[s],[Мини-голубой птенец грифона|Мини-голубых птенца грифона|Мини-голубых птенцов грифона]
@@ -51,7 +51,7 @@ Mini Blue Jackal Pup,Mini Blue Jackal Pup
 Mini Blue Moa,Mini Blue Moa
 Mini Blue Shiba Inu,Мини Синий сиба-ину
 Mini Blue Siege Golem,Mini Blue Siege Golem
-Mini Bonebreaker,Мини Костолом
+Mini Bonebreaker,Мини-костолом
 Mini Boneskinner,Мини Костедир
 Mini Boticca,Mini Boticca
 Mini Braham Eirsson,Мини Braham Eirsson
@@ -60,7 +60,7 @@ Mini Caithe,Mini Caithe
 Mini Captain Rahim,Mini Captain Rahim
 Mini Cave Troll,Mini Cave Troll
 Mini Cerus,Mini Cerus
-Mini Chak Lobber,Мини Чак-метатель
+Mini Chak Lobber,Мини-чак-метатель
 Mini Choya Piñata,Mini Choya Piñata
 Mini Cinder Steeltemper,Mini Cinder Steeltemper
 Mini Cloudseeker,Mini Cloudseeker
@@ -71,13 +71,13 @@ Mini Crecia Stoneglow,Mini Crecia Stoneglow
 Mini Crimson Great Jungle Wurm,Mini Crimson Great Jungle Wurm
 Mini Dagda,Mini Dagda
 Mini Dagonet,Mini Dagonet
-Mini Demmi Beetlestone,Мини Демми Битлстоун
+Mini Demmi Beetlestone,Мини-Демми Битлстоун
 Mini Deputy Ayoub,Mini Deputy Ayoub
-Mini Desert Fox,Мини Пустынная лиса
+Mini Desert Fox,Мини-пустынная лиса
 Mini Desmina,Мини Десмина
 Mini Destroyer Crab,Мини Разрушитель-краб
 Mini Detective Rama,Mini Detective Rama
-Mini Devourer,Мини Пожиратель
+Mini Devourer,Мини-Пожиратель
 Mini Dhuum,Мини Дуум
 Mini Dolyak,Mini Dolyak
 Mini Dredge Resonator,Мини Резонатор дрегов
@@ -93,12 +93,12 @@ Mini Fire Imp,Мини Огненный бес
 Mini First Spear Dehvad,Mini First Spear Dehvad
 Mini Flame Legion Effigy,Mini Flame Legion Effigy
 Mini Freezie,Mini Freezie
-Mini Freshwater Crab,Мини Пресноводный краб
+Mini Freshwater Crab,Мини-пресноводный краб
 Mini Frodak Steelstar,Mini Frodak Steelstar
 Mini Frode,Mini Frode
 Mini Galrath,Mini Galrath
 Mini Gamli,Mini Gamli
-Mini Garm,Мини Гарм
+Mini Garm,Мини-Гарм
 Mini Ghostly Justiciar Hablion[s],Мини Призрачный Justiciar Hablion
 Mini Gorseval[s] the Multifarious,Мини Горсевал Многоликий
 Mini Green Griffon Hatchling[s],[Мини-зелёный птенец грифона|Мини-зелёных птенца грифона|Мини-зелёных птенцов грифона]
@@ -112,7 +112,7 @@ Mini Hylek Nahualli,Mini Hylek Nahualli
 Mini Iboga,Mini Iboga
 Mini Ice Elemental,Мини Ice Elemental
 Mini Ice Imp,Mini Ice Imp
-Mini Icebrood Construct,Мини Ледяной конструкт
+Mini Icebrood Construct,Мини-ледяной конструкт
 Mini Icebrood Goliath,Mini Icebrood Goliath
 Mini Inquest Golemcaster,Mini Inquest Golemcaster
 Mini Isgarren,Mini Isgarren
@@ -123,12 +123,12 @@ Mini Jackal Mount,Мини Ездовой шакал
 Mini Jhavi Jorasdottir,Mini Jhavi Jorasdottir
 Mini Joon,Mini Joon
 Mini Judgment,Mini Judgment
-Mini Karde,Мини Карде
-Mini Kasmeer Meade,Мини Касмир Мид
+Mini Karde,Мини-Карде
+Mini Kasmeer Meade,Мини-Касмир Мид
 Mini Keep Construct,Мини Keep Construct
 Mini Kela,Mini Kela
 Mini Kenut,Mini Kenut
-Mini Kernan,Мини Кернан
+Mini Kernan,Мини-Кернан
 Mini Key of Ahdashim,Мини Key of Ahdashim
 Mini King Adelbern,Mini King Adelbern
 Mini King Wasi,Mini King Wasi
@@ -136,7 +136,7 @@ Mini Kodan Icehammer,Mini Kodan Icehammer
 Mini Koss,Mini Koss
 Mini Krait Damoss,Mini Krait Damoss
 Mini Krait Witch,Mini Krait Witch
-Mini Kryptis,Мини Криптис
+Mini Kryptis,Мини-криптис
 Mini Kryptis Skyscale,Мини Криптис-скайскейл
 Mini Largos,Mini Largos
 Mini Lazarus,Mini Lazarus


### PR DESCRIPTION
Найдено при проверке структурной целостности — той же, что дала #141.

Из **78 893** ключей, лежащих и в корпусе, и в слое, **77 849** хранят в батче английский: правило §1 соблюдено, выключатель имён работает. Ещё 905 повторяют форму слоя слово в слово — это дубль слоя, ваш класс («Слой дублирует категории: 76 516 → 334»). И **139** с ней спорят: обе стороны переведены по-русски, но по-разному, и игрок видит обе формы сразу.

### Что взято — 44 строки

Только механическое различие: дефис, регистр, кавычки.

```
Mini Bone Soldier   корпус «Мини Костяной солдат»  слой «Мини-костяной солдат»
Mini Bronze Llama   корпус «Мини-Бронзовая лама»   слой «Мини-бронзовая лама»
Ancora Bellum       корпус ««Анкора Беллум»»       слой «Анкора Беллум»
```

Канон взят у слоя: он подставляется поверх текста, значит его форму игрок увидит в любом случае, а расходящаяся копия в батче просто с ней спорит.

### Что не взято — 95 строк

Там разные слова, то есть спор о переводе:

```
Mini Awakened Skimmer      корпус «Мини-Пробуждённый скат»       слой «Мини-пробуждённый скиммер»
Mini Awakened Mounts Pack  корпус «Набор мини-пробуждённых верхов»  слой «Мини-набор пробуждённых скакун»
```

Это ваше решение; такие случаи собраны в TERMS_OPEN (#140).

* Гейт: слова не изменились (сравнение без учёта дефиса, регистра и кавычек), а новая форма — **ровно та**, что стоит в слое.
* Линтер без регрессий.