### PR TITLE
Корпус: семейство `*forged` — 28 строк

### DIFF
--- a/pn/pn_items_091.csv
+++ b/pn/pn_items_091.csv
@@ -483,18 +483,18 @@ Shaman's Sneakthief Sandals of the Traveler,Сандалии Скрытного 
 Shaman's Sneakthief Shoulderguards of Divinity,Наплечники «Скрытный вор» из Божественного Предела
 Shaman's Sneakthief Shoulderguards of the Flock,Наплечники шамана-ворчуна «Стая»
 Shaman's Stormforged Axe,"Топор шамана, выкованный в буре"
-Shaman's Stormforged Dagger,Штормокованный кинжал шамана
-Shaman's Stormforged Focus,Шаманский штормокованный фокус
+Shaman's Stormforged Dagger,Бурекованый кинжал шамана
+Shaman's Stormforged Focus,Шаманский бурекованый фокус
 Shaman's Stormforged Greatsword,"Двуручный меч шамана, выкованный в буре"
 Shaman's Stormforged Hammer,Бурекованый молот шамана
 Shaman's Stormforged Longbow,"Длинный лук шамана, выкованный во время бури"
-Shaman's Stormforged Mace,Штормокованная булава шамана
-Shaman's Stormforged Pistol,Штормокованный пистолет шамана
+Shaman's Stormforged Mace,Бурекованая булава шамана
+Shaman's Stormforged Pistol,Бурекованый пистолет шамана
 Shaman's Stormforged Rifle,Штурмовая винтовка шамана
-Shaman's Stormforged Scepter,Штормокованный скипетр шамана
-Shaman's Stormforged Shield,Штормокованный щит шамана
+Shaman's Stormforged Scepter,Бурекованый скипетр шамана
+Shaman's Stormforged Shield,Бурекованый щит шамана
 Shaman's Stormforged Short Bow,"Короткий лук шамана, выкованный во время бури"
-Shaman's Stormforged Staff,Штормокованный посох шамана
+Shaman's Stormforged Staff,Бурекованый посох шамана
 Shaman's Stormforged Sword,"Клинок шамана, закалённый бурей"
 Shaman's Stormforged Torch,Бурекованый факел шамана
 Shaman's Stormforged Warhorn,"Боевой рог шамана, выкованный в буре"

--- a/ui/ui_012.csv
+++ b/ui/ui_012.csv
@@ -291,22 +291,22 @@ english,translate
 %str1%%str2%Skull Masque%str3%%str4%,%str1%%str2%Маска черепа%str3%%str4%
 %str1%%str2%Skullcap of Dhuum%str3%%str4%,%str1%%str2%Тюбетейка Дуума%str3%%str4%
 %str1%%str2%Skybringer%str3%%str4%,%str1%%str2%Огненосец%str3%%str4%
-%str1%%str2%Skyforged Axe%str3%%str4%,%str1%%str2%Морозокованый топор%str3%%str4%
-%str1%%str2%Skyforged Dagger%str3%%str4%,%str1%%str2%Морозокованый кинжал%str3%%str4%
-%str1%%str2%Skyforged Focus%str3%%str4%,%str1%%str2%Морозокованый фокус%str3%%str4%
+%str1%%str2%Skyforged Axe%str3%%str4%,%str1%%str2%Небесный топор%str3%%str4%
+%str1%%str2%Skyforged Dagger%str3%%str4%,%str1%%str2%Небесный кинжал%str3%%str4%
+%str1%%str2%Skyforged Focus%str3%%str4%,%str1%%str2%Небесный фокус%str3%%str4%
 %str1%%str2%Skyforged Greatsword%str3%%str4%,%str1%%str2%Небесный двуручный меч%str3%%str4%
