### PR TITLE
Корпус: причастие с зависимым словом — две «н», 10 строк

### DIFF
--- a/pn/pn_items_078.csv
+++ b/pn/pn_items_078.csv
@@ -134,7 +134,7 @@ Recipe: Feast of Sage-Stuffed Mushrooms,"Рецепт: пиршество из �
 Recipe: Feast of Sage-Stuffed Poultry,Рецепт: пиршество из фаршированной птицей
 Recipe: Feast of Seaweed Salad,Рецепт: пиршество из салата из морских водорослей
 Recipe: Feast of Sesame-Roasted Dinners,Рецепт: пиршество из кунжутно-жареных ужинов
-Recipe: Feast of Sesame-Roasted Meat,"Рецепт: пиршество из мяса, жареного с кунжутом"
+Recipe: Feast of Sesame-Roasted Meat,"Рецепт: пиршество из мяса, жаренного с кунжутом"
 Recipe: Feast of Spiced Mashed Yams,Рецепт: пиршество из пряного пюре из ямса
 Recipe: Feast of Spicier Flank Steaks,Рецепт: пиршество из пикантных стейков с боков
 Recipe: Feast of Spicy Cheeseburgers,Рецепт: пиршество из острых чизбургеров

--- a/pn/pn_items_093.csv
+++ b/pn/pn_items_093.csv
@@ -223,7 +223,7 @@ Skyforged Axe,Небесный топор
 Skyforged Dagger,Кинжал небесной ковки
 Skyforged Focus,Небесный фокус
 Skyforged Greatsword,Небесный двуручный меч
-Skyforged Hammer,Кованый небом молот
+Skyforged Hammer,Кованный небом молот
 Skyforged Longbow,Небесный длинный лук
 Skyforged Mace,Небесная булава
 Skyforged Pistol,Небесный пистолет

--- a/pn/pn_items_101.csv
+++ b/pn/pn_items_101.csv
@@ -140,7 +140,7 @@ Tasty Kryptis Skin,Вкусная шкура криптиса
 Tasty Meat,Вкусное мясо
 Tasty Minotaur Flank,Вкусный минотавр (задняя часть)
 Tasty Moss-Covered Bark,"Вкусная кора, покрытая мхом"
-Tasty Ooze-Cured Meat,"Вкусное мясо, вяленое в слизи"
+Tasty Ooze-Cured Meat,"Вкусное мясо, вяленное в слизи"
 Tasty Skale Fin,Вкусная чешуйчатая рыба.
 Tasty Skelk Liver,Вкусная печень скелька
 Tasty Spider Leg,Вкусная ножка паука

--- a/pn/pn_names_004.csv
+++ b/pn/pn_names_004.csv
@@ -428,7 +428,7 @@ Dealer,Торговец
 Dean,Дин
 Dearthair,Диртхэйр
 Death Shroud,Саван смерти
-Death-Branded Deputy Qais,Клеймёный смертью заместитель Кайс
+Death-Branded Deputy Qais,Клеймённый смертью заместитель Кайс
 Deathling,Смертник
 Deathrain,Смертодождь
 Debbie Lantys,Дебби Лантис

--- a/pn/pn_names_025.csv
+++ b/pn/pn_names_025.csv
@@ -417,7 +417,7 @@ Crystal Bloom Hunter,Охотник Хрустального расцвета
 Crystal Bloom Leader,Глава Хрустального расцвета
 Crystal Bloom Level,Уровень Хрустального расцвета
 Crystal Bloom Paragon,Паладин Хрустального расцвета
-Crystal Bloom Race Master,Мастер расы Кристалл Блум
+Crystal Bloom Race Master,Мастер расы Кристал Блум
 Crystal Bloom Reflector A,Отражатель Crystal Bloom A
 Crystal Bloom Reflector B,Отражатель Crystal Bloom B
 Crystal Bloom Reflector C,Отражатель Crystal Bloom C

--- a/pn/pn_names_040.csv
+++ b/pn/pn_names_040.csv
@@ -98,9 +98,9 @@ Crecia?,Кресия?
 DERV,DERV
 DO NOT TRANSLATE,DO NOT TRANSLATE
 Dark Barrage,Тёмный залп
-Death-Branded Hessper Sasso,Клеймёный смертью Хесспер Сассо
-Death-Branded Shatterer,Клеймёный смертью Сокрушитель
-Death-Branded Wrathbringer,Клеймёный смертью Гневоносец
+Death-Branded Hessper Sasso,Клеймённый смертью Хесспер Сассо
+Death-Branded Shatterer,Клеймённый смертью Сокрушитель
+Death-Branded Wrathbringer,Клеймённый смертью Гневоносец
 "Decima, the Stormsinger","Децима, Певица Бурь"
 Delilah,Делайла
 Demmi!,Демми!

--- a/zone/zone_100.csv
+++ b/zone/zone_100.csv
@@ -43,7 +43,7 @@ Make it quick. We didn't come here to kill thieves.,Поторапливайте
 "Make it warmer, you stooopids!","Сделайте теплее, вы, ту-у-упицы!"
 Make it... stop...,Прекрати... это...
 "Make light if you must, but learn from this mistake before you bring ruin to my people—to your people!","Можешь иронизировать, если хочешь, но извлеки урок из этой ошибки, прежде чем принесешь гибель моему народу — своему народу!"
