### PR TITLE
Корпус: перевод от другого предмета — 13 строк

### DIFF
--- a/misc/misc_002.csv
+++ b/misc/misc_002.csv
@@ -93,16 +93,16 @@ english,translate
 %str1%%str2%Dragon Slayer Longbow%str3%%str4%,%str1%%str2%Лазурный длинный лук убийцы драконов%str3%%str4%
 %str1%%str2%Dragon Slayer Rifle%str3%%str4%,%str1%%str2%Лазурная Dragon Slayer Rifle%str3%%str4%
 %str1%%str2%Dragon Slayer Short Bow%str3%%str4%,%str1%%str2%Short Bow зверобоя%str3%%str4%
-%str1%%str2%Dragon Slayer Staff%str3%%str4%,%str1%%str2%Лазурный факел убийцы драконов%str3%%str4%
+%str1%%str2%Dragon Slayer Staff%str3%%str4%,%str1%%str2%Посох убийцы драконов%str3%%str4%
 %str1%%str2%Dragon Slayer Warhorn%str3%%str4%,%str1%%str2%Лазурный боевой рог убийцы драконов%str3%%str4%
 %str1%%str2%Dredge Spear%str3%%str4%,%str1%%str2%Золочёное копьё%str3%%str4%
 %str1%%str2%Druid's Shoulderguards%str3%%str4%,%str1%%str2%Оплечья лесовода%str3%%str4%
 %str1%%str2%Duelist Gloves%str3%%str4%,%str1%%str2%Перчатки каббалиста%str3%%str4%
-%str1%%str2%Duelist Mask%str3%%str4%,%str1%%str2%Куртка каббалиста%str3%%str4%
+%str1%%str2%Duelist Mask%str3%%str4%,%str1%%str2%Маска дуэлянта%str3%%str4%
 %str1%%str2%Duelist Pants%str3%%str4%,%str1%%str2%Сапоги каббалиста%str3%%str4%
 %str1%%str2%Ebon Epaulets%str3%%str4%,%str1%%str2%Эполеты адепта%str3%%str4%
-%str1%%str2%Fiery Dragon Slayer Axe%str3%%str4%,%str1%%str2%Лазурная булава убийцы драконов%str3%%str4%
-%str1%%str2%Fractal Focus%str3%%str4%,%str1%%str2%Карнавальный посох%str3%%str4%
+%str1%%str2%Fiery Dragon Slayer Axe%str3%%str4%,%str1%%str2%Огненный топор убийцы драконов%str3%%str4%
+%str1%%str2%Fractal Focus%str3%%str4%,%str1%%str2%Фрактальный фокус%str3%%str4%
 %str1%%str2%Full Moon Greatsword%str3%%str4%,%str1%%str2%Двуручный меч кровавой луны%str3%%str4%
 %str1%%str2%Fused Dagger%str3%%str4%,%str1%%str2%Аурический кинжал%str3%%str4%
 %str1%%str2%Greatbow of the Broken Voice%str3%%str4%,%str1%%str2%Бастион Сломленного Голоса%str3%%str4%
@@ -110,9 +110,9 @@ english,translate
 %str1%%str2%Hearty Chef's Backpack%str3%%str4%,%str1%%str2%Базовый рюкзак повара%str3%%str4%
 %str1%%str2%Herald of the Broken Voice%str3%%str4%,%str1%%str2%Клинок Сломленного Голоса%str3%%str4%
 %str1%%str2%Herald's Shield%str3%%str4%,%str1%%str2%Щит хаоса%str3%%str4%
-%str1%%str2%Hero's Dagger%str3%%str4%,%str1%%str2%Молот хаоса%str3%%str4%
+%str1%%str2%Hero's Dagger%str3%%str4%,%str1%%str2%Кинжал героя%str3%%str4%
 %str1%%str2%Hero's Pistol%str3%%str4%,%str1%%str2%Бронзовый пистолет%str3%%str4%
-%str1%%str2%Hero's Torch%str3%%str4%,%str1%%str2%Меч хаоса%str3%%str4%
+%str1%%str2%Hero's Torch%str3%%str4%,%str1%%str2%Факел героя%str3%%str4%
 %str1%%str2%Hoofed Shoes%str3%%str4%,%str1%%str2%Клинковые туфли%str3%%str4%
 %str1%%str2%Impaler of the Sunless%str3%%str4%,%str1%%str2%Клинок Бессолнечного%str3%%str4%
 %str1%%str2%Leather Aquabreather%str3%%str4%,%str1%%str2%Глубинная аквамаска%str3%%str4%
@@ -139,7 +139,7 @@ english,translate
 %str1%%str2%Steel Shield%str3%%str4%,%str1%%str2%Аурический щит%str3%%str4%
 %str1%%str2%Stride of Koda%str3%%str4%,%str1%%str2%Бремя Коды%str3%%str4%
 %str1%%str2%Studded Helm%str3%%str4%,%str1%%str2%Полосный шлем%str3%%str4%
