### PR TITLE
items_125: выброшены 98 мёртвых копий живых строк

### DIFF
--- a/items/items_125.csv
+++ b/items/items_125.csv
@@ -12,15 +12,11 @@ Double-click to gain 50 luck.","«Даже выступая в роли прим
 """With Korag gone, his remaining tribe may finally know peace. Take pride in their new beginning
 Double-click to gain 50 luck.","С уходом Корага его оставшееся племя наконец-то познает покой. Гордитесь их новым началом.
 Дважды щёлкните, чтобы получить 50 единиц удачи."
-"'""""""Nature''s candy"""" is not candy.""'","«""""""Конфеты природы"""" — это не конфеты.""'"
 "'""""""Of course it''s not just an empty bottle. It came with a certificate of authenticity!""""""'","«""""""Конечно, это не просто пустая бутылка. К ней прилагался сертификат подлинности!""""""»"
 "'""""""To keep cool while things heat up is a rare quality. You''re a true testament to the Blood Legion.""""'","«Сохранять хладнокровие, когда вокруг жарко, — редкое качество. Ты — истинное свидетельство Blood Legion»."
 "'""<c=@flavor>""""A good soldier follows orders. A great soldier doesn''t question them.""""'","«""<c=@flavor>""""Хороший солдат следует приказам. Великий солдат их не оспаривает.""""»"
 "'""<c=@flavor>""""Aha! I''ve been looking for those.""""'","""<c=@flavor>""""Ага! Я как раз искал их."""""
 "'""<c=@flavor>""""Always gotta make sure your drinking water''s safe.""""'","'""<c=@flavor>""""Всегда нужно убедиться, что твоя питьевая вода безопасна.""""'"
-"'""<c=@flavor>""""Always triple-check the resonance frequency. The smallest error may have unforeseen consequences.""""
-—Asura Gate Technician''s Guide</c>""'","""<c=@flavor>""""Всегда перепроверяйте резонансную частоту. Малейшая ошибка может привести к непредвиденным последствиям.""""
-—Руководство техника по Asura Gate</c>"""""
 "'""<c=@flavor>""""Always wear a sturdy helm when fighting skritt. There''s no telling what they''ll throw at you.""""'","'""<c=@flavor>""""Всегда носите прочный шлем, сражаясь с скриттами. Никогда не знаешь, что они в вас бросят.""""'"
 "'""<c=@flavor>""""Be careful with that! It''s very fragile.""""'","«""<c=@flavor>""""Осторожнее! Она очень хрупкая.""""»"
 "'""<c=@flavor>""""Bet their catapult won''t work without this!""""'","«""<c=@flavor>""""Держу пари, их катапульта не сработает без этого!""""»"
@@ -29,8 +25,6 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""Can''t have a proper patrol without a proper torch.""""'","«""<c=@flavor>""""Без хорошего факела не может быть хорошего патруля.""""»"
 "'""<c=@flavor>""""Cover your head. That''s rule number one when all the other rules go out the window.""""'","'""<c=@flavor>""""Прикрой голову. Это правило номер один, когда все остальные правила летят в окно.""""'"
 "'""<c=@flavor>""""Crab grabbin'' can be dangerous. Protect those mitts!""""'","'""<c=@flavor>""""Хватать крабов может быть опасно. Береги свои рукавицы!""""'"
-"'""<c=@flavor>""""Detective work''s no court of law—but some of the same arguments work in both."""" —Marjory</c>""'","'""<c=@flavor>""""Детективная работа — это не суд, но некоторые из тех же доводов работают и там."""" —Марджори</c>""'"
-"'""<c=@flavor>""""Don''t be seen.""""</c>""'","'""<c=@flavor>""""Не показывайся.""""</c>""'"
 "'""<c=@flavor>""""Don''t eat this one—the stuff I preserved it with doesn''t taste too good.""""'","'""<c=@flavor>""""Не ешь то, чем я это законсервировал — на вкус оно не очень.""""'"
 "'""<c=@flavor>""""Don''t get any funny ideas. Only trained techs can replace a gate crystal.""""'","«""<c=@flavor>""""Не шути. Только обученные техники могут заменить кристалл врат.""""»"
 "'""<c=@flavor>""""Don''t go into the water to rescue Wardens without this speargun. It''ll keep those undead off you."""" '","'""<c=@flavor>""""Не лезь в воду спасать Стражей без этого гарпуна. Он не подпустит к тебе этих мертвецов."""" '"
@@ -43,13 +37,10 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""Either the quaggan used it backward or this one didn''t fit.""""'","'""<c=@flavor>""""""Либо квагган использовал его задом наперёд, либо этот не подошёл.""""'"
 "'""<c=@flavor>""""Everyone says we need more of these. I think we''ve got enough.""""'","'""<c=@flavor>""""Все говорят, что нам нужно больше таких. Я думаю, у нас достаточно.""""'"
 "'""<c=@flavor>""""Finest pistol ever ''donated'' to our cause.""""'","'""<c=@flavor>""""Лучший пистолет"
-"'""<c=@flavor>""""First Posting: On loan to Reave warband in Redreave Mill. Mountain makes sentry duty easy. Good sight lines. Campfire talk says there''s a killer festival at Butcher''s Block.""""</c>""'","'""<c=@flavor>""""Первое сообщение: Временно передан отряду Рива на мельнице Редрив. Гора облегчает караульную службу. Хороший обзор. У костра говорят, что в Блоке Мясника будет убийственный фестиваль.""""</c>""'"
 "'""<c=@flavor>""""Folks don''t just breathe water.""""'","'""<c=@flavor>""""Люди не просто дышат водой.""""'"
-"'""<c=@flavor>""""Fools! You''ve let her slip her bonds!""""—Separatist Captain DeLana</c>""'","<c=@flavor>«Глупцы! Вы позволили ей выскользнуть из пут!»—Капитан сепаратистов ДеЛана</c>"
 "'""<c=@flavor>""""For a great hero dedicated to Tyria''s safety.""""'","'""<c=@flavor>""""Для великого героя, посвятившего себя безопасности Тирии.""""'"
 "'""<c=@flavor>""""For those large hides that you just can''t get clean.""""'","'""<c=@flavor>""""Для тех больших шкур, которые никак не отчистить.""""'"
 "'""<c=@flavor>""""Good to keep these dark so they don''t shimmer at night.""""'","'""<c=@flavor>""""Храните их в темноте"
