### PR TITLE
Слой: тип вещи в названии не тот, что в оригинале — 42 записи

### DIFF
--- a/pn/pn_items_029.csv
+++ b/pn/pn_items_029.csv
@@ -73,7 +73,7 @@ Cleric's Iron Shield of Accuracy,Железный щит меткости кли
 Cleric's Iron Shield of Air,Щит клирика из железа воздуха
 Cleric's Iron Shield of Chilling,Железный щит клирика «Холод»
 Cleric's Iron Shield of Debility,Железный щит клирика немощи
-Cleric's Iron Shield of Earth,Железный пистолет клирика земли
+Cleric's Iron Shield of Earth,Железный щит клирика земли
 Cleric's Iron Shield of Energy,Железный щит клирика с энергией
 Cleric's Iron Shield of Fire,Железный щит огня клирика
 Cleric's Iron Shield of Force,Железный щит силы клирика

--- a/pn/pn_items_032.csv
+++ b/pn/pn_items_032.csv
@@ -305,7 +305,7 @@ Deathly Pauldrons,Смертоносные Наплечники
 Deathly Pauldrons Skin,Облик смертоносных наплечников
 Deathly Shoulderpads,Смертоносные Наплечники
 Deathly Shoulderpads Skin,Облик оплечьеов «Смертоносные»
-Deathstrider Hammer,Наплечники Смертоносного Шага
+Deathstrider Hammer,Молот Смертоносного Шага
 Deathwish,Тяга к смерти
 Debbie's Cake,Торт Дебби
 Decade Anniversary Achievement Box,Коробка с достижениями за десятилетие

--- a/pn/pn_items_033.csv
+++ b/pn/pn_items_033.csv
@@ -437,7 +437,7 @@ Dire Aureate Longbow of Energy,Грозный золотой длинный лу
 Dire Aureate Longbow of Force,Длинный лук «Золотой» силы
 Dire Aureate Longbow of Water,Грозный золотой длинный лук воды
 Dire Aureate Mace of Air,Пряная дубинка анеевой атаки «Воздух»
-Dire Aureate Mace of Corruption,Грозный позолоченный молот порчи
+Dire Aureate Mace of Corruption,Грозная позолоченная булава порчи
 Dire Aureate Mace of Energy,Грозная позолоченная булава энергии
 Dire Aureate Mace of Force,Грозная золотая булава силы
 Dire Aureate Mace of Water,Грозная золотая булава воды

--- a/pn/pn_items_034.csv
+++ b/pn/pn_items_034.csv
@@ -286,7 +286,7 @@ Dire Orrian Focus of Blood,Грозный оррианский фокус кро
 Dire Orrian Focus of Bloodlust,Грозный оррианский фокус кровожадности
 Dire Orrian Focus of Corruption,Грозное оррианское средоточие Порчи
 Dire Orrian Focus of Earth,Ужас: Оррианский фокус земли
-Dire Orrian Focus of Energy,Оррианский посох энергии (Мертвец)
+Dire Orrian Focus of Energy,Оррианский фокус энергии (Мертвец)
 Dire Orrian Focus of Rage,Оррианский фокус гнева
 Dire Orrian Focus of Vision,Пряное оррианское фокус-оружие видения
 Dire Orrian Focus of Water,Грозный оррианский фокус воды

--- a/pn/pn_items_035.csv
+++ b/pn/pn_items_035.csv
@@ -220,7 +220,7 @@ Diviner's Shining Aureate Charm of Luck,Сияющий золотой обере
 Diviner's Shining Aureate Dirk of Luck,«Сияющий ауреатский кинжал удачи Прорицателя»
 Diviner's Shining Aureate Highlander Greatsword of Luck,Двуручный меч горца «Сияющий ауреат» Прорицателя удачи
 Diviner's Shining Aureate Longbow of Luck,Длинный лук «Сияющий золотой» Прорицателя удачи
-Diviner's Shining Aureate Mace of Luck,Сияющий ауреатный молот Прорицателя удачи
+Diviner's Shining Aureate Mace of Luck,Сияющая ауреатная булава Прорицателя удачи
 Diviner's Shining Aureate Musket of Luck,Прорицателя сияющий золочёный мушкет удачи
 Diviner's Shining Aureate Pistol of Luck,Сверкающий золочёный пистолет Прорицателя удачи
 Diviner's Shining Aureate Rinblade of Luck,Сияющий златоцветный ринблейд Удачи Прорицателя