-"Make me a Bowl of Snow Truffle Soup, a Sesame-Roasted Dinner, and some Sage-Stuffed Poultry. I'll let you know how you did.","Приготовьте мне миску супа из трюфелей и снега, жареную в кунжуте еду на ужин и птицу, фаршированную шалфеем. Я скажу вам, как всё получилось."
+"Make me a Bowl of Snow Truffle Soup, a Sesame-Roasted Dinner, and some Sage-Stuffed Poultry. I'll let you know how you did.","Приготовьте мне миску супа из трюфелей и снега, жаренную в кунжуте еду на ужин и птицу, фаршированную шалфеем. Я скажу вам, как всё получилось."
 "Make me a Bowl of Tropical Mousse, a Bowl of Truffle Sautee, and an Omnomberry Ghost, and I'll watch your technique.","Приготовь мне Bowl of Tropical Mousse, миску трюфельной сате и призрачного омномберри, и я понаблюдаю за твоей техникой."
 Make me look malicious.,Сделай меня похожим на злобного.
 Make me look tormented.,Сделай меня похожим на мученика.

--- a/zone/zone_161.csv
+++ b/zone/zone_161.csv
@@ -13,7 +13,7 @@ Thinkin' we better hit that tentacle now. Hole's not gonna close with that thing
 Thinking a lot about Crecia and the vote. I was mad—let her see that I was mad. I'm an imperator. That's not good.,"Много думаю о Crecia и голосовании. Я был зол — пусть видит, что я был зол. Я император. Это нехорошо."
 Thinking about home keeps me warm. Honey on toast. Hot soup. Mmm. What's your home like?,Мысли о доме согревают. Мед на тосте. Горячий суп. М-м-м. А как выглядит твой дом?
 Thinking about moving back into this citadel?,Собираетесь вернуться в эту цитадель?
-"Thinking about pickled wurm eggs-slimy, blackened, deep-fried-got my stomach growling! I wanna help cook.","Думаю о маринованных яйцах червя — слизистых, почерневших, жареных во фритюре — у меня аж в животе заурчало! Хочу помочь с готовкой."
+"Thinking about pickled wurm eggs-slimy, blackened, deep-fried-got my stomach growling! I wanna help cook.","Думаю о маринованных яйцах червя — слизистых, почерневших, жаренных во фритюре — у меня аж в животе заурчало! Хочу помочь с готовкой."
 "Thinking back on it, the prince treated me as a courtier rather than a guard or a servant. He was a good man.","Вспоминая об этом, принц относился ко мне как к придворному, а не как к стражнику или слуге. Он был хорошим человеком."
 "Thinking back, I now know what Kormir meant. ""Undo this wrong. The means are in your grasp."" You should have it.","Оглядываясь назад, я теперь понимаю, что имела в виду Kormir. «Исправь это зло. Средства в твоих руках». Оно должно быть у тебя."
 "Thinking caps and butt-kicking boots on, everyone. We have undead inbound!","Включаем мозги и готовимся раздавать тумаки, народ. К нам идет нежить!"


### PR DESCRIPTION
Отглагольное прилагательное без приставки и без зависимых слов пишется с одной «н»: «жареный корень», «клеймёный грифон». С зависимым словом оно становится причастием и удваивает «н».

| EN | было | стало |
|---|---|---|
| `Recipe: Feast of Sesame-Roasted Meat` | пиршество из мяса, **жареного** с кунжутом | **жаренного** с кунжутом |
| `Tasty Ooze-Cured Meat` | Вкусное мясо, **вяленое** в слизи | **вяленное** в слизи |
| `Skyforged Hammer` | **Кованый** небом молот | **Кованный** небом молот |
| `Death-Branded Shatterer` | **Клеймёный** смертью Сокрушитель | **Клеймённый** смертью Сокрушитель |

### Откуда класс

Всплыл при ревизии влитой партии [#118](https://github.com/K13or/crowdsource/pull/118) «удвоенные согласные». Она сводила удвоение по словарю форм и сняла вторую «н» там, где та стоит **по правилу, а не по ошибке**: четыре строки испорчены ею, пять были такими и раньше.

Десятая правка — из той же ревизии, но другого рода: #118 применила орфографию нарицательного «кристалл» к транслитерации имени `Crystal Bloom` («Мастер расы Кристалл Блум»). Корпус пишет там «Кристал» 21 раз против 2, и обе двойные — её работа. Канон самого имени не трогаю: он в открытых вопросах владельца («Хрустальный расцвет» 52 против «Кристальный Цветок» 19).

### Чем этот класс труден

Отличить зависимое слово от определяемого — вся работа. «Пиршество с **жареным корнем** лотоса» выглядит точно так же, но «корнем» здесь определяемое: согласовано с причастием в роде, числе и падеже, и «н» остаётся одна. Таких ложных кандидатов шаблон дал вчетверо больше, чем настоящих.

Кандидаты отбирались по двум признакам — обособление запятой перед предлогом («мясо, вяленое **в слизи**») и несогласованный творительный («Кованый **небом**») — но решение по каждой строке принято глазами: автомат путает «Кованый металлолом» и «Спасённый Кованый шлем», где следующее слово стоит в именительном падеже, а не в творительном. Поэтому все 10 правок записаны поимённо.

### Гейты

* тронуто ровно 10 записей в 8 файлах, ничего сверх плана (сверка с `git show HEAD:`);
* колонка `english` не менялась;
* дельта линтера 0/0 — класс ему не виден, он ловится только правилом языка.