-"'""<c=@flavor>""""Got chased in here by the biggest Branded devourer I''d ever seen. Thought I''d starve to death. Never thought I''d see a human lure it away.""""</c>""'","'""<c=@flavor>""""Меня загнал сюда самый огромный пожиратель из Клейма, которого я когда-либо видел. Думал, что умру с голоду. Никогда не думал, что человек сможет увести его.""""</c>""'"
 "'""<c=@flavor>""""Gotta keep these really sharp if you''re gonna skin a dolyak.""""'","""<c=@flavor>""""Надо держать их очень острыми, если собираешься снимать шкуру с дольяка."""""
 "'""<c=@flavor>""""Harpy down makes a good pillow. It''s soft and warm.""""'","'""<c=@flavor>""""Пух гарпии — отличная подушка. Он мягкий и тёплый.""""'"
 "'""<c=@flavor>""""I assume you know which end to use. I''ll be here if you an explanation.""""'","'""<c=@flavor>""""Я полагаю, вы знаете, с какого конца использовать. Я буду здесь, если вам понадобится объяснение.""""'"
@@ -66,7 +57,6 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 —Sheriff Bloodclaw</c>""'","'""<c=@flavor>""""Я утончил лезвие на этом конкретном мече. Вы увидите, что он разит гораздо быстрее обычного клинка.""""
 —Шериф Кровавый Коготь</c>""'"
 "'""<c=@flavor>""""I had to make minor adjustments after getting these in. You won''t be disappointed.""""'","«""<c=@flavor>""""Мне пришлось внести небольшие правки после того, как я их получил. Вы не будете разочарованы.""""»"
-"'""<c=@flavor>""""I pity what''s on the other side of this speargun.""""</c>""'","'""<c=@flavor>""""Мне жаль того, что на другой стороне этого гарпуна.""""</c>""'"
 "'""<c=@flavor>""""I think our doll''s inside a golden chest. I dunno how Grawnk even found a chest like that. Must belong to lazy rich people.""""
 —Laine</c>""'","'""<c=@flavor>""""Думаю, наша кукла внутри золотого сундука. Понятия не имею, как Граунк вообще нашёл такой сундук. Наверное, принадлежит ленивым богачам.""""
 —Лейн</c>""'"
@@ -79,15 +69,11 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""I''ve seen enough battles to know when to use this and when to use diplomacy.""""'","""<c=@flavor>""""Я повидал достаточно битв, чтобы знать, когда использовать это, а когда — дипломатию."""""
 "'""<c=@flavor>""""Infused with the morning''s light.""""'","'""<c=@flavor>""""Наполнено утренним светом.""""'"
 "'""<c=@flavor>""""It almost looks like it''s watching you.""""'","'""<c=@flavor>""""Оно почти выглядит так, будто смотрит на тебя.""""'"
-"'""<c=@flavor>""""It can''t be sheathed ''til it''s spilled blood.""""</c>""'","«<c=@flavor>""""Его нельзя вложить в ножны, пока оно не прольёт кровь.""""</c>»"
-"'""<c=@flavor>""""It''s amazing that such a quality sword was found in a skritt cave""""</c>""'","«""<c=@flavor>""""Это неудивительно, что такой качественный меч нашли в пещере скриттов""""</c>""»"
 "'""<c=@flavor>""""It''s amazing what can happen when you get everyone working together.""""'","'""<c=@flavor>""""Удивительно"
 "'""<c=@flavor>""""It''s amazing what you can find in a old Skritt cave.""""'","'""<c=@flavor>""""Удивительно, что можно найти в старой пещере скриттов.""""'"
 "'""<c=@flavor>""""It''s been recalibrated using the energy readings we took in this area. It''ll be quite effective."""" '","'""<c=@flavor>""""Он был перекалиброван с использованием показаний энергии, которые мы сняли в этой области. Он будет весьма эффективен."""" '"
-"'""<c=@flavor>""""It''s chipped and stained with old blood.""""</c>""'","«""<c=@flavor>""""Он щербат и запятнан старой кровью.""""</c>""»"
 "'""<c=@flavor>""""It''s easier to be vigilant when you have this in your hands.""""'","'""<c=@flavor>""""Легче быть бдительным, когда у тебя это в руках.""""'"
 "'""<c=@flavor>""""It''s got a hair-trigger. I wouldn''t suggest pointing this at yourself while cleaning.""""'",«<c=@flavor>»«У него очень чувствительный спусковой крючок. Я бы не советовал направлять его на себя во время чистки».
-"'""<c=@flavor>""""It''s hard to forget that horrible place. But it''s destroyed now—down to the roots."""" —Kasmeer</c>""'","«""<c=@flavor>""""Трудно забыть это ужасное место. Но оно разрушено — до самых корней."""" —Касмир</c>""»"
 "'""<c=@flavor>""""It''s important to have the right shoes for the job.""""'","«""<c=@flavor>""""Важно иметь правильную обувь для работы.""""»"
 "'""<c=@flavor>""""It''s not like the captain will be needing it soon.""""'","""<c=@flavor>""""Вряд ли капитану это скоро понадобится."""""
 "'""<c=@flavor>""""It''s not meant to be literally hidden.""""'","'""<c=@flavor>""""Не подразумевается"