--- a/pn/pn_items_046.csv
+++ b/pn/pn_items_046.csv
@@ -282,7 +282,7 @@ Hard Wood Pulp,Пульпа из твёрдой древесины
 Hard Wood Scepter,Скипетр из твёрдой древесины
 Hard Wood Short Bow,Короткий лук из твёрдой древесины
 Hard Wood Staff,Посох из твёрдой древесины
-Hard Wood Torch,Топорище из твёрдой древесины
+Hard Wood Torch,Факел из твёрдой древесины
 Hard Wood Trident,Трезубец из твёрдой древесины
 Hard Wood Warhorn,Боевой рог из твёрдой древесины
 Hardened Boot Sole,Закалённая подошва сапога

--- a/pn/pn_items_049.csv
+++ b/pn/pn_items_049.csv
@@ -111,7 +111,7 @@ Honed Iron Hammer of the Geomancer,Заточенный железный мол�
 Honed Iron Imbued Inscription,Заточенная железная пропитанная гравировка
 Honed Iron Mace,Заточенная железная булава
 Honed Iron Mace of Blood,Заточенная железная булава крови
-Honed Iron Mace of Corruption,Заточенный железный молот скверны
+Honed Iron Mace of Corruption,Заточенная железная булава скверны
 Honed Iron Mace of Fire,Заточенная железная булава огня
 Honed Iron Mace of Force,Заточенная железная булава силы
 Honed Iron Mace of Grawl Slaying,Заточенная железная булава истребления граулов

--- a/pn/pn_items_061.csv
+++ b/pn/pn_items_061.csv
@@ -44,7 +44,7 @@ Merciless Staff Skin,Облик посоха «Безжалостный»
 Merciless Sword,Беспощадный меч
 Merciless Sword Skin,Облик меча «Беспощадный»
 Merciless Torch,Безжалостный факел
-Merciless Torch Skin,Облик безжалостного меча
+Merciless Torch Skin,Облик безжалостного факела
 Merciless Warhorn,Безжалостный боевой рог
 Merciless Warhorn Skin,Облик боевого рога «Безжалостный»
 Merciless Weapon Box,Коробка безжалостного оружия

--- a/pn/pn_items_065.csv
+++ b/pn/pn_items_065.csv
@@ -400,7 +400,7 @@ Oil Slick,Масляное пятно
 Oil Slick Dye,Краска «Нефтяное пятно»
 Oil-Soaked Roots,Пропитанные маслом корни
 Oiled Ancient Focus Casing,Пропитанный маслом корпус древнего фокуса
-Oiled Ancient Focus Core,Пропитанная маслом древняя сердцевина посоха
+Oiled Ancient Focus Core,Пропитанная маслом древняя сердцевина фокуса
 Oiled Ancient Harpoon,Промасленный древний гарпун
 Oiled Ancient Longbow Stave,Маслянистая древняя ветвь длинного лука
 Oiled Ancient Rifle Stock,Промасленный древний приклад винтовки

--- a/pn/pn_items_072.csv
+++ b/pn/pn_items_072.csv
@@ -448,7 +448,7 @@ Rampager's Auric Focus,Аурический фокус Буяна
 Rampager's Auric Greatsword,Двуручный меч Буяна
 Rampager's Auric Hammer,Аурический молот Буяна
 Rampager's Auric Longbow,Лук Буяна
-Rampager's Auric Mace,Боевой молот Буяна
+Rampager's Auric Mace,Боевая булава Буяна
 Rampager's Auric Pistol,Аурический пистолет Буяна
 Rampager's Auric Rifle,Аурический винт Буяна
 Rampager's Auric Scepter,Аурический скипетр Буяна
@@ -459,7 +459,7 @@ Rampager's Auric Sword,Аурический меч Буяна
 Rampager's Auric Torch,Аурический факел Буяна
 Rampager's Auric Warhorn,Боевой рог Буяна
 Rampager's Aurora Garb of Balthazar,Одеяние Буяна «Аврора Бальтазара»
-Rampager's Aurora Gloves of Balthazar,Рукавицы Буяна с аурой Бальтазара
+Rampager's Aurora Gloves of Balthazar,Перчатки Буяна с аурой Бальтазара
 Rampager's Aurora Helm of Balthazar,Шлем Буяна с аурой Бальтазара
 Rampager's Aurora Leggings of Balthazar,Поножи Буяна с аурой Бальтазара
 Rampager's Aurora Mantle of Balthazar,Плащ Бхалтазара Буяна

