### PR TITLE
Корпус: приставка «Мини-» приведена к шаблону, 20 строк

### DIFF
--- a/items/items_068.csv
+++ b/items/items_068.csv
@@ -317,7 +317,7 @@ Mini Cavalier Hero,Mini Cavalier Hero
 Mini Cavalier Heroine,Mini Cavalier Heroine
 Mini Celestial Cuckoo Hatchling,Мини-небесная кукушка-птенец
 Mini Celestial Rooster,Мини-небесный петух
-Mini Celestial Turtle Hatchling,Мини небесный детёныш черепахи
+Mini Celestial Turtle Hatchling,Мини-небесный детёныш черепахи
 Mini Chainsaw the Skeleton,Mini Chainsaw the Skeleton
 Mini Chak Gerent,Mini Chak Gerent
 Mini Charitable Gift Skritt,Мини-скритт «Благотворительный подарок»
@@ -341,7 +341,7 @@ Mini Comrade Molechev,Mini Comrade Molechev
 Mini Consortium Pacifier,Mini Consortium Pacifier
 Mini Construct of Galdra,Мини конструкт Галдры
 Mini Convalescent Logan,Мини-выздоравливающий Логан
-Mini Copper Skyscale Hatchling,Миниатюрный медный детёныш скайскейля
+Mini Copper Skyscale Hatchling,Мини-медный детёныш скайскейля
 Mini Corgi,Мини корги
 Mini Corrupted,Mini Corrupted
 Mini Corrupted Eagle Spirit,Мини-дух коррумпированного орла

--- a/new/new_119.csv
+++ b/new/new_119.csv
@@ -463,12 +463,12 @@ Mini Angry Snowman,Мини Злой снеговик
 Mini Angry Wintersday Gift[s],Мини Злой Wintersday Gift
 Mini Anise,Mini Anise
 Mini Apprentice Steward[s] of Galdra,Мини Ученик-стюард Галдры
-Mini Aqua Jackal Pup,Мини Аквамариновый щенок шакала
+Mini Aqua Jackal Pup,Мини-аквамариновый щенок шакала
 Mini Aqua Stalker,Mini Aqua Stalker
 Mini Archon Iberu,Mini Archon Iberu
 Mini Arctic Fox Kit,Mini Arctic Fox Kit
 Mini Arctic Quaggan,Мини Арктический квагган
-Mini Arctodus Cub,Мини Детёныш арктодуса
+Mini Arctodus Cub,Мини-детёныш арктодуса
 Mini Armored Scarlet Briar,Mini Armored Scarlet Briar
 Mini Arrowhead,Мини Стреловик
 Mini Ascalonian Mage,Мини Аскалонский маг

--- a/new/new_120.csv
+++ b/new/new_120.csv
@@ -10,14 +10,14 @@ Mini Bangar Ruinbringer,Mini Bangar Ruinbringer
 Mini Barbed Vale,Mini Barbed Vale
 Mini Basenji,Мини Басенджи
 Mini Beach Gourdon,Mini Beach Gourdon
-Mini Bear Cub,Мини Медвежонок
+Mini Bear Cub,Мини-медвежонок
 Mini Beetle,Мини Жук
 Mini Beige Journeykit,Мини Бежевый странник
-Mini Beige Warclaw Cub,Мини Бежевый детёныш боевого когтя
+Mini Beige Warclaw Cub,Мини-бежевый детёныш боевого когтя
 Mini Belinda Delaqua,Mini Belinda Delaqua
 Mini Berg,Мини Берг
 Mini Big Nose Ted,Mini Big Nose Ted
-Mini Bioluminescent Skyscale Hatchling[s],Мини биолюминесцентный детёныш скайскейла
+Mini Bioluminescent Skyscale Hatchling[s],Мини-биолюминесцентный детёныш скайскейла
 Mini Black Bear Cub,Mini Black Bear Cub
 Mini Black Jackal Pup,Mini Black Jackal Pup
 Mini Black Labrador,Мини Чёрный лабрадор
@@ -29,13 +29,13 @@ Mini Black Springer Kit,Mini Black Springer Kit
 Mini Black Tigris Cub,Mini Black Tigris Cub
 Mini Black Wind Rider,Мини Чёрный наездник ветра
 Mini Black and Cyan Turtle Hatchling[s],[Детёныш|Детёныша|Детёнышей] чёрно-голубой черепахи «Мини»