@@ -100,15 +86,12 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""Let''s make a deal.""""'","«""<c=@flavor>""""Давайте заключим сделку.""""»"
 "'""<c=@flavor>""""Let''s see them run after us now!""""'","""<c=@flavor>""""Посмотрим, как они теперь за нами погонятся!"""""
 "'""<c=@flavor>""""Looks like your heroics qualified you. You have the Iron Legion''s thanks.""""'","'""<c=@flavor>""Похоже, твои героические подвиги дали тебе право. Ты получил благодарность Iron Legion.""'"
-"'""<c=@flavor>""""Made from a devourer''s tail.""""</c>""'","""<c=@flavor>""""Сделан из хвоста пожирателя.""""</c>"""
 "'""<c=@flavor>""""Magic! It''s like the frosting on a giant misty cake. Made of pistols. That burn blue. Just like Mom used to make.""""'","'""<c=@flavor>""""Магия! Это как глазурь на гигантском туманном торте. Сделанном из пистолетов. Которые горят синим. Прямо как мама готовила.""""'"
 "'""<c=@flavor>""""Market research! That''s the ticket. I just need to know what those quaggan chaps eat.""""'","'""<c=@flavor>""""Маркетинговое исследование! В этом вся суть. Мне просто нужно знать, что едят эти квагганы.""""'"
-"'""<c=@flavor>""""May the sun god''s rays warm your back.""""—Qoetl</c>""'","<c=@flavor>«Пусть лучи бога солнца согревают твою спину.»—Кетль</c>"
 "'""<c=@flavor>""""Maybe you''ll run into someone that knows why these are floating.""""'","'""<c=@flavor>""""Может быть, вы встретите кого-то, кто знает, почему они парят.""""'"
 "'""<c=@flavor>""""More spikes mean Naknar''s mace better than mace with less spikes.""""'","'""<c=@flavor>""""Чем больше шипов"
 "'""<c=@flavor>""""Never know what you''ll step in around here.""""'","""<c=@flavor>""""Никогда не знаешь, на что наступишь здесь."""""
 "'""<c=@flavor>""""Never know when you''ll need one of these.""""'","'""<c=@flavor>""«Никогда не знаешь"
-"'""<c=@flavor>""""Not even close to the weirdest request I''ve fulfilled."""" —Zommoros.</c>""'","'""<c=@flavor>""""Даже близко не самая странная просьба, которую я выполнил."""" —Зомморос.</c>""'"
 "'""<c=@flavor>""""Not stealing. ''Acquiring.''""""'","'""<c=@flavor>""""Не воровство. ''Приобретение.''""""'"
 "'""<c=@flavor>""""One thing''s for sure: enemies you hit with this axe will hurt for a long time afterward.""""'","'""<c=@flavor>""""Одно можно сказать наверняка: враги, которых вы ударите этим топором, будут страдать ещё долго.""""'"
 "'""<c=@flavor>""""Operation Lion''s Pride was a great success!""""'","«""<c=@flavor>""""Операция «Львиная гордость» прошла с большим успехом!""""»"
@@ -121,11 +104,9 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 —Doolsileep</c>""'","«""<c=@flavor>""""Куакка делает эти украшенные драгоценностями раковины, чтобы защитить других от проклятий кровавой ведьмы. Может быть, однажды она сможет защитить и тебя.""""
 — Дулисилип</c>""»"
 "'""<c=@flavor>""""Quaggan wouldn''t know what to do if quaggan couldn''t breathe underwater.""""'","'""<c=@flavor>""""Квагган не знал бы"
-"'""<c=@flavor>""""Remember: ''dead or alive'' means dead.""""</c>""'","""<c=@flavor>""""Помните: ''живым или мёртвым'' означает мёртвый.""""</c>"""
 "'""<c=@flavor>""""Scholar told me all about matrixes and arcane stuffs. I couldn''t listen because of how shiny this shiny is.""""
 —Sik''klak</c>""'","'""<c=@flavor>""""Учёный рассказывал мне о матрицах и таинственных штуках. Я не мог слушать из-за того, насколько этот блестяшка блестит.""""
 —Сик'клак</c>""'"
-"'""<c=@flavor>""""Skale sure don''t like getting zapped with magic.""""</c>""'","'""<c=@flavor>""""Скейлы точно не любят, когда их жарит магия.""""</c>""'"
 "'""<c=@flavor>""""Skritt are highly attracted to shiny things. Some postulate it''s due to their enhanced subterranean vision.""""'","'""<c=@flavor>""""Скриттов сильно привлекают блестящие вещи. Некоторые предполагают, что это связано с их улучшенным подземным зрением.""""'"
 "'""<c=@flavor>""""Skritt rip these out of the mines all the time. Looks like this one survived the explosion. The skritt didn''t.""""
 —Faithspotter</c>""'","«""<c=@flavor>""""Скритты постоянно выдирают это из шахт. Похоже, этот пережил взрыв. Скритты — нет.""""
@@ -142,40 +123,15 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""Sometimes out here you ''scout'' something a little bigger than normal.""""'","'""<c=@flavor>""""Иногда здесь можно ''высмотреть'' кое-что покрупнее обычного.""""'"
 "'""<c=@flavor>""""Take care when fighting those steam beasts; who knows where they''ve been.""""'","""<c=@flavor>""""Будьте осторожны, сражаясь с этими паровыми зверями; кто знает, где они побывали."""""
 "'""<c=@flavor>""""Thanks for helping out. Bring back what you kill; it''ll help feed the soldiers.""""'","'""<c=@flavor>""""Спасибо за помощь. Приносите то, что убьёте; это поможет накормить солдат.""""'"