--- a/pn/pn_items_073.csv
+++ b/pn/pn_items_073.csv
@@ -31,9 +31,9 @@ Rampager's Cabalist Coat of Infiltration,Куртка скрытности гр�
 Rampager's Cabalist Coat of the Lich,Кабалистская куртка Лича Рэмпейджера
 Rampager's Cabalist Gloves,Перчатки Кабалиста Буяна
 Rampager's Cabalist Gloves of Balthazar,Перчатки Кабалиста Бальтазара Буяна
-Rampager's Cabalist Gloves of Divinity,Рукавицы божественного каббалиста Буяна
+Rampager's Cabalist Gloves of Divinity,Перчатки божественного каббалиста Буяна
 Rampager's Cabalist Gloves of Scavenging,"Перчатки алхимика разрушителя, дающие бонус к сбору ресурсов"
-Rampager's Cabalist Gloves of the Dolyak,Рукавицы каббалиста Дольяка Буяна
+Rampager's Cabalist Gloves of the Dolyak,Перчатки каббалиста Дольяка Буяна
 Rampager's Cabalist Hood,Капюшон Кабалиста Буяна
 Rampager's Cabalist Hood of the Centaur,Капюшон Кабалиста-разрушителя кентавра
 Rampager's Cabalist Hood of the Flame Legion,Капюшон каббалиста из Flame Legion
@@ -158,7 +158,7 @@ Rampager's Hard Inscription,Жесткая гравировка Буяна
 Rampager's Hard Wood Focus,Фокус «Твёрдая древесина» Буяна
 Rampager's Hard Wood Harpoon Gun,Гарпунное ружьё «Твёрдая древесина»
 Rampager's Hard Wood Longbow,Длинный лук из твёрдой древесины Буяна
-Rampager's Hard Wood Scepter,Посох из твёрдой древесины Буяна
+Rampager's Hard Wood Scepter,Скипетр из твёрдой древесины Буяна
 Rampager's Hard Wood Short Bow,Короткий лук из твёрдого дерева Буяна
 Rampager's Hard Wood Staff,Твёрдый посох Буяна
 Rampager's Hard Wood Torch,Твёрдая деревянная факел Буяна
@@ -232,20 +232,20 @@ Rampager's Iron Hammer of Purity,Железный молот чистоты яр
 Rampager's Iron Hammer of Serpent Slaying,Железный молот Буяна для убийства змей
 Rampager's Iron Hammer of Venom,Железный молот яда Буяна
 Rampager's Iron Mace,Железная булава Буяна
-Rampager's Iron Mace of Air,"Железный молот разрушителя, дарующий силу воздуха"
-Rampager's Iron Mace of Chilling,Железный молот «Ледяной ярости»
-Rampager's Iron Mace of Corruption,Железный молот скверны Буяна
-Rampager's Iron Mace of Earth,Железный молот земли Буяна
-Rampager's Iron Mace of Fire,Железный молот огня яростного воина
-Rampager's Iron Mace of Force,Железный молот силы Буяна
-Rampager's Iron Mace of Grawl Slaying,"Железный молот граула, сокрушитель граулов"
+Rampager's Iron Mace of Air,"Железная булава разрушителя, дарующая силу воздуха"
+Rampager's Iron Mace of Chilling,Железная булава «Ледяной ярости»
+Rampager's Iron Mace of Corruption,Железная булава скверны Буяна
+Rampager's Iron Mace of Earth,Железная булава земли Буяна
+Rampager's Iron Mace of Fire,Железная булава огня яростного воина
+Rampager's Iron Mace of Force,Железная булава силы Буяна
+Rampager's Iron Mace of Grawl Slaying,"Железная булава граула, сокрушитель граулов"
 Rampager's Iron Mace of Ice,Железная булава льда Буяна
 Rampager's Iron Mace of Ogre Slaying,Железная булава убийства огров Буяна