-Mini Black and Green Cuckoo Hatchling[s],Мини Чёрно-зелёный Птенец Кукушки
+Mini Black and Green Cuckoo Hatchling[s],Мини-чёрно-зелёный Птенец Кукушки
 Mini Black and Tan Shiba Inu,Мини Чёрно-рыжий сиба-ину
 Mini Blademaster Diarmid,Mini Blademaster Diarmid
-Mini Blazing Cuckoo Hatchling[s],Мини Пылающий детёныш кукушки
+Mini Blazing Cuckoo Hatchling[s],Мини-пылающий детёныш кукушки
 Mini Blazing Shiba Inu,Мини Пылающий сиба-ину
-Mini Blazing Tigris Cub,Мини Пылающий детёныш тигриса
-Mini Blazing Turtle Hatchling[s],Мини пылающий черепашонок
+Mini Blazing Tigris Cub,Мини-пылающий детёныш тигриса
+Mini Blazing Turtle Hatchling[s],Мини-пылающий черепашонок
 Mini Bloodstone Elemental[s],[Мини-элементаль|Мини-элементаля|Мини-элементалей] кровавого камня
 Mini Bloodstone Rock,Мини Камень крови
 Mini Bloody Prince Thorn,Mini Bloody Prince Thorn

--- a/pn/pn_items_005.csv
+++ b/pn/pn_items_005.csv
@@ -47,7 +47,7 @@ Mabon's Journal,Дневник Мабона
 Man o' War,Португальский кораблик
 Mini Bog Queen,Мини Болотная Королева
 Mini Kela,Мини Кела
-Mini Lion Cub,Мини Львенок
+Mini Lion Cub,Мини-львенок
 Mini Polar Bear,Мини Полярный медведь
 Mini Rytlock,Мини Ритлок
 Mini Sebb,Мини Себб
@@ -81,7 +81,7 @@ Major Sigil of the Night,Большой сигил Ночи
 Many-Buckled Swash,Многопряжечный щёголь
 Massey's Gauntlet,Латная перчатка Мэсси
 Mini Black and Cyan Turtle Hatchling,Детёныш чёрно-голубой черепахи «Мини»
-Mini Blazing Turtle Hatchling,Мини пылающий черепашонок
+Mini Blazing Turtle Hatchling,Мини-пылающий черепашонок
 Mini Raven,Мини Ворон
 Mini Silver Griffon Hatchling,Мини-серебряный птенец грифона
 Mini Silver Turtle Hatchling,Мини-серебряный детёныш черепахи

--- a/pn/pn_items_061.csv
+++ b/pn/pn_items_061.csv
@@ -423,9 +423,9 @@ Mini Barbed Vale,Мини Шипастая Долина
 Mini Barradin's Hammer,Мини Молот Баррадина
 Mini Beach Gourdon,Мини Пляжный Гурдон
 Mini Big Nose Ted,Мини Носатый Тед
-Mini Bioluminescent Skyscale Hatchling,Мини биолюминесцентный детёныш скайскейла
+Mini Bioluminescent Skyscale Hatchling,Мини-биолюминесцентный детёныш скайскейла
 Mini Black Raptor Hatchling,Мини-чёрный детёныш раптора
-Mini Black and Green Cuckoo Hatchling,Мини Чёрно-зелёный Птенец Кукушки
+Mini Black and Green Cuckoo Hatchling,Мини-чёрно-зелёный Птенец Кукушки
 Mini Blademaster Diarmid,Мини Мастер клинка Диармид
 Mini Blazing Cuckoo Hatchling,Мини-Птенец Пылающей Кукушки
 Mini Bloodstone Elemental,Мини-элементаль кровавого камня

--- a/pn/pn_items_062.csv
+++ b/pn/pn_items_062.csv
@@ -72,7 +72,7 @@ Mini Servitor Golem,Мини-служитель Голем
 Mini Shade,Мини Тень
 Mini Shadhavar,Мини Шадхавар
 Mini Shadow Warrior,Мини Теневой воин
-Mini Shadows Agent Kito,Мини агент Кито
+Mini Shadows Agent Kito,Мини-агент Кито
 Mini Shadowstone Pet Rock,Мини-Камень «Теневая скала»
 Mini Shaman of Jormag,Мини-шаман Йормага
 Mini Shiba Pup Reward Chest,Сундук с наградой «Мини-щенок сиба»
@@ -166,7 +166,7 @@ Mini Svelicht the Fog Raven,Мини-Свельхт Туманный Ворон
 Mini Swamp Drake,Мини-болотный дракон
 Mini Swamp Spider,Мини-болотный паук
 Mini Swiftwing,Мини-Быстрокрылая