-"'""<c=@flavor>""""The enemy doesn''t stand a chance now!""""</c>""'",«<c=@flavor>»«Врагу теперь не поздоровится!»</c>»
 "'""<c=@flavor>""""The first arrow I shot was from a bow such as this. Nevermind about that. That was a long time ago.""""
 —Pact Crusader D''Stolt""'","'""<c=@flavor>""""Первая стрела, которую я выпустил, была из такого лука. Не обращай внимания. Это было давно.""""
 —Pact Crusader Д'Столт""'"
 "'""<c=@flavor>""""The mission isn''t done until you come home.""""'","'""<c=@flavor>""""Миссия не закончена"
 "'""<c=@flavor>""""The sea is as deep as fate''s are intertwined.""""'","'""<c=@flavor>""""Море так же глубоко, как переплетены судьбы.""""'"
-"'""<c=@flavor>""""There''s more rust than iron left here.""""</c>""'","'""<c=@flavor>""""Здесь больше ржавчины, чем железа.""""</c>""'"
 "'""<c=@flavor>""""There''s only one thing better than a sword...""""'","""'<c=@flavor>""""Есть только одна вещь лучше меча...""""'"
-"'""<c=@flavor>""""These aren''t ACTUALLY everburning. But they will keep your feet from getting charred up around here.""""
-—Brencis Quickblood</c>""'","'""<c=@flavor>""""На самом деле они НЕ вечногорящие. Но они не дадут вашим ногам обуглиться здесь.""""
-—Brencis Quickblood</c>""'"
-"'""<c=@flavor>""""These creatures are just fleeing the undead. It''s a shame that they encroach upon the village and have to be dealt with so harshly.""""
-—Quennida</c>""'","""<c=@flavor>""""Эти существа просто спасаются от нежити. Жаль, что они вторгаются в деревню и с ними приходится так сурово разбираться.""""
-—Квеннида</c>""'"
-"'""<c=@flavor>""""These crystals have some kind of energy. I''ve modified a standard bow with them. Let me know how it works.""""
-—Olenn</c>""'","'""<c=@flavor>""""В этих кристаллах есть какая-то энергия. Я модифицировал с их помощью обычный лук. Дай знать, как он работает.""""
-—Оленн</c>""'"
-"'""<c=@flavor>""""These sometimes misfire due to the skritt''s inability to maintain them.""""
-—Durmand Priory Field Guide to Skritt</c>""'","'""<c=@flavor>""""Иногда они дают осечку из-за того, что скритты не могут их обслуживать.""""
-—Полевой справочник скриттов Дурмандского Приората</c>""'"
 "'""<c=@flavor>""""These were stolen a while back. It''s nice to have them back.""""'","'""<c=@flavor>""""Они были украдены некоторое время назад. Приятно вернуть их.""""'"
-"'""<c=@flavor>""""These wrecks were from Lion''s Arch. I''d not mistake the mark of the Lionguard."""" -Danu</c>""'","'""<c=@flavor>""""Эти обломки были из Львиной Арки. Я бы не спутал знак Львиной Стражи."""" -Дану</c>""'"
-"'""<c=@flavor>""""They say the Ogres infuse these with some kind of magic. Thus the bond with their pets. We just collect them because it''s fun.""""
-—Avarr Sneakpaw</c>""'","'""<c=@flavor>""""Говорят, огры наполняют их какой-то магией. Отсюда и связь с их питомцами. Мы просто собираем их, потому что это весело.""""
-—Аварр Лапокрад</c>""'"
 "'""<c=@flavor>""""They won''t be using these on us anytime soon.""""'",«<c=@flavor>»«Им не удастся использовать это против нас в ближайшее время».
 "'""<c=@flavor>""""This axe has a keen edge. It''s better suited for cutting skritt tails or wasp stingers.""""'",<c=@flavor>«У этого топора острая кромка. Он лучше подходит для отрезания хвостов скриттов или жал ос».
-"'""<c=@flavor>""""This chest has been puzzling me for a while. I see no way to reach the mechanism through this field...unless you''re a tank-mounted harpoon.""""</c>""'","'""<c=@flavor>""""Этот сундук озадачивает меня уже некоторое время. Я не вижу способа добраться до механизма через это поле... если только ты не гарпун на танке.""""</c>""'"
-"'""<c=@flavor>""""This is a part from a steam creature. I''ve studied it all I could. Maybe you''ll find it more useful.""""
-—Garrius</c>""'","'""<c=@flavor>""""Это часть парового существа. Я изучил её, как мог. Возможно, она пригодится вам.""""
-—Гарриус</c>""'"
-"'""<c=@flavor>""""This is mostly fireproof. Calculations indicate that you''ll be fine if you aim the flamethrower away from you.""""
-—Jezza</c>""'","«""<c=@flavor>""""Это в основном огнеупорно. Расчёты показывают, что с вами все будет в порядке, если вы направите огнемет от себя.""""
-—Джезза</c>""»"
 "'""<c=@flavor>""""This is the smallest trident I''ve ever seen.""""'","'""<c=@flavor>""""Это самый маленький трезубец"
 "'""<c=@flavor>""""This looks unlike any type of gear we''ve seen before.""""'","'""<c=@flavor>""""Это не похоже ни на один тип снаряжения, который мы видели раньше.""""'"
 "'""<c=@flavor>""""This mill is a dangerous place. A sturdy helm will help cut down on any ''accidents.''""""'","""<c=@flavor>""""Эта мельница — опасное место. Прочный шлем поможет сократить количество «несчастных случаев»."""""
