### PR TITLE
Корпус: набор `Dominator` отделён от `Abomination` — 13 строк

### DIFF
--- a/misc/misc_002.csv
+++ b/misc/misc_002.csv
@@ -77,18 +77,18 @@ english,translate
 %str1%%str2%Destroyer Greatsword%str3%%str4%,%str1%%str2%Двуручный меч зверобоя%str3%%str4%
 %str1%%str2%Devout Mantle%str3%%str4%,%str1%%str2%Накидка Авроры%str3%%str4%
 %str1%%str2%Devout Shoes%str3%%str4%,%str1%%str2%Туфли Авроры%str3%%str4%
-%str1%%str2%Dominator Dagger%str3%%str4%,%str1%%str2%Кинжал Мерзости%str3%%str4%
-%str1%%str2%Dominator Focus%str3%%str4%,%str1%%str2%Фокус Мерзости%str3%%str4%
-%str1%%str2%Dominator Greatsword%str3%%str4%,%str1%%str2%Двуручный меч Мерзости%str3%%str4%
-%str1%%str2%Dominator Hammer%str3%%str4%,%str1%%str2%Молот Мерзости%str3%%str4%
-%str1%%str2%Dominator Longbow%str3%%str4%,%str1%%str2%Длинный лук Мерзости%str3%%str4%
-%str1%%str2%Dominator Pistol%str3%%str4%,%str1%%str2%Пистолет Мерзости%str3%%str4%
-%str1%%str2%Dominator Rifle%str3%%str4%,%str1%%str2%Винтовка Мерзости%str3%%str4%
-%str1%%str2%Dominator Scepter%str3%%str4%,%str1%%str2%Скипетр Мерзости%str3%%str4%
-%str1%%str2%Dominator Short Bow%str3%%str4%,%str1%%str2%Короткий лук Мерзости%str3%%str4%
-%str1%%str2%Dominator Staff%str3%%str4%,%str1%%str2%Посох Мерзости%str3%%str4%
-%str1%%str2%Dominator Torch%str3%%str4%,%str1%%str2%Факел Мерзости%str3%%str4%
-%str1%%str2%Dominator Warhorn%str3%%str4%,%str1%%str2%Боевой рог Мерзости%str3%%str4%
+%str1%%str2%Dominator Dagger%str3%%str4%,%str1%%str2%Кинжал доминатора%str3%%str4%
+%str1%%str2%Dominator Focus%str3%%str4%,%str1%%str2%Фокус доминатора%str3%%str4%
+%str1%%str2%Dominator Greatsword%str3%%str4%,%str1%%str2%Двуручный меч доминатора%str3%%str4%
+%str1%%str2%Dominator Hammer%str3%%str4%,%str1%%str2%Молот доминатора%str3%%str4%
+%str1%%str2%Dominator Longbow%str3%%str4%,%str1%%str2%Длинный лук доминатора%str3%%str4%
+%str1%%str2%Dominator Pistol%str3%%str4%,%str1%%str2%Пистолет доминатора%str3%%str4%
+%str1%%str2%Dominator Rifle%str3%%str4%,%str1%%str2%Винтовка доминатора%str3%%str4%
+%str1%%str2%Dominator Scepter%str3%%str4%,%str1%%str2%Скипетр доминатора%str3%%str4%
+%str1%%str2%Dominator Short Bow%str3%%str4%,%str1%%str2%Короткий лук доминатора%str3%%str4%
+%str1%%str2%Dominator Staff%str3%%str4%,%str1%%str2%Посох доминатора%str3%%str4%
+%str1%%str2%Dominator Torch%str3%%str4%,%str1%%str2%Факел доминатора%str3%%str4%
+%str1%%str2%Dominator Warhorn%str3%%str4%,%str1%%str2%Боевой рог доминатора%str3%%str4%
 %str1%%str2%Dragon Slayer Focus%str3%%str4%,%str1%%str2%Лазурный фокус убийцы драконов%str3%%str4%
 %str1%%str2%Dragon Slayer Longbow%str3%%str4%,%str1%%str2%Лазурный длинный лук убийцы драконов%str3%%str4%
 %str1%%str2%Dragon Slayer Rifle%str3%%str4%,%str1%%str2%Лазурная Dragon Slayer Rifle%str3%%str4%

--- a/pn/pn_items_035.csv
+++ b/pn/pn_items_035.csv
@@ -308,7 +308,7 @@ Domain of Vabbi: Commander's Choice Chest,Domain of Vabbi: Сундук выбо
 Domain of Vabbi: Hero's Choice Chest,Domain of Vabbi: Сундук выбора героя
 Dominator Axe,Топор доминатора
 Dominator Axe Skin,Облик топора «Доминатор»
-Dominator Dagger,Кинжал повелителя
+Dominator Dagger,Кинжал доминатора
 Dominator Dagger Skin,Облик кинжала «Доминатор»
 Dominator Focus,Фокус доминатора
 Dominator Focus Skin,Облик фокуса «Доминатор»


### PR DESCRIPTION
Двенадцать строк подряд в `misc_002`: «Кинжал Мерзости», «Молот Мерзости», «Посох Мерзости» — а в оригинале везде `Dominator`. «Мерзость» же занята: так корпус зовёт `Abomination` (51 вхождение), и в инвентаре два набора сливались.

| EN | было | стало |
|---|---|---|
| `Dominator Dagger` | Кинжал **Мерзости** | Кинжал **доминатора** |
| `Dominator Greatsword` | Двуручный меч **Мерзости** | Двуручный меч **доминатора** |
| `Dominator Warhorn` | Боевой рог **Мерзости** | Боевой рог **доминатора** |

### Канон

Взят из слоя, где те же предметы уже переведены: `pn_items_035` — «Топор доминатора», «Фокус доминатора», «Двуручный меч доминатора». Всего «доминатор» 39 вхождений.

Тринадцатая правка из того же гнезда: `Dominator Dagger` **в самом слое** звался «Кинжалом повелителя» — единственное отступление от собственного канона.

Правится только слово-имя, тип вещи и падеж остаются.

### Не тронуто

`Fabled` тоже сливается с `Legendary` — 10 столкновений, оба «легендарный». Своего слова у него в корпусе нет вовсе: все 12 вхождений «легендарный». Выбрать новое («сказочный», «былинный») значит решить вопрос о каноне, а не починить механику.

### Гейты

* тронуто ровно 13 записей в 2 файлах, ничего сверх плана;
* в каждой строке изменилось ровно одно слово;
* колонка `english` не менялась, дельта линтера 0/0;
* **столкновений «Dominator = Abomination» не осталось**.