-%str1%%str2%Student Shoes%str3%%str4%,%str1%%str2%Куртка адепта%str3%%str4%
+%str1%%str2%Student Shoes%str3%%str4%,%str1%%str2%Студенческие туфли%str3%%str4%
 %str1%%str2%Tenebrous Greatsword%str3%%str4%,%str1%%str2%Двуручный меч хаоса%str3%%str4%
 %str1%%str2%Tengu Dagger%str3%%str4%,%str1%%str2%Кинжал чаков%str3%%str4%
 %str1%%str2%Tengu Pistol%str3%%str4%,%str1%%str2%Пистолет чаков%str3%%str4%

--- a/new/new_096.csv
+++ b/new/new_096.csv
@@ -174,7 +174,7 @@ Strong Attacks,Сильные атаки
 "Strong Echo[pl:""Echoes""] of the Shiverpeaks",Сильное эхо Шиверпикс
 Strong Pistol Attacks,Сильные атаки пистолетом
 Strong Pollen Fever Salve,Мазь от сильной аллергии на пыльцу
-Strong Scepter Attacks • Stuns • Might,Сильные атаки посохом • Оглушение • Мощь
+Strong Scepter Attacks • Stuns • Might,Сильные атаки скипетром • Оглушение • Мощь
 "Strong against Prime Light constructs, but weak to their attacks.","Эффективен против конструкций из чистой энергии света, но уязвим к их атакам."
 "Strong against Static Light constructs, but weak to their attacks.","Эффективен против статических световых конструкций, но уязвим к их атакам."
 "Strong against Synergetic Light constructs, but weak to their attacks.","Эффективен против синергетических световых конструкций, но уязвим к их атакам."

--- a/ui/ui_012.csv
+++ b/ui/ui_012.csv
@@ -172,7 +172,7 @@ english,translate
 %str1%%str2%Shadewort%str3%%str4%,%str1%%str2%Теневая трава%str3%%str4%
 %str1%%str2%Shadow Axe%str3%%str4%,%str1%%str2%Теневой топор%str3%%str4%
 %str1%%str2%Shadow Dagger%str3%%str4%,%str1%%str2%Теневой кинжал%str3%%str4%
-%str1%%str2%Shadow Hammer%str3%%str4%,%str1%%str2%Кинжал Абаддона%str3%%str4%
+%str1%%str2%Shadow Hammer%str3%%str4%,%str1%%str2%Теневой молот%str3%%str4%
 %str1%%str2%Shadow Mace%str3%%str4%,%str1%%str2%Теневая булава%str3%%str4%
 %str1%%str2%Shadow of Grenth%str3%%str4%,%str1%%str2%Тень Грента%str3%%str4%
 %str1%%str2%Shadow of the Dragon Gloves%str3%%str4%,%str1%%str2%Перчатки тени дракона%str3%%str4%
@@ -420,7 +420,7 @@ english,translate
 %str1%%str2%Soaring Pistol%str3%%str4%,%str1%%str2%Парящий пистолет%str3%%str4%
 %str1%%str2%Soaring Rifle%str3%%str4%,%str1%%str2%Парящая винтовка%str3%%str4%
 %str1%%str2%Soaring Scepter%str3%%str4%,%str1%%str2%Парящий скипетр%str3%%str4%
-%str1%%str2%Soaring Shield%str3%%str4%,%str1%%str2%Цепной меч%str3%%str4%
+%str1%%str2%Soaring Shield%str3%%str4%,%str1%%str2%Парящий щит%str3%%str4%
 %str1%%str2%Soaring Short Bow%str3%%str4%,%str1%%str2%Парящий короткий лук%str3%%str4%
 %str1%%str2%Soaring Staff%str3%%str4%,%str1%%str2%Парящий посох%str3%%str4%
 %str1%%str2%Soaring Torch%str3%%str4%,%str1%%str2%Парящий факел%str3%%str4%
@@ -458,7 +458,7 @@ english,translate
 %str1%%str2%Sorcerer's Livery%str3%%str4%,%str1%%str2%Одеяние колдуна%str3%%str4%
 %str1%%str2%Sorcerer's Masque%str3%%str4%,%str1%%str2%Маска колдуна%str3%%str4%
 %str1%%str2%Sorcerer's Pants%str3%%str4%,%str1%%str2%Штаны колдуна%str3%%str4%
-%str1%%str2%Sorcerer's Shoes%str3%%str4%,%str1%%str2%Сапоги колдуна%str3%%str4%
+%str1%%str2%Sorcerer's Shoes%str3%%str4%,%str1%%str2%Туфли чародея%str3%%str4%
 %str1%%str2%Soul of Koda%str3%%str4%,%str1%%str2%Душа Коды%str3%%str4%
 %str1%%str2%Soulbeast Pads%str3%%str4%,%str1%%str2%Ступни зверодушника%str3%%str4%
 %str1%%str2%Soulbeast's Dagger%str3%%str4%,%str1%%str2%Кинжал душезверя%str3%%str4%