@@ -183,15 +139,9 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""This one''s for my favorite experiment: Will it smash?""""'","'""<c=@flavor>""""Этот для моего любимого эксперимента: Разобьётся ли он?""""'"
 "'""<c=@flavor>""""This way you don''t have to touch...them.""""'","""<c=@flavor>""""Так тебе не придётся прикасаться... к ним.""""'"
 "'""<c=@flavor>""""Too bad we can''t put them back on the people that made them.""""'","'""<c=@flavor>""""Жаль"
-"'""<c=@flavor>""""Undercoats of certain colors cause aetherovacillation at wavelengths that can enhance an armor''s durability...maybe. We''re still waiting on lab results.""""
-—Peacemaker Owta</c>""'","'""<c=@flavor>""""Подкладки определённых цветов вызывают аэровакуумные колебания на длинах волн, которые могут повышать прочность брони... возможно. Мы всё ещё ждём результаты лабораторных исследований.""""
-—Peacemaker Owta</c>""'"
 "'""<c=@flavor>""""Very interesting that the imp''s heart seems frozen but still works.""""'","'""<c=@flavor>""""Очень интересно, что сердце бесёнка кажется замороженным, но всё ещё работает.""""'"
 "'""<c=@flavor>""""Watch out for those destroyer fissures; one wrong move''ll get you a nasty burn.""""'","""<c=@flavor>""""Смотри в оба на эти разломы разрушителей; один неверный шаг — и получишь сильный ожог."""""
 "'""<c=@flavor>""""We aren''t expert marksmen the moment we awaken.""""'","'""<c=@flavor>""""Мы не становимся меткими стрелками в момент пробуждения.""""'"
-"'""<c=@flavor>""""We didn''t need to steal these. We have claws. We took thems because they are so shiny. Cheers!""""
-—Cakilak''ka</c>""'","'""<c=@flavor>""""Мы не нуждались в краже этого. У нас есть когти. Мы взяли их, потому что они такие блестящие. Ура!""""
-—Какилак'ка</c>""'"
 "'""<c=@flavor>""""We''ve found these useful in disrupting their shields.""""'",«<c=@flavor>»«Мы нашли их полезными для нарушения их щитов».
 "'""<c=@flavor>""""What did they think I''d be doing at Seraph''s Landing?""""'","""«<c=@flavor>»«Что, по их мнению, я делал бы в Лагере Серафимов?»"""
 "'""<c=@flavor>""""What you think you know can kill you just a quickly as what you don''t.""""'","'""<c=@flavor>""""То, что ты думаешь, что знаешь, может убить тебя так же быстро, как и то, чего ты не знаешь.""""'"
@@ -201,22 +151,16 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""<c=@flavor>""""With this you can end conversations as fast as you start ''em.""""'","'""<c=@flavor>""""С помощью этого вы можете заканчивать разговоры так же быстро, как и начинать их.""""'"
 "'""<c=@flavor>""""You can still feel magic pulsing through it''s veins.""""'","«""<c=@flavor>""""Вы всё ещё чувствуете, как магия пульсирует в его жилах.""""»"
 "'""<c=@flavor>""""You can''t ignore this land''s plea to protect it from the legendary evil.""""'","'""<c=@flavor>""""Вы не можете игнорировать мольбу этой земли защитить её от легендарного зла.""""'"
-"'""<c=@flavor>""""You don''t wanna know how many wrecked trebuchets I had to search through to find that.""""</c>""'","'""<c=@flavor>""""Лучше не спрашивай, сколько разбитых требушетов мне пришлось перерыть, чтобы найти это.""""</c>""'"
 "'""<c=@flavor>""""You don''t want to get any of this stuff on your hands. Crystal or ghost. Trust me.""""'","'""<c=@flavor>""""Ты не хочешь, чтобы эта дрянь попала тебе на руки. Кристалл или призрак. Поверь мне.""""'"
 "'""<c=@flavor>""""You don''t want your hands to damage the artifacts.""""'","'""<c=@flavor>""""Ты не хочешь, чтобы твои руки повредили артефакты.""""'"
-"'""<c=@flavor>""""You might need a little extra protection. These ghosts don''t take kindly to us destroying their precious wall a second time.""""
-—Legionnaire Bladechipper</c>""'","""<c=@flavor>""""Вам может понадобиться дополнительная защита. Эти призраки не обрадуются, если мы снова разрушим их драгоценную стену.""""
-—Легионер Осколок Лезвия</c>"""
 "'""<c=@flavor>""""You need these more than I do. I don''t wear shoes.""""'","«""<c=@flavor>""""Они нужны тебе больше, чем мне. Я не ношу обувь.""""»"
 "'""<c=@flavor>""""You need to learn all you can about your enemy if you''re going to defeat them.""""'","'""<c=@flavor>""""Вам нужно узнать всё о вашем враге"
 "'""<c=@flavor>""""You''d be surprised at the amount of information this staff can collect.""""'","'""<c=@flavor>""""Вы удивитесь, сколько информации может собрать этот посох.""""'"
 "'""<c=@flavor>""""You''d be surprised how many uses a fisher like me has for a shield.""""'","«""<c=@flavor>""""Вы бы удивились, сколько применений находит такой рыбак, как я, для щита.""""'"
 "'""<c=@flavor>""""You''d think it would be easier to clean the tar off these.""""'","""<c=@flavor>""""Можно подумать, счищать с них дёготь так уж легко."""""""
 "'""<c=@flavor>""""You''ll like the extra padding around the ears when the cannons fire.""""'","'""<c=@flavor>""""Вам понравится дополнительная прокладка вокруг ушей"
-"'""<c=@flavor>""""You''ll need this for fighting those nasty pirates.""""—Joukje</c>""'","<c=@flavor>«Тебе это понадобится для борьбы с этими гнусными пиратами.»—Жукье</c>"
 "'""<c=@flavor>""""You''re going to need one of these when fighting mighty foes like the jotun.""""'","'""<c=@flavor>""""Тебе понадобится один из них, когда будешь сражаться с могучими врагами, такими как ётун.""""'"
 "'""<c=@flavor>""""You''ve got some bite after all—just not enough to best the best.""""'","""<c=@flavor>""""Ты всё-таки умеешь кусаться — но недостаточно, чтобы одолеть лучшего."""""
