### PR TITLE
main_013: сняты 10 немецких строк

### DIFF
--- a/main/main_013.csv
+++ b/main/main_013.csv
@@ -858,16 +858,6 @@ Mabon","Зойя,
   
 Твой друг,  
 Мейбон"
-[F]%str1%%str2%Gold-Fraktal-Fackel%str3%%str4%,[F]%str1%%str2%Золотой фрактальный факел%str3%%str4%
-[F]%str1%%str2%Gold-Fraktal-Harpune%str3%%str4%,[F]%str1%%str2%Золотая фрактальная гарпуна%str3%%str4%
-[F]%str1%%str2%Plasma-Fackel%str3%%str4%,[F]%str1%%str2%Плазменный факел%str3%%str4%
-[F]%str1%%str2%Saryx-Fackel%str3%%str4%,[F]%str1%%str2%Факел Сарыкса%str3%%str4%
-[M]%str1%%str2%Balthasar-Schild%str3%%str4%,[M][М] %str1%%str2% Щит Балтаха %str3%%str4%
-[M]%str1%%str2%Gold-Fraktal-Langbogen%str3%%str4%,[M][М] %str1%%str2%Золотой фрактальный длинный лук%str3%%str4%
-[M]%str1%%str2%Improvisierter Hammer%str3%%str4%,[M][М] %str1%%str2%Улучшенный молот%str3%%str4%
-[M]%str1%%str2%Piraten-Haken%str3%%str4%,[M][М] %str1%%str2%Пиратский крюк%str3%%str4%
-[M]%str1%%str2%Plasma-Langbogen%str3%%str4%,[M][М] %str1%%str2%Пламенный лук-арбалет%str3%%str4%
-[M]%str1%%str2%Saryx-Langbogen%str3%%str4%,[M][М] %str1%%str2% Сарикс-лук для стрельбы из лука %str3%%str4%
 [N]%str1%%str2%Geheul-Experiment%str3%%str4%,%str1%%str2%Эксперимент «Вой»%str3%%str4%
 [b],[b]
 [f]%str1%,[f]%str1%


### PR DESCRIPTION
Десять записей подряд (137–146) держали в колонке `english` не английский, а немецкий текст:

```
[M]%str1%%str2%Improvisierter Hammer%str3%%str4%
[F]%str1%%str2%Gold-Fraktal-Fackel%str3%%str4%
```

Так выглядит строка, пришедшая через прокси с немецкого клиента. Переводить их нельзя и чинить бессмысленно: хеш считается от немецкого, и в игре по нему лежит немецкий оригинал — наш русский текст встал бы поверх немецкого клиента. CLAUDE.md §5 требует такие строки удалять.

### Удаление безопасно вдвойне

У каждой немецкой строки есть английский близнец, живущий в корпусе своей жизнью:

| немецкая | английская | перевод, который остаётся |
|---|---|---|
| `Improvisierter Hammer` | `Improvised Hammer` | «Импровизированный молот» |
| `Piraten-Haken` | `Pirate Hook` | «Пиратский крюк» |
| `Balthasar-Schild` | `Balthazar's Shield` | «Щит Бальтазара» |
| `Plasma-Langbogen` | `Plasma Longbow` | «Плазменный длинный лук» |

Попутно уходит второй дефект этих же строк: родовой маркер `[M]` в переводе был продублирован кириллическим `[М]` — «[M][М] Улучшенный молот». Чинить его отдельно незачем: запись всё равно мертва.

### Почему список поимённый, а не найден инструментом

`tools/langfilter.py` эти строки **не видит**, и это его слепая зона: у немецких названий нет ни артиклей, ни диакритики, а последний и самый слабый признак — «корпус не знает ни одного слова» — применяется только к **непереведённым** строкам, эти же переведены.

Пороги в фильтре выверены по всему корпусу (в комментариях к ним стоят замеры на 477 374 строках), и расшатывать их ради десяти записей неразумно. Поэтому список задан явно, а каждая строка проверена по трём признакам: немецкий корень, родовой маркер, совпадение с ожидаемым текстом.

### Гейты

* изменён один файл, записей 199 → 189, удалено ровно 10;
* оставшиеся записи совпадают **побайтово** — сверка с `git show HEAD:`;
* немецких корней в файле не осталось, кириллических маркеров тоже.

Чтобы записи ушли из bin, нужна сборка с `--prune`.