-%str1%%str2%Skyforged Hammer%str3%%str4%,%str1%%str2%Морозокованый молот%str3%%str4%
-%str1%%str2%Skyforged Longbow%str3%%str4%,%str1%%str2%Морозокованый длинный лук%str3%%str4%
-%str1%%str2%Skyforged Mace%str3%%str4%,%str1%%str2%Морозокованая булава%str3%%str4%
-%str1%%str2%Skyforged Pistol%str3%%str4%,%str1%%str2%Морозокованый пистолет%str3%%str4%
-%str1%%str2%Skyforged Rifle%str3%%str4%,%str1%%str2%Морозокованая винтовка%str3%%str4%
-%str1%%str2%Skyforged Scepter%str3%%str4%,%str1%%str2%Морозокованый скипетр%str3%%str4%
-%str1%%str2%Skyforged Shield%str3%%str4%,%str1%%str2%Морозокованый щит%str3%%str4%
-%str1%%str2%Skyforged Short Bow%str3%%str4%,%str1%%str2%Морозокованый короткий лук%str3%%str4%
-%str1%%str2%Skyforged Staff%str3%%str4%,%str1%%str2%Морозокованый посох%str3%%str4%
-%str1%%str2%Skyforged Sword%str3%%str4%,%str1%%str2%Морозокованый меч%str3%%str4%
-%str1%%str2%Skyforged Torch%str3%%str4%,%str1%%str2%Морозокованый факел%str3%%str4%
-%str1%%str2%Skyforged Warhorn%str3%%str4%,%str1%%str2%Морозокованый боевой рог%str3%%str4%
+%str1%%str2%Skyforged Hammer%str3%%str4%,%str1%%str2%Небесный молот%str3%%str4%
+%str1%%str2%Skyforged Longbow%str3%%str4%,%str1%%str2%Небесный длинный лук%str3%%str4%
+%str1%%str2%Skyforged Mace%str3%%str4%,%str1%%str2%Небесная булава%str3%%str4%
+%str1%%str2%Skyforged Pistol%str3%%str4%,%str1%%str2%Небесный пистолет%str3%%str4%
+%str1%%str2%Skyforged Rifle%str3%%str4%,%str1%%str2%Небесная винтовка%str3%%str4%
+%str1%%str2%Skyforged Scepter%str3%%str4%,%str1%%str2%Небесный скипетр%str3%%str4%
+%str1%%str2%Skyforged Shield%str3%%str4%,%str1%%str2%Небесный щит%str3%%str4%
+%str1%%str2%Skyforged Short Bow%str3%%str4%,%str1%%str2%Небесный короткий лук%str3%%str4%
+%str1%%str2%Skyforged Staff%str3%%str4%,%str1%%str2%Небесный посох%str3%%str4%
+%str1%%str2%Skyforged Sword%str3%%str4%,%str1%%str2%Небесный меч%str3%%str4%
+%str1%%str2%Skyforged Torch%str3%%str4%,%str1%%str2%Небесный факел%str3%%str4%
+%str1%%str2%Skyforged Warhorn%str3%%str4%,%str1%%str2%Небесный боевой рог%str3%%str4%
 %str1%%str2%Skyscale Axe%str3%%str4%,%str1%%str2%Топор скайскейля%str3%%str4%
 %str1%%str2%Skyscale Dagger%str3%%str4%,%str1%%str2%Кинжал скайскейла%str3%%str4%
 %str1%%str2%Skyscale Focus%str3%%str4%,%str1%%str2%Фокус скайскейля%str3%%str4%

--- a/ui/ui_013.csv
+++ b/ui/ui_013.csv
@@ -227,18 +227,18 @@ english,translate
 %str1%%str2%Stormcaller Torch%str3%%str4%,%str1%%str2%Факел заклинателя бури%str3%%str4%
 %str1%%str2%Stormcaller Warhorn%str3%%str4%,%str1%%str2%Боевой рог зова бури%str3%%str4%
 %str1%%str2%Stormforged Axe%str3%%str4%,%str1%%str2%Топор бури%str3%%str4%
-%str1%%str2%Stormforged Dagger%str3%%str4%,%str1%%str2%Штормокованный кинжал%str3%%str4%
+%str1%%str2%Stormforged Dagger%str3%%str4%,%str1%%str2%Бурекованый кинжал%str3%%str4%
 %str1%%str2%Stormforged Focus%str3%%str4%,%str1%%str2%Фокус бури%str3%%str4%
 %str1%%str2%Stormforged Greatsword%str3%%str4%,%str1%%str2%Двуручный меч бури%str3%%str4%
 %str1%%str2%Stormforged Hammer%str3%%str4%,%str1%%str2%Бурекованый молот%str3%%str4%
 %str1%%str2%Stormforged Longbow%str3%%str4%,%str1%%str2%Длинный лук бури%str3%%str4%