-"'""<c=@flavor>""""Your enemy doesn''t stand a chance now!""""</c>""'","'""<c=@flavor>""""Твой враг теперь не имеет шансов!""""</c>""'"
 "'""<c=@flavor>""""Your standard dagger. Why don''t you let me sharpen that up for ya?""""'","'""<c=@flavor>""""Твой обычный кинжал. Почему бы тебе не дать мне его заточить?""""'"
 "'""<c=@flavor>He''s rich...with a burning passion!</c>'","«""<c=@flavor>Он богат... с жгучей страстью!</c>»"
 "'""<c=@flavor>It''s shaped like a hug.'","""<c=@flavor>Он похож на объятие.'"
@@ -230,18 +174,13 @@ Double-click to gain 50 luck.","С уходом Корага его оставш
 "'""A shark statue used to create Kamohoali''i Kotaki.'","«Статуя акулы, используемая для создания Камохоали'и Котаки»."
 "'""A turtle egg discovered after the battle with Soo-Won in Dragon''s End.'","'""Яйцо черепахи, найденное после битвы с Су-Вон в Логове Дракона.""'"
 "'""Automatically applies credit toward one of the Glory to a Legion achievements based on which you''ve chosen.'","'""Автоматически начисляет очки в одно из достижений «Слава легиону» в зависимости от вашего выбора.'"
-"'""Berserker''s Pirate """"Fork""""""'",«Пиратская „вилка“ берсерка»
 "'""Bring things to Mehsheh at Zephyr''s Trace to help out the villagers.'","«Принеси вещи Мехше в След Зефира, чтобы помочь жителям деревни»."
 "'""Checked out by Farir. Last seen in Champion''s Dawn.'","«""Выдан Фариром. Последний раз замечен в Заре Чемпиона»."
 "'""Coins are used to create high-level weapons at the Mystic Forge in Lion''s Arch. '",Монеты используются для создания высокоуровневого оружия в Таинственной кузнице в Львиной Арке.
 "'""Collect Vexa''s Golem Diagnostic Reader from her lab hidden in Fireheart Rise. Interact with the remains of Old Tom in the Uncategorized fractal to analyze them.'","«[Соберите диагностический считыватель голема Вексы из её лаборатории в Огненном восходе. Взаимодействуйте с останками Старого Тома во фрактале «Без категории», чтобы проанализировать их.]»"
 "'""Combine 3 key fragments to open the Mad King''s Chest in the Grand Piazza of Lion''s Arch.'","«Объедините 3 фрагмента ключа, чтобы открыть сундук Безумного Короля на Большой площади Львиной Арки.»"
-"'""Consumed automatically when acquired. Grants a small amount of volatile magic.
-Traditional Olmakhan song. <c=@flavor>""""No song so sweet as a young cub''s laugh...""""</c>""'","Потребляется автоматически при получении. Даёт небольшое количество нестабильной магии.
-Традиционная песня олмакханов. <c=@flavor>""""Нет песни слаще смеха детёныша...""""</c>"
 "'""Contains machetes and other items useful in exploring Dragon''s Stand. '","'""Содержит мачете и другие предметы, полезные для исследования Стойбища Дракона. '"
 "'""Contains rewards based on your world''s performance in the previous WvW season.'","'""Содержит награды"
-"'""Contains the book """"Expertise in Torch Crafting"""" and recipes for second-tier Rodgort''s Flame.""'",«Содержит книгу «Мастерство в создании факелов» и рецепты для пламени Родгорта второго уровня».
 "'""Created by combining a +4 Agony Infusion with the magical fissure located in Bloomhunger''s domain in the Swampland fractal.'","'""Создано путем объединения +4 инфузии агонии с магической трещиной, расположенной во владениях Блумхангер во фрактале Болото.'"
 "'""Deposit into a pile of carrots for the springers at Highjump Ranch or trade to Stablemaster Unja for special Adventurer''s Goods.'","'""Сложите в кучу моркови для спрингеров на ранчо Высокого Прыжка или обменяйте у конюха Унджи на особые товары искателя приключений.'"
 "'""Double click to travel to the Memory of Old Lion''s Arch or return from it.'","«Дважды щёлкните, чтобы переместиться в Память о Старом Львином Шпиле или вернуться обратно»"
@@ -261,7 +200,6 @@ Traditional Olmakhan song. <c=@flavor>""""No song so sweet as a young cub''s lau
 "'""Found in Greer''s Chest in the Mount Balrior raid.'","'""Найдено в сундуке Грира в рейде на Mount Balrior.'"
 "'""Found in Ura''s Chest in the Mount Balrior raid.'","'""Найдено в сундуке Уры в рейде на гору Бальриор.""'"
 "'""Gain entry to the Havoc''s Heir Airship.'",'«Получить доступ к дирижаблю Наследника Хаоса»'
-"'""Hammerhart''s """"Recovered"""" Hoard""'",«Сокровище «Восстановленное» Молотхарта»
 "'""I''m sure Isgarren won''t mind if I borrow this...'","«Я уверен, что Исгаррен не будет против, если я позаимствую это...»"
 "'""In which Zola''s father is afforded special hospitality during her engagement to King Thorn.'",«В котором отец Золы удостаивается особого гостеприимства во время её помолвки с королём Терном».
 "'""It''s unclear how old this cloth could be.'","'Непонятно, насколько древней может быть эта ткань.'"