-Rampager's Iron Mace of Perception,Железный молот восприятия яростного воина
-Rampager's Iron Mace of Rage,Железный молот ярости Буяна
-Rampager's Iron Mace of Smoldering,"Железный молот яростного воина, опаляющий"
-Rampager's Iron Mace of Water,Железный молот Водомета Буяна
-Rampager's Iron Mace of the Hydromancer,Железный молот Буяна гидрометра
+Rampager's Iron Mace of Perception,Железная булава восприятия яростного воина
+Rampager's Iron Mace of Rage,Железная булава ярости Буяна
+Rampager's Iron Mace of Smoldering,"Железная булава яростного воина, опаляющая"
+Rampager's Iron Mace of Water,Железная булава Водомета Буяна
+Rampager's Iron Mace of the Hydromancer,Железная булава Буяна гидрометра
 Rampager's Iron Pistol,Железный пистолет Буяна
 Rampager's Iron Pistol of Accuracy,Железный пистолет «Точный удар» Буяна
 Rampager's Iron Pistol of Air,Железный пистолет «Громовержец»

--- a/pn/pn_items_074.csv
+++ b/pn/pn_items_074.csv
@@ -9,10 +9,10 @@ Rampager's Rogue Coat of Grenth,Куртка Буяна из Грента
 Rampager's Rogue Coat of Lyssa,Куртка Буяна Лиссы
 Rampager's Rogue Coat of Strength,Куртка силы грабитель Буяна
 Rampager's Rogue Coat of the Pack,Куртка «Когти стаи»
-Rampager's Rogue Gloves of Grenth,Рукавицы разбойника Грента
+Rampager's Rogue Gloves of Grenth,Перчатки разбойника Грента
 Rampager's Rogue Gloves of Infiltration,Перчатки разбойника Буяна проникновения
 Rampager's Rogue Gloves of Rage,Перчатки ярости Буяна
-Rampager's Rogue Gloves of the Afflicted,Рукавицы Буяна для Подверженных Аффекту
+Rampager's Rogue Gloves of the Afflicted,Перчатки Буяна для Подверженных Аффекту
 Rampager's Rogue Pants of Divinity,Брюки «Божественная хитрость» Буяна
 Rampager's Rogue Pants of Lyssa,Брюки Буяна из Лисса
 Rampager's Rogue Pants of Melandru,Брюки Разбойника Меландру Буяна

--- a/pn/pn_items_088.csv
+++ b/pn/pn_items_088.csv
@@ -174,7 +174,7 @@ Sapphire Platinum Ring,Сапфировое платиновое кольцо
 Sapphire Shard,Сапфировый осколок
 Sapphire-Scaled Moonfish,Лунная рыба с сапфировой чешуёй
 Sarayi Gauntlets,Перчатки Сарайи
-Sarayi Gloves,Рукавицы Сарайи
+Sarayi Gloves,Перчатки Сарайи
 Sarayi Staff,Посох Сарайи
 Sarayi Sword,Меч Сарайи
 Sarcophagus,Саркофаг

--- a/pn/pn_items_089.csv
+++ b/pn/pn_items_089.csv
@@ -219,8 +219,8 @@ Sentinel's Cabalist Boots,Сапоги каббалиста стража
 Sentinel's Cabalist Boots of Strength,"Сапоги Кабалиста стража, дарующие мощь"
 Sentinel's Cabalist Coat,Куртка каббалиста стража
 Sentinel's Cabalist Coat of Balthazar,Куртка каббалиста из Бхалтазара (стража)
-Sentinel's Cabalist Gloves,Рукавицы каббалиста стража
-Sentinel's Cabalist Gloves of the Afflicted,Рукавицы Кабалиста стража для страдающих
+Sentinel's Cabalist Gloves,Перчатки каббалиста стража
+Sentinel's Cabalist Gloves of the Afflicted,Перчатки Кабалиста стража для страдающих
 Sentinel's Cabalist Hood,Капюшон каббалиста стража
 Sentinel's Cabalist Hood of Vampirism,Капюшон каббалиста-стража вампиризма
 Sentinel's Cabalist Legs,Штаны каббалиста стража
@@ -263,7 +263,7 @@ Sentinel's Elder Inscription,Древняя гравировка стража
 Sentinel's Elder Wood Focus,Фокус стража из древней древесины
 Sentinel's Elder Wood Harpoon Gun,Древний гарпунный ружьё стража
 Sentinel's Elder Wood Longbow,Длинный лук из древней древесины стража