-%str1%%str2%Stormforged Mace%str3%%str4%,%str1%%str2%Штормокованная булава%str3%%str4%
-%str1%%str2%Stormforged Pistol%str3%%str4%,%str1%%str2%Штормокованный пистолет%str3%%str4%
+%str1%%str2%Stormforged Mace%str3%%str4%,%str1%%str2%Бурекованая булава%str3%%str4%
+%str1%%str2%Stormforged Pistol%str3%%str4%,%str1%%str2%Бурекованый пистолет%str3%%str4%
 %str1%%str2%Stormforged Rifle%str3%%str4%,%str1%%str2%Штурмовая винтовка%str3%%str4%
-%str1%%str2%Stormforged Scepter%str3%%str4%,%str1%%str2%Штормокованный скипетр%str3%%str4%
-%str1%%str2%Stormforged Shield%str3%%str4%,%str1%%str2%Штормокованный щит%str3%%str4%
+%str1%%str2%Stormforged Scepter%str3%%str4%,%str1%%str2%Бурекованый скипетр%str3%%str4%
+%str1%%str2%Stormforged Shield%str3%%str4%,%str1%%str2%Бурекованый щит%str3%%str4%
 %str1%%str2%Stormforged Short Bow%str3%%str4%,%str1%%str2%Короткий лук бури%str3%%str4%
-%str1%%str2%Stormforged Staff%str3%%str4%,%str1%%str2%Штормокованный посох%str3%%str4%
+%str1%%str2%Stormforged Staff%str3%%str4%,%str1%%str2%Бурекованый посох%str3%%str4%
 %str1%%str2%Stormforged Sword%str3%%str4%,%str1%%str2%Меч бури%str3%%str4%
 %str1%%str2%Stormforged Torch%str3%%str4%,%str1%%str2%Бурекованый факел%str3%%str4%
 %str1%%str2%Stormforged Warhorn%str3%%str4%,%str1%%str2%Боевой рог бури%str3%%str4%


### PR DESCRIPTION
В игре четыре родственных набора оружия, и русские имена у них разные:

| EN | канон корпуса | против |
|---|---|---|
| `Mistforged` | туманнокованый 150 | — |
| `Stormforged` | бурекованый 47 | **штормокованный 13** |
| `Frostforged` | морозокованый 19 | — |
| `Skyforged` | Небесный 21 | **морозокованый 15** |

### `Skyforged` → «морозокованый», 15 строк

Это не разнобой, а **чужое имя**: так зовётся `Frostforged`, и в инвентаре два разных набора сливаются в один. Все 15 строк лежат подряд в `ui_012`, а слой те же предметы зовёт «Небесными» (`pn_items_093`: «Небесный топор», «Небесная булава», «Небесный фокус») — и это же большинство по корпусу.

| EN | было | стало |
|---|---|---|
| `Skyforged Axe` | **Морозокованый** топор | **Небесный** топор |
| `Skyforged Mace` | **Морозокованая** булава | **Небесная** булава |

### `Stormforged` → «штормокованный», 13 строк

Здесь настоящий разнобой: своё имя есть у обеих сторон, но корпус пишет «бурекованый» вчетверо чаще. Заодно уходит лишняя «н» — отглагольное прилагательное без приставки и зависимых слов пишется с одной.

Правится основа, окончание остаётся: «морозокован+ая» → «небесн+ая», «штормокованн+ый» → «бурекован+ый». Род и падеж этим сохраняются.

### Не тронуто

Прочий разнобой `Skyforged`: «Небесно-закалённый» (7), «небесной ковки» (3), «в небесной кузнице» (2), «Небесно-кованый» (2), «Кованый небом» (1). Свести их к одному — решение о каноне, а не механика; в этой партии только чужое имя.

### Гейты

* тронуто ровно 28 записей в 3 файлах, ничего сверх плана;
* в каждой строке изменилось ровно одно слово — проверено отдельно;
* колонка `english` не менялась, дельта линтера 0/0;
* остаток класса — ноль.