@@ -289,7 +227,6 @@ Traditional Olmakhan song. <c=@flavor>""""No song so sweet as a young cub''s lau
 "'""This is perfect for creating Solus the Outlier''s vegetable oil.'","'""Это идеально подходит для создания растительного масла Солуса Изгоя.'"
 "'""This key will unlock one WvW Season 1 Reward Chest containing rewards based on your server''s performance in the previous season.'","'""Этот ключ откроет один сундук награды 1-го сезона WvW"
 "'""This quiver has a simple back strap to wear if you don''t have another back-slot item.'","'""Этот колчан имеет простой ремень для ношения на спине"
-"'""Travel to Noran''s """"Safe Room."""" Built to keep out his enemies and guard his valuables.""'","«""Путешествие в """"безопасную комнату"""" Норана """", построенную, чтобы держать врагов снаружи и охранять его ценности.""'"
 "'""Used to craft the legendary rifle precursor Man o'' War.'",«Используется для создания легендарного прекурсора винтовки «Морской конёк»».
 "'<c=@Flavor>Captain''s Council recommends avoiding direct contact with this substance.</c>""'","«<c=@Flavor>Совет капитана рекомендует избегать прямого контакта с этим веществом.</c>""'"
 "'<c=@flavor>""""If we factor in the rate of expansion there''s no way we contained the undead. Take this and burn away any corrupted flora or fauna.""""
@@ -301,61 +238,12 @@ Traditional Olmakhan song. <c=@flavor>""""No song so sweet as a young cub''s lau
 "'<c=@flavor>""""You''re telling me you haven''t gotten one of these weapons until now? That''s crazy.""""</c>""'","«<c=@flavor>""""Ты хочешь сказать, что до сих пор не раздобыл ни одного из этих видов оружия? Это безумие.""""</c>""»"
 "'<c=@flavor>Its baleful flames glow brighter as the hour of Adelbern''s curse draws near.</c>""'","'<c=@flavor>Его зловещее пламя разгорается ярче, когда приближается час проклятия Адельберна.</c>""'"
 '<c=flavor>I''m still working on the size issue.','<c=flavor>Я все ещё работаю над проблемой размера.'
-'Agent''s Pack',Сумка агента
-'Aviator''s Memory Box',Коробка воспоминаний авиатора
-'Bandit Sniper''s Outfit','Набор бандита-снайпера'
-'Bloody Prince''s Outfit','Наряд Кровавого принца'
-'Bottomless Belcher''s Bluff Kit',Набор «Бездонная глотка Бэлчера»
-'Chasing Tales: Storm''s Eye',В погоне за историями: Глаз бури
-'Chasing Tales: Wanderer''s Way',В погоне за историями: Путь странника
 "'Combine in the Mystic Forge to create Mini Pumpkin Jack O'' Lantern.""'","Смешайте в Таинственной кузнице, чтобы создать миниатюрный фонарь Джека."
-'Cook''s Outfit',«Наряд повара»
-'Devona''s Rest Veteran',Ветеран Покоя Девоны
 "'Dive Master Astora in Lion''s Arch can refine this infusion to upgrade it.""'","'Мастер дайвинга Астора в Львиной арке может переработать эту инфузию, чтобы улучшить её.""'"
-'Divinity''s Reach Supplies',Припасы Божественного предела
 "'Double-click to show Ela''s location.""'","'Дважды щёлкните, чтобы показать местоположение Элы.""'"
-'Dragon''s Breath',Драконье дыхание
-'Dragon''s Gaze',Взгляд Дракона
-'Duskk''s World 1 Super Boom Box','Супер-бумбокс мира 1 Даска'
-'Dwayna''s Throne',«Трон Двайны»
-'Elegant Noble''s Glider',Элегантный планер дворянина
-'Eve''s Prophecies Outfit',«Наряд пророчеств Евы»
-'Executioner''s Outfit',Наряд палача
-'Ferguson''s Crossing Veteran',Ветеран переправы Фергюсона
 "'Fractal Encryption Keys can be purchased inside Dessa''s lab in the Mistlock Observatory.""'","'Ключи шифрования фракталов можно приобрести в лаборатории Дессы в Обсерватории Туманной Лощины.""'"
-'Glint''s Bastion',Бастион Глинта
-'Grand Savant Valis the Learned''s Research Journal',Исследовательский журнал великого учёного Валиса Учёного
-'Grenth''s Regalia Outfit',Наряд «Одеяние Грента»
-'Gunnar''s Hold Veteran',Ветеран крепости Гуннар
-'Gwen''s Attire',Наряд Гвен
-'Jora''s Outfit','Наряд Йоры'
-'Kasmeer''s Regal Outfit',Королевский наряд Касмира
-'Legionnaire''s Chair',Кресло легионера
-'Lightbringer''s Pack',Ранец Светоносца
-'Logan''s Pact Marshal Outfit',Маршальский мундир Логана из Пакта
-'Luminate''s Backplate',Наспинная пластина Люмината
-'Mad King''s Outfit',Костюм Безумного короля
-'Miller''s Sound Veteran',Ветеран звука Миллера
-'Mining Rig Operator''s Seat',Кресло оператора буровой установки
-'Monk''s Outfit','Наряд монаха'
-'Nature''s Oath Outfit',Наряд «Клятва природы»
-'Oni Lord''s Throne',Трон владыки они
 "'Part of Zommoros''s favorite trades.""'",«Часть любимых сделок Зоммороса».
-'Pharaoh''s Regalia Outfit',Наряд «Регалии фараона»
-'Pirate Captain''s Outfit',Наряд «Капитан пиратов»
-'Priory''s History',История Приората
-'Raven''s Spirit Glider',Планер духа Ворона
-'Rox''s Pathfinder Outfit',Наряд следопыта Рокс
-'Scholar''s Pack',Рюкзак учёного
-'Seafarer''s Rest Veteran',Ветеран покоя морехода
-'Shiro''s Legacy Outfit',Наряд наследия Широ
-'Siren''s Call',Зов сирены
-'Slayer''s Outfit','Костюм убийцы'
 "'Someone in Sun''s Refuge might be interested in this.""'","«Кому-то в Убежище Солнца это может быть интересно."""