-Sentinel's Elder Wood Scepter,Древний посох стража
+Sentinel's Elder Wood Scepter,Древний скипетр стража
 Sentinel's Elder Wood Short Bow,Короткий лук из древней древесины стража
 Sentinel's Elder Wood Staff,Посох из древней древесины стража
 Sentinel's Elder Wood Torch,Факел из древнего дерева стража
@@ -310,7 +310,7 @@ Sentinel's Iron Hammer of Accuracy,Железный молот точности 
 Sentinel's Iron Hammer of Serpent Slaying,Железный молот-убийца змей из стража
 Sentinel's Iron Mace,Железная булава стража
 Sentinel's Iron Mace of Accuracy,Железная булава точности стража
-Sentinel's Iron Mace of Battle,Железный боевой молот стража
+Sentinel's Iron Mace of Battle,Железная боевая булава стража
 Sentinel's Iron Pistol,Железный пистолет стража
 Sentinel's Iron Pistol of Bloodlust,Железный пистолет стража «Кровавый азарт»
 Sentinel's Iron Pistol of Earth,Железный пистолет земли стража

--- a/pn/pn_items_090.csv
+++ b/pn/pn_items_090.csv
@@ -142,8 +142,8 @@ Settler's Iron Greatsword of Hobbling,"Железный двуручный ме�
 Settler's Iron Greatsword of the Geomancer,Железный двуручный меч поселенца-геоманта
 Settler's Iron Hammer,Железный молот поселенца
 Settler's Iron Hammer of Serpent Slaying,Железный молот поселенца для убийства змей
-Settler's Iron Mace of Accuracy,Железный молот поселенца с бонусом к точности
-Settler's Iron Mace of Battle,Железный боевой молот поселенца
+Settler's Iron Mace of Accuracy,Железная булава поселенца с бонусом к точности
+Settler's Iron Mace of Battle,Железная боевая булава поселенца
 Settler's Iron Pistol,Железный пистолет поселенца
 Settler's Iron Pistol of Bloodlust,Железный пистолет поселенца жажды крови
 Settler's Iron Pistol of Earth,Железный пистолет поселенца Земли

--- a/pn/pn_items_091.csv
+++ b/pn/pn_items_091.csv
@@ -101,7 +101,7 @@ Shaman's Etched Revolver of Vision,Выгравированный револьв
 Shaman's Etched Scepter of Accuracy,Жезл шамана с рунами точности
 Shaman's Etched Scepter of Blood,Ритуальный скипетр шамана из крови
 Shaman's Etched Scepter of Rage,Жезл ярости шамана с руническими письменами
-Shaman's Etched Scepter of Vision,Выгравированный посох шамана видений
+Shaman's Etched Scepter of Vision,Выгравированный скипетр шамана видений
 Shaman's Etched Shard of Accuracy,Выкованный шаманом осколок точности
 Shaman's Etched Shard of Blood,Отшлифованный осколок крови шамана
 Shaman's Etched Shard of Rage,Выкованный шаманом осколок ярости
@@ -349,9 +349,9 @@ Shaman's Ring,Кольцо шамана
 Shaman's Rogue Coat of Hoelbrak,Шаманская кожаная куртка из Хёльбрака
 Shaman's Rogue Coat of the Grove,Куртка шамана-разбойника из рощи
 Shaman's Rogue Coat of the Traveler,Куртка странника шамана-вора
-Shaman's Rogue Gloves of Divinity,Рукавицы ловкости шамана из Божественного предела
-Shaman's Rogue Gloves of Hoelbrak,Рукавицы Хоэльбрака для ловкача-шамана
-Shaman's Rogue Gloves of Vampirism,Рукавицы шамана-вора вампиризма
+Shaman's Rogue Gloves of Divinity,Перчатки ловкости шамана из Божественного предела
+Shaman's Rogue Gloves of Hoelbrak,Перчатки Хоэльбрака для ловкача-шамана
+Shaman's Rogue Gloves of Vampirism,Перчатки шамана-вора вампиризма
 Shaman's Rogue Pants of Hoelbrak,Штаны шамана-вора из Хёльбрака
 Shaman's Rogue Pants of Melandru,Штаны шамана-разбойника Меландру
 Shaman's Rogue Pants of Rage,Штаны разгневанного шамана-вора

--- a/pn/pn_items_098.csv
+++ b/pn/pn_items_098.csv
@@ -285,7 +285,7 @@ Strong Magician Coat of the Flame Legion,Прочная куртка мага Fl
 Strong Magician Coat of the Flock,Куртка прочного волшебника «Стая»
 Strong Magician Gloves,Прочные перчатки мага
 Strong Magician Gloves of the Flame Legion,Прочные перчатки мага из Flame Legion