--- a/ui/ui_013.csv
+++ b/ui/ui_013.csv
@@ -51,7 +51,7 @@ english,translate
 %str1%%str2%Spectral Longbow%str3%%str4%,%str1%%str2%Призрачный длинный лук%str3%%str4%
 %str1%%str2%Spectral Mace%str3%%str4%,%str1%%str2%Призрачная булава%str3%%str4%
 %str1%%str2%Spectral Pistol%str3%%str4%,%str1%%str2%Пистолет «Zodiac»%str3%%str4%
-%str1%%str2%Spectral Rifle%str3%%str4%,%str1%%str2%Карнавальный факел%str3%%str4%
+%str1%%str2%Spectral Rifle%str3%%str4%,%str1%%str2%Спектральная винтовка%str3%%str4%
 %str1%%str2%Spectral Shield%str3%%str4%,%str1%%str2%Призрачный щит%str3%%str4%
 %str1%%str2%Spectral Short Bow%str3%%str4%,%str1%%str2%Призрачный короткий лук%str3%%str4%
 %str1%%str2%Spectral Staff%str3%%str4%,%str1%%str2%Призрачный посох%str3%%str4%
@@ -373,7 +373,7 @@ english,translate
 %str1%%str2%Tempered Scale Legs%str3%%str4%,%str1%%str2%Закалённые чешуйчатые поножи%str3%%str4%
 %str1%%str2%Tempered Scale Pauldrons%str3%%str4%,%str1%%str2%Закалённые чешуйчатые наплечники%str3%%str4%
 %str1%%str2%Tempered Spinal Blades%str3%%str4%,%str1%%str2%Закалённые спинные лезвия%str3%%str4%
-%str1%%str2%Tempest Axe%str3%%str4%,%str1%%str2%Булава Инквеста%str3%%str4%
+%str1%%str2%Tempest Axe%str3%%str4%,%str1%%str2%Топор бури%str3%%str4%
 %str1%%str2%Tempest Dagger%str3%%str4%,%str1%%str2%Кинжал Инквеста%str3%%str4%
 "%str1%%str2%Tempest Focus[pl:""Foci""]%str3%%str4%",%str1%%str2%[Фокус|фокуса|фокусов] «Буря»%str3%%str4%
 %str1%%str2%Tempest Greatsword%str3%%str4%,%str1%%str2%Двуручный меч бури%str3%%str4%


### PR DESCRIPTION
`Duelist Mask` названа «Курткой каббалиста», `Fractal Focus` — «Карнавальным посохом». Игрок видит в инвентаре чужое имя, а **линтер молчит**: он считает потерянным только название внутри фразы, здесь же строка целиком является названием. Класс ловится лишь сверкой с оригиналом.

| EN | было | стало |
|---|---|---|
| `Dragon Slayer Staff` | Лазурный **факел** убийцы драконов | **Посох** убийцы драконов |
| `Duelist Mask` | **Куртка каббалиста** | **Маска дуэлянта** |
| `Hero's Torch` | **Меч хаоса** | **Факел героя** |
| `Shadow Hammer` | **Кинжал Абаддона** | **Теневой молот** |
| `Spectral Rifle` | **Карнавальный факел** | **Спектральная винтовка** |
| `Tempest Axe` | **Булава Инквеста** | **Топор бури** |

### Как отбирались

Признак строгий: в оригинале тип вещи назван ровно один раз, в переводе стоит **другой** известный тип, а верного нет вовсе. Синонимы учтены — `Shoes` бывают и туфлями, и ботинками, и башмаками, `Mace` бывает шестопёром; такие пары под правило не подпадают, иначе в партию попало бы 15 законных «башмаков» и «оплечий».

### Чем чинилось

Не выдумкой, а **подстановкой из корпуса** (README, «прежде чем переводить руками»): та же английская строка уже переведена в слое имён, оттуда и взята готовая форма — 12 строк из 13.

Тринадцатая — `Strong Scepter Attacks`, где образца нет и правится только слово типа: «атаки **посохом**» → «атаки **скипетром**».

### Не вошло

`Maguuma Mace Skin[s]` — «Магумский молот[|а|ы]». Там смена рода («молот» мужского, «булава» женского) развалила бы группу форм, а образца в корпусе нет: нужна ручная переделка всей строки.

### Гейты

* тронуто ровно 13 записей в 4 файлах, ничего сверх плана;
* колонка `english` не менялась;
* набор плейсхолдеров в каждой строке совпадает с прежним — проверено отдельно, названия здесь обёрнуты в `%str1%%str2%…%str3%%str4%`;
* дельта линтера 0/0.