### PR TITLE
Корпус: канон глоссария для Knockback — 2 строки

### DIFF
--- a/discovered/discovered_2026-08-05.csv
+++ b/discovered/discovered_2026-08-05.csv
@@ -1103,7 +1103,7 @@ Temperance,Умеренность
 Roo,Рык
 I didn't oversleep and miss the Great Hunt. This is his fight.,Я не проспал и не пропустил Великую Охоту. Это его бой.
 ((518367)),((518367))
-Pulls Player • Summons Minions • AOE Knockback,Притягивает игрока • Призывает миньонов • Область действия с отбрасыванием
+Pulls Player • Summons Minions • AOE Knockback,Притягивает игрока • Призывает миньонов • Область действия с отталкиванием
 Dragon Grawl Shaman,Драконий граульский шаман
 Leopard Form,Форма леопарда
 "It was inevitable, Horace. Fated even. Our legend will grow here when we set up our shop.","Это было неизбежно, Гораций. Даже предначертано судьбой. Наша легенда будет расти здесь, когда мы откроем нашу лавку."

--- a/ui/ui_113.csv
+++ b/ui/ui_113.csv
@@ -2,7 +2,7 @@ english,translate
 QA Health 8,Здоровье QA 8
 QA Health 9,Здоровье QA 9
 QA Immobilize,Неподвижность QA
-QA Knockback,Отбрасывание QA
+QA Knockback,Отталкивание QA
 QA Knockdown,Сбивание с ног QA
 QA Launch,Запуск QA
 QA Might 1,Мощь QA 1


### PR DESCRIPTION
GLOSSARY, шапка: «Отсюда же закрыт давний спор из DEFECTS.md: **Knockback → Отталкивание, Launch → Отбрасывание**. Корпус делает наоборот… но эталон однозначен».

Спор с тех пор в корпусе выдержан — канон стоит в **44 строках из 56**. Остались две, где при `Knockback` по-прежнему «отбрасывание», а оно принадлежит `Launch`:

```
Pulls Player • Summons Minions • AOE Knockback
   Область действия с отбрасыванием  ->  с отталкиванием
QA Knockback
   Отбрасывание QA  ->  Отталкивание QA
```

Строки, где в оригинале стоят **оба** термина сразу, пропущены: там «отбрасывание» может принадлежать `Launch`, и решать по одному слову нельзя.

### Что проверено и не вошло

**Прочие термины сверенных таблиц** (12 бонов, 14 состояний, 8 эффектов контроля) механической проверке не поддаются: они омонимичны обычным словам. Первый заход насчитал 964 «нарушения», где `might` — это «может быть», а `launch` — «запуск игры».

**Согласование причастия.** Нашёл три строки вида «получить привязанны**й** к учётной записи легендарная дыхательная маска». Собрал правку — и снял: смена рода не чинит строку, там сломан падеж всей группы («получить привязанн**ую** … маск**у**»), а это уже перевод, а не правило.

**Названия красок и мини-питомцев** — ваши правила соблюдены: у красок 1183 канона из 1246 (остальное — законные исключения `Enameled` и счётчики вроде `Applied %num1%/%num2% Dye[s]`), у цветных детёнышей 115 из 126.