-'Sorcerer''s Cape Glider',Планер чародея
-'Sorrow''s Furnace Veteran',Ветеран Горнила Скорби
-'Storm Lord''s Throne',Трон Владыки Шторма
-'The Music of Divinity''s Reach',Музыка Божественного предела
 'The decree is only valid in the skritt king''s home territory of Brisban Wildlands.',Указ действителен только на родной территории короля скриттов — Брисбенские Пустоши.
 "'The recipe can be purchased from Lyhr in the Wizard''s Tower.""'",«Рецепт можно купить у Лира в Башне Чародея».
 "'Trade to alliance field quartermasters in Castora for a Forge Guard''s Pauldron.""'","Обменяйте у полевых интендантов альянса в Касторе на наплечник стража кузни."""
@@ -365,17 +253,7 @@ Traditional Olmakhan song. <c=@flavor>""""No song so sweet as a young cub''s lau
 "'Trade to alliance field quartermasters in Castora for a pair of Forge Guard''s Gloves.""'","'Обменяйте у полевых интендантов альянса в Касторе на пару перчаток Стражи Кузни.""'"
 "'Trade to alliance field quartermasters in Castora for a pair of Forge Guard''s Leggings.""'","Обменяйте у полевых интендантов альянса в Касторе на пару поножей Кузнечной стражи."""
 "'Trade to alliance field quartermasters in Castora for a pair of Restless Captain''s Leggings.""'","'Обменяйте у полевых интендантов альянса в Касторе на пару поножей Беспокойного капитана.""'"
-'Traveler''s Outfit',Наряд путешественника
 "'Use the box to randomly unlock a Black Lion wardrobe item you don''t already have. Some items—in particular mounts and some weapon sets—are less common than others. Preview to see everything available.""'",'Используйте коробку
-'Vigil''s Honor',Честь Дозора
-'Visionary''s Helm',Шлем Визионера
-'Warmaster''s Pack',Сумка военачальника
-'Whisper''s Secret',Тайна Шёпота
-'Witch''s Outfit',Наряд ведьмы
-'Wizard''s Tower Trial: Bronze',Испытание Башни Мага: Бронза
-'Wizard''s Tower Trial: Gold',Испытание Башни Мага: Золото
-'Wizard''s Tower Trial: Silver',Испытание Башни Мага: Серебро
-'Yak''s Bend Veteran',Ветеран «Ячьего изгиба»
 "'—Cakilak''ka</c>""'","'—Cakilak''ka</c>""'"
 "'—Hua''racche</c>""'","«—Хуа'ракке</c>""'"
 "'—Mrr''kkant</c>""'","'—Мрр''ккант</c>""'"


### PR DESCRIPTION
`frombatches` берёт хеш от английского как есть (`h = fnv1a_u16(en)`), а игра хеширует настоящий текст. У этих 98 записей в колонке `english` лежит не строка игры, а её SQL-выгрузка:

```
'"""Nature''s candy"" is not candy."'   →   "Nature's candy" is not candy.
```

Хеш считается от испорченного текста, поэтому в игре запись не совпадёт никогда. Правка её перевода не видна — на этом уже обожглись в PR #10, где канон «Львиный Архив» привели в мёртвой копии `items_125:208`, тогда как живая строка лежала в `items_041:214`.

У каждой из 98 распрямлённый английский совпадает со строкой, живущей в `items_001`, и та живая строка **переведена**. Уходит только недостижимая копия, перевод остаётся.

### Выброшено меньше, чем найдено

Записей с обёрткой по корпусу — 1 262, из них дубли живых строк — 239. Но признак порчи доказан только у 98:

| группа | записей | решение |
|---|---|---|
| SQL-обёртка (одинарная кавычка + удвоенные апострофы) | **98** | выброшены |
| только кавычки CSV вокруг значения | 141 | оставлены |
| оригинала нет нигде | 1 016 | оставлены |

**Почему 141 не тронуты.** Одних кавычек мало: в игре строка может законно стоять в кавычках — `"He's taken over! He killed them!"`. Проверил гипотезу «весь батч закавычен конвейером»: сплошной закавыченности нет ни в одном файле, доли от 2% (`new_001`) до 62% (`zone_001`). Значит это свойство отдельных строк, и доказательства порчи нет.

**Почему 1 016 не тронуты.** Распрямление даёт правдоподобный текст, но подтверждения нет ни в батчах, ни в дампе сервера. Дамп для таких строк и не оракул: он покрывает короткие названия (медиана 31 символ), а описаний предметов в нём нет вовсе — в `items_041` совпадений 0 из 501.

### Гейты

* изменён один файл, записей 464 → 366, удалено ровно 98;
* оставшиеся записи не изменились ни на байт — сверка с `git show HEAD:`;
* у всех 98 удалённых живая переведённая копия на месте (проверено после удаления).

### Что дальше

Чтобы записи ушли из bin, нужна сборка с `--prune`: словарь теряет запись только от ОТСУТСТВИЯ строки в батчах.

Штатный `dict_tool.py unquote` эту работу не закрывает: он снимает один слой обёртки, а здесь их до трёх (SQL поверх CSV), и из 1 262 записей он распрямит 85. Если решите чинить остаток — команду стоит научить снимать слои итеративно.