-Strong Magician Gloves of the Flock,Прочные рукавицы мага стаи
+Strong Magician Gloves of the Flock,Прочные перчатки мага стаи
 Strong Magician Gloves of the Lich,Прочные перчатки мага «Лича»
 Strong Magician Legs,Прочные ноги мага
 Strong Magician Legs of Lyssa,Прочные поножи мага Лиссы

--- a/pn/pn_items_101.csv
+++ b/pn/pn_items_101.csv
@@ -115,7 +115,7 @@ Tarragon Leaves,Листья эстрагона
 Tarragon Seed Pouch,Мешочек семян эстрагона
 Tarrktun Personal Delivery Portal,Персональный портал доставки Таррктуна
 Tarstar Gauntlets,Перчатки Тарстар
-Tarstar Gloves,Рукавицы Тарстар
+Tarstar Gloves,Перчатки Тарстар
 Tarstar Handwraps,Обмотки Тарстар
 Tarstar Longbow,Длинный лук Тарстар
 Tassi's Relay Golem,Ретрансляционный голем Тасси

--- a/pn/pn_items_110.csv
+++ b/pn/pn_items_110.csv
@@ -290,7 +290,7 @@ World Ender Dye,Краска «Концесвет»
 World Veteran Title Box,Коробка с титулом «Ветеран мира»
 World vs. World Support Pack,Набор поддержки «World vs. World»
 Worm Rancher's Gauntlets,Перчатки червячного фермера
-Worm Rancher's Gloves,Рукавицы червячного фермера
+Worm Rancher's Gloves,Перчатки червячного фермера
 Worm Rancher's Studded Gloves,Перчатки с шипами червячного фермера
 Worm Rancher's Torch,Факел червячного фермера
 Worn Bone,Потёртая кость


### PR DESCRIPTION
Щит назван пистолетом, факел — топорищем, молот — наплечниками, булава — молотом. Тип вещи игрок видит в инвентаре, и подмена тут не вопрос вкуса.

| EN | было | стало |
|---|---|---|
| `Cleric's Iron Shield of Earth` | Железный **пистолет** клирика земли | Железный **щит** |
| `Hard Wood Torch` | **Топорище** из твёрдой древесины | **Факел** |
| `Deathstrider Hammer` | **Наплечники** Смертоносного Шага | **Молот** |
| `Rampager's Iron Mace of Corruption` | Железный **молот** скверны | Железная **булава** |
| `Sarayi Gloves` | **Рукавицы** Сарайи | **Перчатки** Сарайи |
| `Rampager's Hard Wood Scepter` | **Посох** из твёрдой древесины | **Скипетр** |

### Канон

Корпус единодушен, спорить не с чем:

| тип | верно | подмена |
|---|---|---|
| `Mace` | булава 1294 | молот 20 |
| `Gloves` | перчатки 1121 | рукавицы 15 |
| `Scepter` | скипетр 1232 | посох 3 |
| `Torch` | факел 1191 | посох 2 |

Отбор строгий: тип назван в оригинале ровно один раз, в переводе стоит **другой известный тип**, а верного нет вовсе. Пересказ своими словами под правило не подпадает.

`Gauntlets` в класс не вошли: корпус зовёт их и перчатками (319), и рукавицами (82) — это разнобой, а не подмена, и решать его отдельно.

### Смена рода

«Молот» мужского рода, «булава» женского, поэтому у `Mace` правится и согласование, включая причастие в хвосте: «Железный молот разрушителя, **дарующий** силу воздуха» → «Железная булава разрушителя, **дарующая** силу воздуха».

Падежные формы взяты таблицей, а не правилом: правило давало «Перчаткы», «Факеле» и «Сияющяя» — после шипящих и заднеязычных окончания другие.

### Откуда класс

Найден при ревизии влитой партии [#116](https://github.com/K13or/crowdsource/pull/116). **Сама она чиста**: все 3 843 записи — одна и та же замена служебного слова `Recipe:` → «Рецепт:», подмен там нет.

### Гейты

* тронуто ровно 42 записи в 19 файлах, ничего сверх плана;
* колонка `english` не менялась, дельта линтера 0/0;
* остаток класса в слое — ноль.