-Mini Sylvan Pup,Мини Сильвари-щенок
+Mini Sylvan Pup,Мини-сильвари-щенок
 Mini TT6-B Devourer,Мини-TT6-B Пожиратель
 Mini Tamini Warrior,Мини Воин тамини
 Mini Tanuki,Мини-тануки

--- a/ui/ui_096.csv
+++ b/ui/ui_096.csv
@@ -8,7 +8,7 @@ Mini Lion Cub[s],[Мини-львёнок|Мини-львёнка|Мини-ль�
 Mini Llama[s],[Мини-лама|Мини-ламы|Мини-лам]
 Mini Locked,Мини-заперто
 "Mini Longhorn Sheep[pl:""Sheep""]",[Миниатюрный длиннорогий баран|Миниатюрные длиннорогие бараны|Миниатюрных длиннорогих баранов]
-Mini Lucky Lantern Puppy now available!,Мини Счастливый Фонарный Щенок теперь доступен!
+Mini Lucky Lantern Puppy now available!,Мини-счастливый Фонарный Щенок теперь доступен!
 "Mini Lucky Lantern Puppy[pl:""Puppies""]",Мини-счастливый щенок-фонарик
 "Mini Lunar ""Horse[s]""",[Мини-лунная «лошадь»|Мини-лунной «лошади»|Мини-лунных «лошадей»]
 Mini Lunar Gourdog[s],[Мини-лунный тыквопёс|Мини-лунного тыквопса|Мини-лунных тыквопсов]
@@ -94,14 +94,14 @@ Mini Princess Llama[s],Мини-принцесса [лама|ламы|лам]
 Mini Prismatic Ooze[s],Мини-призматическая [слизь|слизи|слизей]
 Mini Professor Mew[s],Мини-[профессор|профессора|профессоров] Мью
 Mini Pummel Spider[s],Мини-[паук|паука|пауков] Паммел
-"Mini Puppy[pl:""Puppies""]",Миниатюрный щенок
+"Mini Puppy[pl:""Puppies""]",Мини-щенок
 Mini Purple Skimmer Pup[s],[Мини-фиолетовый щенок скиммера|Мини-фиолетовых щенка скиммера|Мини-фиолетовых щенков скиммера]
 Mini Quaggan Ghost Trick-or-Treater[s],Мини призрак кваггана-сластён[а|ы|]
 Mini Ragged White Mantle Figurehead[s],Мини потрепанная носовая [фигура|фигуры|фигур] Белого Пламени
 Mini Ram<br>Now Available!,Мини-баран<br>Теперь доступен!
 Mini Raptor Mount[s],Мини [маунт|маунта|маунтов] раптора
 Mini Raven[s],Мини [ворон|ворона|воронов]
-Mini Red and White Cuckoo Hatchling[s],Мини детен[ыш|ыша|ышей] красно-белой кукушки
+Mini Red and White Cuckoo Hatchling[s],Мини-детен[ыш|ыша|ышей] красно-белой кукушки
 Mini Red Griffon Hatchling[s],[Мини-красный птенец грифона|Мини-красных птенца грифона|Мини-красных птенцов грифона]
 Mini Red Guardian[s],Мини красный [хранитель|хранителя|хранителей]
 Mini Red Jackal Pup[s],[Мини-красный щенок шакала|Мини-красных щенка шакала|Мини-красных щенков шакала]


### PR DESCRIPTION
GLOSSARY, «Мини-питомцы: цветные детёныши»: «Шаблон: **„Мини-‹цвет› ‹детёныш›"**, приставка через дефис (счёт 56 против „Мини " 27 и „Миниатюрный" 3)».

Канон в корпусе держится — **227 строк из 258**. Остаток правится здесь:

```
Mini Bear Cub                   Мини Медвежонок       ->  Мини-медвежонок
Mini Copper Skyscale Hatchling  Миниатюрный медный …  ->  Мини-медный …
Mini Aqua Jackal Pup            Мини Аквамариновый …  ->  Мини-аквамариновый …
```

Правится **только приставка**: ставится дефис, следующее слово опускается в строчную — в шаблоне цвет идёт со строчной. Само название не трогаю: «Птенец Кукушки» с прописными и «Львенок» без ё остаются как были, это другие классы и другие правила.

**Описания в партию не входят.** «Миниатюрные шакальи щенки изготавливаются вручную…» — нормальная фраза, а не имя предмета, и шаблон её не касается. Так отсеяно 59 строк по признаку глагольного хвоста и длины.

* Гейт: строки совпадают при сравнении без дефисов, пробелов и регистра — то есть тронута ровно приставка; у всех двадцати она теперь «Мини-».
* Линтер без регрессий.